### PR TITLE
01d stp enrolment analysis

### DIFF
--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -61,47 +61,23 @@ na_vals = c("", " ", "(Unspecified)", NA)
 #  - There are some epens with > 1 gender still (in the SQL version) as an original UPDATE query
 # appears to not be deterministic; without loss of generality(?) choosing slice_max.
 
-cols <- c(
+stp_cols <- c(
   "ID",
-  "PSI_PEN",
   "PSI_BIRTHDATE",
   "psi_birthdate_cleaned",
   "PSI_GENDER",
   "PSI_STUDENT_NUMBER",
-  #"PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT",
-  "TRUE_PEN",
   "ENCRYPTED_TRUE_PEN",
   "PSI_SCHOOL_YEAR",
-  #"PSI_REGISTRATION_TERM",
-  #"PSI_STUDENT_POSTAL_CODE_CURRENT",
-  #"PSI_INDIGENOUS_STATUS",
-  #"PSI_NEW_STUDENT_FLAG",
-  "PSI_ENROLMENT_SEQUENCE",
   "PSI_CODE",
-  "PSI_TYPE",
-  "PSI_FULL_NAME",
-  #"PSI_BASIS_OF_ADMISSION",
   "PSI_MIN_START_DATE",
-  #"PSI_CREDENTIAL_PROGRAM_DESCRIPTION",
-  "PSI_PROGRAM_CODE",
   "PSI_CIP_CODE",
-  "PSI_PROGRAM_EFFECTIVE_DATE",
-  #"PSI_FACULTY",
-  #"PSI_CONTINUING_EDUCATION_COURSE_ONLY",
-  #"PSI_CREDENTIAL_CATEGORY",
-  #"PSI_VISA_STATUS",
-  #"PSI_STUDY_LEVEL",
-  #"PSI_ENTRY_STATUS",
-  #"OVERALL_INDIGENOUS_STATUS"
+  "PSI_CREDENTIAL_CATEGORY"
 )
+cred_cols <- c("ENCRYPTED_TRUE_PEN", "PSI_CODE", "PSI_STUDENT_NUMBER", "psi_gender_cleaned")
 
 min_enrolment <- stp_enrolment |>
-  select(all_of(cols)) |>
-  mutate(
-    AGE_AT_CENSUS_2016 = NA_real_,
-    AGE_GROUP_CENSUS_2016 = NA_real_,
-    IS_SKILLS_BASED = NA_integer_
-  ) |>
+  select(all_of(stp_cols)) |>
   inner_join(
     stp_enrolment_record_type |>
       filter(RecordStatus == 0, MinEnrolment == 1) |>
@@ -149,6 +125,7 @@ min_enrolment <- min_enrolment |>
 
 # select the first valid gender for each student in credential data - pass #1 valid epens
 credential_epen <- credential |>
+  select(all_of(cred_cols)) |>
   filter(!ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
   select(ENCRYPTED_TRUE_PEN, gender_cred_epen = psi_gender_cleaned) |>
   slice_head(
@@ -158,6 +135,7 @@ credential_epen <- credential |>
 
 # select the first valid gender for each student in credential data - pass #2 invalid epens
 credential_no_epen <- credential |>
+  select(all_of(cred_cols)) |>
   filter(ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
   select(
     PSI_STUDENT_NUMBER,
@@ -456,11 +434,10 @@ min_enrolment <- min_enrolment |>
 # FROM MinEnrolment
 # GROUP BY PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE
 # ORDER BY PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE;"
-
+# 
 # s1 <- dbGetQuery(con, sql)
 # r1 <- min_enrolment |> count(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE) |> arrange(PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE)
-# res <- full_join(s1, r1, by = join_by(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE))
-
+# res <- full_join(s1, r1, by = join_by(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE)
 # ks.test(res$n.x, res$n.y)
 # plot(res$n.x, res$n.y)
 
@@ -471,13 +448,11 @@ min_enrolment <- min_enrolment |>
 # INNER JOIN AgeGroupLookup
 # ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
 # GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
-# ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;""
-
+# ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
 # s2 <- dbGetQuery(con, sql)
 # r2<- min_enrolment |> inner_join(age_group_lookup, by = c("AGE_GROUP_ENROL_DATE" = "AgeIndex")) |>
 #   count(PSI_SCHOOL_YEAR, AgeGroup, PSI_GENDER) |> arrange(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR)
 # res <- full_join(s2, r2, by = join_by(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR))
-
 # ks.test(res$n.x, res$n.y)
 # plot(res$n.x, res$n.y)
 

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -366,8 +366,8 @@ extract_no_age <- extract_no_age |>
   )
 
 # calculate missing ages from first enrolments
+# Arrange to ensure the first record (baseline) is chronologically first
 calc_ages <- extract_no_age |>
-  # Arrange to ensure the first record (baseline) is chronologically first
   arrange(PSI_STUDENT_NUMBER, PSI_CODE, PSI_MIN_START_DATE_D) |>
   group_by(PSI_STUDENT_NUMBER, PSI_CODE) |>
   mutate(
@@ -398,10 +398,8 @@ extract_no_age <- extract_no_age |>
   select(-AGE_AT_ENROL_DATE_to_update)
 
 # ---- some manual edits ----
-# SQL version starts at line ? on branch main
-# Replicates:
-# What the code does: Some manual updates were made here to remaining missing ages.
-# BA Notes: I haven't done the manual fixes as we're getting away from manual work
+# BA Notes: Some manual updates were made here to remaining missing ages. 
+# I haven't done the manual fixes as we're getting away from manual work
 
 min_enrolment <- min_enrolment |>
   left_join(
@@ -419,42 +417,14 @@ min_enrolment <- min_enrolment |>
     by = join_by(between(AGE_AT_ENROL_DATE, LowerBound, UpperBound))
   ) |>
   mutate(
-    # Update the target column and clean up the join helpers
     AGE_GROUP_ENROL_DATE = AgeIndex
   ) |>
   select(-AgeIndex, -LowerBound, -UpperBound)
 
 
 # ---- Final Distributions ----
-# This section moved to 01e-stp-distributions
+# !! This section moved to 01e-stp-distributions
 
-# Test 1
-# sql <- "
-# SELECT PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, COUNT(*) AS n
-# FROM MinEnrolment
-# GROUP BY PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE
-# ORDER BY PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE;"
-# 
-# s1 <- dbGetQuery(con, sql)
-# r1 <- min_enrolment |> count(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE) |> arrange(PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE)
-# res <- full_join(s1, r1, by = join_by(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE)
-# ks.test(res$n.x, res$n.y)
-# plot(res$n.x, res$n.y)
-
-# Test 2
-# sql <- "
-# SELECT MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS n
-# FROM MinEnrolment
-# INNER JOIN AgeGroupLookup
-# ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
-# GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
-# ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
-# s2 <- dbGetQuery(con, sql)
-# r2<- min_enrolment |> inner_join(age_group_lookup, by = c("AGE_GROUP_ENROL_DATE" = "AgeIndex")) |>
-#   count(PSI_SCHOOL_YEAR, AgeGroup, PSI_GENDER) |> arrange(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR)
-# res <- full_join(s2, r2, by = join_by(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR))
-# ks.test(res$n.x, res$n.y)
-# plot(res$n.x, res$n.y)
 
 # ---- Clean Up ----
 tables_to_keep <- c(

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -59,7 +59,7 @@ cred_cols <- c("ENCRYPTED_TRUE_PEN", "PSI_CODE", "PSI_STUDENT_NUMBER", "psi_gend
 
 # ---- Extract first-time enrolled records ----
 # Where is the SQL version: Originally sourced from branch 'main' (line 46)
-# Replicates: qry01a through qry01e (STP Enrolment Analysis), qry_CreateMinEnrolmentView and qry02a-qry04a2 (except 03 series)
+# Replicates: qry01a through qry01e (STP Enrolment Analysis), qry_CreateMinEnrolmentView and qry02a-qry02b (except 03 series)
 # What the code does:
 # - Constructs the core 'min_enrolment' dataframe by joining raw STP data with
 #  record-type filters and previously initialized supplemental variables.
@@ -117,7 +117,8 @@ min_enrolment <- min_enrolment |>
 
 
 # ---- Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER  ----
-# Where is the SQL version: Originally sourced from branch 'main' (line 62)
+# Where is the SQL version: Originally sourced from branch 'main' (line 59)
+# Replicates: qry04a1 through qry04a2
 # What the code does: identifies invalid genders  ("", " ", "(Unspecified)", NA) and 
 #   uses genders from the credential view to impute (backfill) gender into min_enrolment.  Accomplished 
 #   by performing two passes - 1) using valid epens, then 2) valid psi code/number combinations for records without valid epens.
@@ -126,10 +127,12 @@ min_enrolment <- min_enrolment |>
 # We should consider reducing complexity and create aunified approach
 
 # select the first valid gender for each student in credential data - pass #1 valid epens
+# this mimicks SQL - in SQL when an UPDATE...SET returns multiple options, the engine will choose one, usually the first one
+# this is unpredictable but at this point we only concerned with generating the same counts as the SQL version.
 credential_epen <- credential |>
   select(all_of(cred_cols)) |>
   filter(!ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
-  select(ENCRYPTED_TRUE_PEN, gender_cred_epen = psi_gender_cleaned) |>
+  select(ENCRYPTED_TRUE_PEN, gender_cred_epen = psi_gender_cleaned) |> 
   slice_head(
     by = ENCRYPTED_TRUE_PEN,
     n = 1
@@ -225,12 +228,14 @@ gender_weights <- min_enrolment |>
   mutate(TARGET_N = round(PROPORTION * total_unknowns))
 
 # resample unknownws
-imputed_first_enrolments <- extract_no_gender_first |>
-  mutate(
-    PSI_GENDER_IMPUTED = sample(rep(
-      gender_weights$PSI_GENDER,
-      times = gender_weights$TARGET_N
-    ))
+imputed_first_enrolments <- extract_no_gender_first |>  
+  mutate(  
+    PSI_GENDER_IMPUTED = sample(  
+      gender_weights$PSI_GENDER,  
+      size = n(),  
+      replace = TRUE,  
+      prob = gender_weights$PROPORTION  
+    )  
   )
 
 # carry forward first seen gender for records with valid encrypted true pen

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -123,7 +123,7 @@ min_enrolment <- min_enrolment |>
 #   by performing two passes - 1) using valid epens, then 2) valid psi code/number combinations for records without valid epens.
 # BA Notes:
 # We have 3 quite different methods for imputing invalid genders in the next couple of sections
-# We should consider reducing complexity and creating a more unified approach
+# We should consider reducing complexity and create aunified approach
 
 # select the first valid gender for each student in credential data - pass #1 valid epens
 credential_epen <- credential |>
@@ -283,9 +283,9 @@ min_enrolment <- min_enrolment |>
 # Replicates: qry07a-qry08 and much R code
 # What the code does:
 # - This code extracts and isolates records where the student's age could not be calculated.
-# - Performs a Stratified Proportional Imputation for missing ages.
-# - Followed by a Temporal Projection to fill in subsequent records.
-# - Updates extract_no_age with imputed ages
+# - Performs a proportional imputation for missing ages.
+# - Followed by a temporal (or forward-fill) projection to fill in subsequent records.
+# - Updates min_enrolment with imputed ages.
 # BA Notes:
 # - compare extract_no_age to Extract_No_Age and
 # - compare extract_no_age_first_enrol to Extract_No_Age_First_Enrolment

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -143,8 +143,10 @@ min_enrolment <- min_enrolment |>
 
 # ---- Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER  ----
 # uses genders from the credential view to impute gender into min_enrolment in the case of NULLS
-# what we have going here is 3 different methods for imputing invalid genders.  We could reduce complexity
-# and allocate 1.
+# !!! what we have going in the code below is 3 quite different methods for imputing invalid genders.
+# # We could reduce complexity and created a more unified approach
+
+# select the first valid gender for each student in credential data - pass #1 valid epens
 credential_epen <- credential |>
   filter(!ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
   select(ENCRYPTED_TRUE_PEN, gender_cred_epen = psi_gender_cleaned) |>
@@ -153,6 +155,7 @@ credential_epen <- credential |>
     n = 1
   )
 
+# select the first valid gender for each student in credential data - pass #2 invalid epens
 credential_no_epen <- credential |>
   filter(ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
   select(
@@ -165,6 +168,7 @@ credential_no_epen <- credential |>
     n = 1
   )
 
+# back fill NA genders in min_enrolment
 min_enrolment <- min_enrolment |>
   left_join(credential_epen, by = join_by(ENCRYPTED_TRUE_PEN)) |> # some duplicates being introduced here
   left_join(credential_no_epen, by = join_by(PSI_STUDENT_NUMBER, PSI_CODE)) |>
@@ -187,6 +191,7 @@ min_enrolment <- min_enrolment |>
 # - This code performs a historic imputation process based on a student’s earliest recorded data . This
 # solves the problem of the same student appearing with different gender labels across different rows in the dataset.
 
+# select first-time recorded gender from min-enrolment data
 first_gender_lookup <- min_enrolment |>
   filter(IS_FIRST_ENROLMENT == "Yes") |>
   mutate(
@@ -198,6 +203,7 @@ first_gender_lookup <- min_enrolment |>
   ) |>
   distinct(CONCATENATED_ID, FIRST_GENDER = PSI_GENDER)
 
+# forward fill NA genders (join on a concatenated ID, instead of 2-passes, epen, no epen)
 min_enrolment <- min_enrolment |>
   mutate(
     CONCATENATED_ID = if_else(

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -45,27 +45,71 @@ na_vals = c("", " ", "(Unspecified)", NA)
 # - Originally sourced from branch 'main' (line 46)
 # Replicates:
 # - qry01a through qry01e (STP Enrolment Analysis)
+# - Replicates:qry_CreateMinEnrolmentView and qry02a-qry04a2 (missing 03 series)
 # What the code does:
-# - Creates table min_enrolment_sup_vars from 'stp_enrolment'
-#   containing supplementary variables for later use.
-# - It performs initial type-casting for dates and creates placeholder
-#   columns for age/group variables that are populated in later steps.
+#  - Constructs the core 'min_enrolment' dataframe by joining raw STP data with
+#  record-type filters and previously initialized supplemental variables.
+#  - It also calculates the primary 'AGE_AT_ENROL_DATE' using lubridate
+#  intervals and maps age groups via an inequality join.
 # QA/Review Notes:
-# - creates min_enrolment_sup_var (identical db table MinEnrolment)
-# - Placeholder columns (AGE_AT_ENROL_DATE, etc.) are initialized as
-#   typed NAs (NA_real_) to maintain structure consistency
-#   with database tables.  There are many columns I suspect are non-essential
-#   which we may want to remove later.
 # - qry defn for qry01d1_MinEnrolmentSupVar is missing a ")". qry errors - I fixed manually and reran.
+#  - creates min_enrolment (identical db table MinEnrolment)
+#  - Column bloat: I’ve retained all 30+ legacy columns to ensure 1:1 parity
+#  with the SQL version for QA/Review purposes. Non-essential columns
+#  can be dropped in a later 'refine' phase once the logic is validated.
+#  - There are some epens with > 1 gender still (in the SQL version) as an original UPDATE query
+# appears to not be deterministic; without loss of generality(?) choosing slice_max.
 
-min_enrolment_sup_var <- stp_enrolment |>
-  select(ID, psi_birthdate_cleaned, PSI_MIN_START_DATE) |>
+cols <- c(
+  "ID",
+  "PSI_PEN",
+  "PSI_BIRTHDATE",
+  "psi_birthdate_cleaned",
+  "PSI_GENDER",
+  "PSI_STUDENT_NUMBER",
+  "PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT",
+  "TRUE_PEN",
+  "ENCRYPTED_TRUE_PEN",
+  "PSI_SCHOOL_YEAR",
+  "PSI_REGISTRATION_TERM",
+  "PSI_STUDENT_POSTAL_CODE_CURRENT",
+  "PSI_INDIGENOUS_STATUS",
+  "PSI_NEW_STUDENT_FLAG",
+  "PSI_ENROLMENT_SEQUENCE",
+  "PSI_CODE",
+  "PSI_TYPE",
+  "PSI_FULL_NAME",
+  "PSI_BASIS_OF_ADMISSION",
+  "PSI_MIN_START_DATE",
+  "PSI_CREDENTIAL_PROGRAM_DESCRIPTION",
+  "PSI_PROGRAM_CODE",
+  "PSI_CIP_CODE",
+  "PSI_PROGRAM_EFFECTIVE_DATE",
+  "PSI_FACULTY",
+  "PSI_CONTINUING_EDUCATION_COURSE_ONLY",
+  "PSI_CREDENTIAL_CATEGORY",
+  "PSI_VISA_STATUS",
+  "PSI_STUDY_LEVEL",
+  "PSI_ENTRY_STATUS",
+  "OVERALL_INDIGENOUS_STATUS"
+)
+
+min_enrolment <- stp_enrolment |>
+  select(all_of(cols)) |>
+  mutate(
+    AGE_AT_CENSUS_2016 = NA_real_,
+    AGE_GROUP_CENSUS_2016 = NA_real_,
+    IS_SKILLS_BASED = NA_integer_
+  ) |>
   inner_join(
     stp_enrolment_record_type |>
-      select(ID, MinEnrolment, FirstEnrolment, RecordStatus),
+      filter(RecordStatus == 0, MinEnrolment == 1) |>
+      select(ID, FirstEnrolment),
     by = "ID"
   ) |>
-  rename_with(toupper) |>
+  rename_with(toupper)
+
+min_enrolment <- min_enrolment |>
   mutate(
     PSI_BIRTHDATE_CLEANED_D = if_else(
       PSI_BIRTHDATE_CLEANED %in%
@@ -77,98 +121,18 @@ min_enrolment_sup_var <- stp_enrolment |>
     PSI_MIN_START_DATE_D = if_else(
       PSI_MIN_START_DATE %in% na_vals,
       as.Date(NA),
-      as.Date(PSI_MIN_START_DATE),
+      as.Date(PSI_MIN_START_DATE)
     ),
     IS_FIRST_ENROLMENT = if_else(FIRSTENROLMENT == 1, "Yes", NA_character_),
-    AGE_AT_ENROL_DATE = NA_real_,
-    AGE_GROUP_ENROL_DATE = NA_real_,
-    AGE_AT_CENSUS_2016 = NA_real_,
-    AGE_GROUP_CENSUS_2016 = NA_real_,
-    IS_SKILLS_BASED = NA_integer_
-  )
-
-# ---- Create MinEnrolment View ---
-# SQL Reference: branch 'main' (line 46)
-# Replicates:qry_CreateMinEnrolmentView and qry02a-qry04a2 (missing 03 series)
-# What the code does:
-#  - Constructs the core 'min_enrolment' dataframe by joining raw STP data with
-#  record-type filters and previously initialized supplemental variables.
-#  - It also calculates the primary 'AGE_AT_ENROL_DATE' using lubridate
-#  intervals and maps age groups via an inequality join.
-# BA Notes:
-#  - creates min_enrolment (identical db table MinEnrolment)
-#  - Column bloat: I’ve retained all 30+ legacy columns to ensure 1:1 parity
-#  with the SQL version for QA/Review purposes. Non-essential columns
-#  can be dropped in a later 'refine' phase once the logic is validated.
-#  - There are some epens with > 1 gender still (in the SQL version) as an original UPDATE query
-# appears to not be deterministic; without loss of generality(?) choosing slice_max.
-#  - hard to test the SQL version seperatly as min_enrolment is a view to stp_enrolment.  You'd need
-# to make sure this script hasn't been run once already which could be tricky or not reasonable.
-
-min_enrolment <- stp_enrolment |>
-  select(
-    ID,
-    PSI_PEN,
-    PSI_BIRTHDATE,
-    psi_birthdate_cleaned,
-    PSI_GENDER,
-    PSI_STUDENT_NUMBER,
-    PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT,
-    TRUE_PEN,
-    ENCRYPTED_TRUE_PEN,
-    PSI_SCHOOL_YEAR,
-    PSI_REGISTRATION_TERM,
-    PSI_STUDENT_POSTAL_CODE_CURRENT,
-    PSI_INDIGENOUS_STATUS,
-    PSI_NEW_STUDENT_FLAG,
-    PSI_ENROLMENT_SEQUENCE,
-    PSI_CODE,
-    PSI_TYPE,
-    PSI_FULL_NAME,
-    PSI_BASIS_OF_ADMISSION,
-    PSI_MIN_START_DATE,
-    PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
-    PSI_PROGRAM_CODE,
-    PSI_CIP_CODE,
-    PSI_PROGRAM_EFFECTIVE_DATE,
-    PSI_FACULTY,
-    PSI_CONTINUING_EDUCATION_COURSE_ONLY,
-    PSI_CREDENTIAL_CATEGORY,
-    PSI_VISA_STATUS,
-    PSI_STUDY_LEVEL,
-    PSI_ENTRY_STATUS,
-    OVERALL_INDIGENOUS_STATUS
-  ) |>
-  inner_join(
-    stp_enrolment_record_type |>
-      filter(RecordStatus == 0, MinEnrolment == 1) |>
-      select(ID),
-    by = "ID"
-  ) |>
-  inner_join(
-    min_enrolment_sup_var |>
-      select(
-        ID,
-        PSI_BIRTHDATE_CLEANED_D,
-        PSI_MIN_START_DATE_D,
-        AGE_AT_ENROL_DATE,
-        AGE_GROUP_ENROL_DATE,
-        AGE_AT_CENSUS_2016,
-        AGE_GROUP_CENSUS_2016,
-        IS_FIRST_ENROLMENT,
-        IS_SKILLS_BASED
-      ),
-    by = "ID"
-  )
-
-min_enrolment <- min_enrolment |>
-  mutate(
     AGE_AT_ENROL_DATE = if_else(
       !is.na(PSI_BIRTHDATE_CLEANED_D) & !is.na(PSI_MIN_START_DATE_D),
       floor(interval(PSI_BIRTHDATE_CLEANED_D, PSI_MIN_START_DATE_D) / years(1)),
       NA_real_
     )
   ) |>
+  select(-FIRSTENROLMENT)
+
+min_enrolment <- min_enrolment |>
   left_join(
     age_group_lookup,
     by = join_by(between(AGE_AT_ENROL_DATE, LowerBound, UpperBound))
@@ -176,13 +140,17 @@ min_enrolment <- min_enrolment |>
   mutate(AGE_GROUP_ENROL_DATE = AgeIndex) |>
   select(-AgeIndex, -AgeGroup, -LowerBound, -UpperBound)
 
+
+# ---- Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER  ----
+# uses genders from the credential view to impute gender into min_enrolment in the case of NULLS
+# what we have going here is 3 different methods for imputing invalid genders.  We could reduce complexity
+# and allocate 1.
 credential_epen <- credential |>
   filter(!ENCRYPTED_TRUE_PEN %in% na_vals, !psi_gender_cleaned %in% na_vals) |>
   select(ENCRYPTED_TRUE_PEN, gender_cred_epen = psi_gender_cleaned) |>
-  slice_max(
+  slice_head(
     by = ENCRYPTED_TRUE_PEN,
-    order_by = gender_cred_epen,
-    with_ties = FALSE
+    n = 1
   )
 
 credential_no_epen <- credential |>
@@ -192,10 +160,9 @@ credential_no_epen <- credential |>
     PSI_CODE,
     gender_cred_no_epen = psi_gender_cleaned
   ) |>
-  slice_max(
+  slice_head(
     by = c(PSI_STUDENT_NUMBER, PSI_CODE),
-    order_by = gender_cred_no_epen,
-    with_ties = FALSE
+    n = 1
   )
 
 min_enrolment <- min_enrolment |>
@@ -213,17 +180,13 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-gender_cred_epen, -gender_cred_no_epen, -gender_cred)
 
-# ---- Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER  ----
-# AND
 # ---- Assign one gender/student and update MinEnrolment table ----
 # SQL version starts at line 62 on branch main
 # Replicates: qry04b through qry04e2
 # What the code does:
-# - This code performs a Gender Standardization process based on a student’s earliest recorded data.
-# - It is designed to solve the problem of "conflicting records", where the same student might appear
-# with different gender labels across different rows in the dataset.
-# BA Notes: We use Concatenated_ID instead of EPEN for the next set of queries
-# I beleive this would be a useful approach to adopt for many of the other steps.
+# - This code performs a historic imputation process based on a student’s earliest recorded data . This
+# solves the problem of the same student appearing with different gender labels across different rows in the dataset.
+
 first_gender_lookup <- min_enrolment |>
   filter(IS_FIRST_ENROLMENT == "Yes") |>
   mutate(
@@ -256,67 +219,75 @@ min_enrolment <- min_enrolment |>
 # - Perform a Proportional Imputation for missing gender data.
 # Instead of leaving "Unknown" genders as blanks or assigning them all to one category,
 # it calculates the "natural" distribution of the known population and applies that same ratio to the missing records.
+# the distribution is taken from the set of firt enrolment records, effectivly performing a historical imputation,
+# where the first seen record is carried forward. (This was what I think SQL versions were doing - we should relook at this)
 
 na_vals <- c("U", "Unknown", "(Unspecified)", "", NA)
 
+# first-time "unknowns"
 extract_no_gender_first <- min_enrolment |>
   filter(IS_FIRST_ENROLMENT == "Yes", PSI_GENDER %in% na_vals) |>
   select(ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER)
 
 total_unknowns <- nrow(extract_no_gender_first)
 
+# first-time valid genders (Male, Female, Gender Diverse)
 gender_weights <- min_enrolment |>
   filter(IS_FIRST_ENROLMENT == "Yes", !PSI_GENDER %in% na_vals) |>
   count(PSI_GENDER) |>
   mutate(PROPORTION = n / sum(n)) |>
   mutate(TARGET_N = round(PROPORTION * total_unknowns))
 
+# resample unknownws
 imputed_first_enrolments <- extract_no_gender_first |>
-  sample_frac(size = 1, replace = FALSE) |>
   mutate(
-    PSI_GENDER = rep(
+    PSI_GENDER_IMPUTED = sample(rep(
       gender_weights$PSI_GENDER,
       times = gender_weights$TARGET_N
-    ) |>
-      head(total_unknowns) |> # handle
-      as.character()
+    ))
   )
 
-extract_no_gender <- min_enrolment |>
-  filter(PSI_GENDER %in% na_vals) |>
-  select(ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE) |>
-  left_join(
+# carry forward first seen gender for records with valid encrypted true pen
+extract_no_gender_epen <- min_enrolment |>
+  filter(PSI_GENDER %in% na_vals, !ENCRYPTED_TRUE_PEN %in% na_vals) |>
+  select(ID, ENCRYPTED_TRUE_PEN) |>
+  inner_join(
     imputed_first_enrolments |>
-      distinct(PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE),
-    by = join_by(PSI_STUDENT_NUMBER, PSI_CODE)
+      distinct(ENCRYPTED_TRUE_PEN, PSI_GENDER_IMPUTED),
+    by = join_by(ENCRYPTED_TRUE_PEN)
   )
 
-# at this point SQL does some more proportional updates to obtain a gender for a handful of records, followed by
-# further processing to handle multiple EPEN-gender combos.
-# however, those records all have valid EPENS so I'm doing a second pass and joining by epen.
-# The finals distributions are minimally off, but worth noting.
-extract_no_gender <- extract_no_gender |>
-  left_join(
-    extract_no_gender |>
-      filter(PSI_GENDER %in% na_vals) |>
-      left_join(
-        imputed_first_enrolments |>
-          distinct(ENCRYPTED_TRUE_PEN, PSI_GENDER_to_update = PSI_GENDER)
-      )
-  ) |>
-  mutate(PSI_GENDER_to_update = coalesce(PSI_GENDER, PSI_GENDER_to_update)) |>
-  select(-PSI_GENDER)
+# carry forward first seen gender for records without valid encrypted true pen
+extract_no_gender_no_epen <- min_enrolment |>
+  filter(PSI_GENDER %in% na_vals, ENCRYPTED_TRUE_PEN %in% na_vals) |>
+  filter(!PSI_CODE %in% na_vals, !PSI_STUDENT_NUMBER %in% na_vals) |>
+  select(ID, PSI_CODE, PSI_STUDENT_NUMBER) |>
+  inner_join(
+    imputed_first_enrolments |>
+      distinct(PSI_CODE, PSI_STUDENT_NUMBER, PSI_GENDER_IMPUTED),
+    by = join_by(PSI_CODE, PSI_STUDENT_NUMBER)
+  )
 
+# backfill genders in min_enrolment data
 min_enrolment <- min_enrolment |>
-  left_join(extract_no_gender |> select(ID, PSI_GENDER_to_update)) |>
+  left_join(
+    extract_no_gender_epen |> select(ID, PSI_GENDER_IMPUTED),
+    by = "ID"
+  ) |>
+  left_join(
+    extract_no_gender_no_epen |> select(ID, PSI_GENDER_IMPUTED),
+    by = "ID",
+    suffix = c(".pen", ".nopen")
+  ) |>
   mutate(
-    PSI_GENDER = if_else(
-      PSI_GENDER %in% na_vals,
-      PSI_GENDER_to_update,
-      PSI_GENDER
+    PSI_GENDER = if_else(PSI_GENDER %in% na_vals, NA_character_, PSI_GENDER),
+    PSI_GENDER = coalesce(
+      PSI_GENDER,
+      PSI_GENDER_IMPUTED.pen,
+      PSI_GENDER_IMPUTED.nopen
     )
   ) |>
-  select(-PSI_GENDER_to_update)
+  select(-PSI_GENDER_IMPUTED.pen, -PSI_GENDER_IMPUTED.nopen)
 
 
 # ---- Create Age and Gender Distrbutions ----

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -21,6 +21,7 @@ set.seed(123456)
 # QA/Review Notes:
 # - As more queries from SQL are ported and the process is refined,
 #   new tables may be added to the 'required_tables' list below.
+
 required_tables <- c(
   "age_group_lookup",
   "outcome_credential",
@@ -67,31 +68,31 @@ cols <- c(
   "psi_birthdate_cleaned",
   "PSI_GENDER",
   "PSI_STUDENT_NUMBER",
-  "PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT",
+  #"PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT",
   "TRUE_PEN",
   "ENCRYPTED_TRUE_PEN",
   "PSI_SCHOOL_YEAR",
-  "PSI_REGISTRATION_TERM",
-  "PSI_STUDENT_POSTAL_CODE_CURRENT",
-  "PSI_INDIGENOUS_STATUS",
-  "PSI_NEW_STUDENT_FLAG",
+  #"PSI_REGISTRATION_TERM",
+  #"PSI_STUDENT_POSTAL_CODE_CURRENT",
+  #"PSI_INDIGENOUS_STATUS",
+  #"PSI_NEW_STUDENT_FLAG",
   "PSI_ENROLMENT_SEQUENCE",
   "PSI_CODE",
   "PSI_TYPE",
   "PSI_FULL_NAME",
-  "PSI_BASIS_OF_ADMISSION",
+  #"PSI_BASIS_OF_ADMISSION",
   "PSI_MIN_START_DATE",
-  "PSI_CREDENTIAL_PROGRAM_DESCRIPTION",
+  #"PSI_CREDENTIAL_PROGRAM_DESCRIPTION",
   "PSI_PROGRAM_CODE",
   "PSI_CIP_CODE",
   "PSI_PROGRAM_EFFECTIVE_DATE",
-  "PSI_FACULTY",
-  "PSI_CONTINUING_EDUCATION_COURSE_ONLY",
-  "PSI_CREDENTIAL_CATEGORY",
-  "PSI_VISA_STATUS",
-  "PSI_STUDY_LEVEL",
-  "PSI_ENTRY_STATUS",
-  "OVERALL_INDIGENOUS_STATUS"
+  #"PSI_FACULTY",
+  #"PSI_CONTINUING_EDUCATION_COURSE_ONLY",
+  #"PSI_CREDENTIAL_CATEGORY",
+  #"PSI_VISA_STATUS",
+  #"PSI_STUDY_LEVEL",
+  #"PSI_ENTRY_STATUS",
+  #"OVERALL_INDIGENOUS_STATUS"
 )
 
 min_enrolment <- stp_enrolment |>
@@ -295,7 +296,7 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-PSI_GENDER_IMPUTED.pen, -PSI_GENDER_IMPUTED.nopen)
 
-# reviewed to here
+
 # ---- Create Age and Gender Distrbutions ----
 # SQL version starts at line 163 on branch main
 # Replicates: qry07a-qry07b2
@@ -340,8 +341,7 @@ extract_no_age_first_enrol <- min_enrolment |>
 # - Performs a Stratified Proportional Imputation for missing ages.
 # - Followed by a Temporal Projection to fill in subsequent records.
 # - Updates extract_no_age with imputed ages
-# BA Notes:
-# compare extract_no_age to Extract_No_Age
+# - distribution of assigned (imputed) ages are similar for this version vs last
 
 impute_age_by_gender <- function(sub_df, gender_name, lookup_table) {
   # Look for the distribution for this specific gender
@@ -450,37 +450,40 @@ min_enrolment <- min_enrolment |>
 # ---- Final Distributions ----
 # This section moved to 01e-stp-distributions
 
-## Review ----
-# SQL version starts at line ? on branch main
-# Replicates:
-# What the code does:
-# BA Notes: I get an error in qry09c_:
-#   invalid object name 'PSI_CODE_RECODE' is this another table I need to bring in?
-# dbExecute(con, qry09c_MinEnrolment_PSI_TYPE)
+# Test 1
+# sql <- "
+# SELECT PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, COUNT(*) AS n
+# FROM MinEnrolment
+# GROUP BY PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE
+# ORDER BY PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE;"
+
+# s1 <- dbGetQuery(con, sql)
+# r1 <- min_enrolment |> count(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE) |> arrange(PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE)
+# res <- full_join(s1, r1, by = join_by(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE))
+
+# ks.test(res$n.x, res$n.y)
+# plot(res$n.x, res$n.y)
+
+# Test 2
+# sql <- "
+# SELECT MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS n
+# FROM MinEnrolment
+# INNER JOIN AgeGroupLookup
+# ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+# GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
+# ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;""
+
+# s2 <- dbGetQuery(con, sql)
+# r2<- min_enrolment |> inner_join(age_group_lookup, by = c("AGE_GROUP_ENROL_DATE" = "AgeIndex")) |>
+#   count(PSI_SCHOOL_YEAR, AgeGroup, PSI_GENDER) |> arrange(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR)
+# res <- full_join(s2, r2, by = join_by(PSI_GENDER, AgeGroup, PSI_SCHOOL_YEAR))
+
+# ks.test(res$n.x, res$n.y)
+# plot(res$n.x, res$n.y)
 
 # ---- Clean Up ----
-# SQL version starts at line ? on branch main
-# Replicates:
-# What the code does:
-# BA Notes: refine as needed
 tables_to_keep <- c(
-  "stp_enrolment",
-  "stp_credential",
-  "stp_enrolment_record_type",
-  "stp_credential_record_type",
-  "stp_enrolment_valid",
   "age_group_lookup",
-  "credential_rank",
-  "credential",
-  "credential_non_dup",
-  "credential_sup_vars",
-  "tbl_credential_highest_rank",
-  "tbl_credential_delay_effect",
-  "outcome_credential",
-  "con",
-  "db_config",
-  "my_schema",
-  "db_schema",
   "min_enrolment"
 )
 

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -18,8 +18,9 @@ set.seed(123456)
 # What the code does: Ensures all source dataframes
 #   and lookup tables are present in global environemnt before processing.
 # BA Notes:
-# - As more queries from SQL are ported and the process is refined,
-#   new tables may be added to the 'required_tables' list below.
+# - Required tables, and "tables to keep" at the end of the script, reflect
+#  tables used/retained from this script only.  Additional changes will be needed
+# if running as a continuous workflow.
 
 required_tables <- c(
   "age_group_lookup",
@@ -65,7 +66,6 @@ cred_cols <- c("ENCRYPTED_TRUE_PEN", "PSI_CODE", "PSI_STUDENT_NUMBER", "psi_gend
 # - Calculates the primary 'AGE_AT_ENROL_DATE' intervals
 # - maps age groups via an inequality join.
 # BA Notes:
-# - qry defn for qry01d1_MinEnrolmentSupVar is missing a ")". qry errors - I fixed manually and reran.
 # - Non-essential columns have been dropped from STP_Enrolment and Credential tables to speed up processing
 
 

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -14,11 +14,10 @@ library(tidyverse)
 set.seed(123456)
 
 # ---- Check required Tables etc. ----
-# SQL version: Originally sourced from branch 'main' (line 41)
-# What the code does: Acts as a pre-flight "circuit breaker" to ensure all source dataframes
-#   and lookup tables are present in global environemnt before processing. Prevents
-#   partial execution errors.
-# QA/Review Notes:
+# Where is the SQL version: Originally sourced from branch 'main' (line 41)
+# What the code does: Ensures all source dataframes
+#   and lookup tables are present in global environemnt before processing.
+# BA Notes:
 # - As more queries from SQL are ported and the process is refined,
 #   new tables may be added to the 'required_tables' list below.
 
@@ -39,27 +38,8 @@ if (length(missing) > 0) {
   ))
 }
 
+# define global variables
 na_vals = c("", " ", "(Unspecified)", NA)
-
-# ---- Extract first-time enrolled records ----
-# SQL Reference:
-# - Originally sourced from branch 'main' (line 46)
-# Replicates:
-# - qry01a through qry01e (STP Enrolment Analysis)
-# - Replicates:qry_CreateMinEnrolmentView and qry02a-qry04a2 (missing 03 series)
-# What the code does:
-#  - Constructs the core 'min_enrolment' dataframe by joining raw STP data with
-#  record-type filters and previously initialized supplemental variables.
-#  - It also calculates the primary 'AGE_AT_ENROL_DATE' using lubridate
-#  intervals and maps age groups via an inequality join.
-# QA/Review Notes:
-# - qry defn for qry01d1_MinEnrolmentSupVar is missing a ")". qry errors - I fixed manually and reran.
-#  - creates min_enrolment (identical db table MinEnrolment)
-#  - Column bloat: I’ve retained all 30+ legacy columns to ensure 1:1 parity
-#  with the SQL version for QA/Review purposes. Non-essential columns
-#  can be dropped in a later 'refine' phase once the logic is validated.
-#  - There are some epens with > 1 gender still (in the SQL version) as an original UPDATE query
-# appears to not be deterministic; without loss of generality(?) choosing slice_max.
 
 stp_cols <- c(
   "ID",
@@ -76,6 +56,22 @@ stp_cols <- c(
 )
 cred_cols <- c("ENCRYPTED_TRUE_PEN", "PSI_CODE", "PSI_STUDENT_NUMBER", "psi_gender_cleaned")
 
+# ---- Extract first-time enrolled records ----
+# Where is the SQL version: Originally sourced from branch 'main' (line 46)
+# Replicates: qry01a through qry01e (STP Enrolment Analysis), qry_CreateMinEnrolmentView and qry02a-qry04a2 (except 03 series)
+# What the code does:
+# - Constructs the core 'min_enrolment' dataframe by joining raw STP data with
+#  record-type filters and previously initialized supplemental variables.
+# - Calculates the primary 'AGE_AT_ENROL_DATE' intervals
+# - maps age groups via an inequality join.
+# BA Notes:
+# - qry defn for qry01d1_MinEnrolmentSupVar is missing a ")". qry errors - I fixed manually and reran.
+# - Non-essential columns have been dropped from STP_Enrolment and Credential tables to speed up processing
+
+
+
+# define min_enrolment dataframe from stp_enrolment and stp_enrolment_record_type
+# keeping only valid first enrolment records (RecordStatus == 0, MinEnrolment == 1)
 min_enrolment <- stp_enrolment |>
   select(all_of(stp_cols)) |>
   inner_join(
@@ -86,6 +82,7 @@ min_enrolment <- stp_enrolment |>
   ) |>
   rename_with(toupper)
 
+# clean and format date variables, calculate age at enrolment, and flag first enrolments
 min_enrolment <- min_enrolment |>
   mutate(
     PSI_BIRTHDATE_CLEANED_D = if_else(
@@ -109,6 +106,7 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-FIRSTENROLMENT)
 
+# map age groups via an inequality join
 min_enrolment <- min_enrolment |>
   left_join(
     age_group_lookup,
@@ -119,9 +117,13 @@ min_enrolment <- min_enrolment |>
 
 
 # ---- Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER  ----
-# uses genders from the credential view to impute gender into min_enrolment in the case of NULLS
-# !!! what we have going in the code below is 3 quite different methods for imputing invalid genders.
-# # We could reduce complexity and created a more unified approach
+# Where is the SQL version: Originally sourced from branch 'main' (line 62)
+# What the code does: identifies invalid genders  ("", " ", "(Unspecified)", NA) and 
+#   uses genders from the credential view to impute (backfill) gender into min_enrolment.  Accomplished 
+#   by performing two passes - 1) using valid epens, then 2) valid psi code/number combinations for records without valid epens.
+# BA Notes:
+# We have 3 quite different methods for imputing invalid genders in the next couple of sections
+# We should consider reducing complexity and creating a more unified approach
 
 # select the first valid gender for each student in credential data - pass #1 valid epens
 credential_epen <- credential |>
@@ -164,11 +166,11 @@ min_enrolment <- min_enrolment |>
   select(-gender_cred_epen, -gender_cred_no_epen, -gender_cred)
 
 # ---- Assign one gender/student and update MinEnrolment table ----
-# SQL version starts at line 62 on branch main
-# Replicates: qry04b through qry04e2
+# Where is the SQL version: Originally sourced from branch 'main' (line 78)
+# Replicates: qry04c through qry04e2
 # What the code does:
-# - This code performs a historic imputation process based on a student’s earliest recorded data . This
-# solves the problem of the same student appearing with different gender labels across different rows in the dataset.
+# - Performs a historic imputation process based on a student’s earliest recorded data in stp_enrolment.
+# - Accomplished in one pass by creating a concatenated ID (encrypted true pen where available, and psi code/number where not) 
 
 # select first-time recorded gender from min-enrolment data
 first_gender_lookup <- min_enrolment |>
@@ -198,14 +200,13 @@ min_enrolment <- min_enrolment |>
   select(-FIRST_GENDER)
 
 # ---- impute gender  ----
-# SQL version starts ~line 101 on branch main
-# Replicates: qry05a1 through qry06a5
+# Where is the SQL version: SQL version starts ~line 101 on branch main
+# Replicates: qry05a1 through qry06a5 and some R code from lines 101 to 170 (main)
 # What the code does:
-# - Perform a Proportional Imputation for missing gender data.
-# Instead of leaving "Unknown" genders as blanks or assigning them all to one category,
-# it calculates the "natural" distribution of the known population and applies that same ratio to the missing records.
-# the distribution is taken from the set of firt enrolment records, effectivly performing a historical imputation,
-# where the first seen record is carried forward. (This was what I think SQL versions were doing - we should relook at this)
+# - Performs a proportional imputation for missing gender data.
+# It calculates the distribution of the known population from the set of first enrolment records
+#  and applies that same ratio to missing first records.
+# Simulataneously performs a historical imputation, where the first seen record is carried forward. 
 
 na_vals <- c("U", "Unknown", "(Unspecified)", "", NA)
 
@@ -276,15 +277,21 @@ min_enrolment <- min_enrolment |>
 
 
 # ---- Create Age and Gender Distrbutions ----
-# SQL version starts at line 163 on branch main
-# Replicates: qry07a-qry07b2
+# and 
+# ----- Assign age to records with missing age -----
+# Where is the SQL version: Originally sourced from branch 'main' (line 164:281)
+# Replicates: qry07a-qry08 and much R code
 # What the code does:
 # - This code extracts and isolates records where the student's age could not be calculated.
-# - It prepares the data for a second round of imputation (on age) by identifying which students are missing an age.
+# - Performs a Stratified Proportional Imputation for missing ages.
+# - Followed by a Temporal Projection to fill in subsequent records.
+# - Updates extract_no_age with imputed ages
 # BA Notes:
 # - compare extract_no_age to Extract_No_Age and
 # - compare extract_no_age_first_enrol to Extract_No_Age_First_Enrolment
-# R version carries the column PSI_GENDER - needed?
+# - distribution of assigned (imputed) ages are similar for this version vs last
+
+# extract records with missing age at enrolment
 extract_no_age <- min_enrolment |>
   filter(is.na(AGE_AT_ENROL_DATE)) |>
   distinct(
@@ -300,6 +307,7 @@ extract_no_age <- min_enrolment |>
     PSI_GENDER
   )
 
+# extract records with missing age at enrolment for first enrolments only (for imputation)
 extract_no_age_first_enrol <- min_enrolment |>
   filter(is.na(AGE_AT_ENROL_DATE), IS_FIRST_ENROLMENT == "Yes") |>
   distinct(
@@ -311,53 +319,46 @@ extract_no_age_first_enrol <- min_enrolment |>
     AGE_AT_ENROL_DATE_first = AGE_AT_ENROL_DATE
   )
 
+# function to impute age by gender
+# assumes that wt contains a p for every age 
+impute_age_by_gender <- function(df, gender_name, wt) {
+  # isolate frequency distribution for specified gender
+  dist <- wt |> filter(PSI_GENDER == gender_name)
 
-# ----- Assign age to records with missing age -----
-# SQL version starts at line 169 on branch main
-# Replicates: the R code from lines 171 to 263 (main)
-# What the code does:
-# - Performs a Stratified Proportional Imputation for missing ages.
-# - Followed by a Temporal Projection to fill in subsequent records.
-# - Updates extract_no_age with imputed ages
-# - distribution of assigned (imputed) ages are similar for this version vs last
-
-impute_age_by_gender <- function(sub_df, gender_name, lookup_table) {
-  # Look for the distribution for this specific gender
-  dist <- lookup_table |> filter(PSI_GENDER == gender_name)
-
-  # Fallback: If gender group is empty/missing, use the global age distribution
+  # if the distribution is empty/missing, use the global age distribution
   if (nrow(dist) == 0) {
-    dist <- lookup_table |>
+    dist <- wt |>
       count(AGE_AT_ENROL_DATE, wt = count) |>
-      mutate(prob = n / sum(n))
+      mutate(p = n / sum(n))
   }
 
-  # Assign the sampled ages
-  sub_df$AGE_AT_ENROL_DATE <- sample(
+  # sample ages and assign to df
+  df$AGE_AT_ENROL_DATE <- sample(
     dist$AGE_AT_ENROL_DATE,
-    size = nrow(sub_df),
+    size = nrow(df),
     replace = TRUE,
-    prob = dist$prob
+    prob = dist$p
   )
-  return(sub_df)
+  return(df)
 }
 
-# 1. Prep the weights once
+# calculate natural age by gender distribution from known ages at first enrolment
 age_weights <- min_enrolment |>
   filter(!is.na(AGE_AT_ENROL_DATE), IS_FIRST_ENROLMENT == "Yes") |>
   count(PSI_GENDER, AGE_AT_ENROL_DATE, name = "count") |>
   group_by(PSI_GENDER) |>
-  mutate(prob = count / sum(count)) |>
+  mutate(p = count / sum(count)) |>
   ungroup()
 
-# 2. Run the imputation
-# We split by gender, apply the function, and bind the results back together
+# impute ages for records with missing age at first enrolment
+# improvement: assumes age_weights includes a p for every age
+# but if there are missing ages, this forces sampling with 0 p.
 extract_no_age_first_enrol <- extract_no_age_first_enrol |>
   split(~PSI_GENDER) |>
   imap(~ impute_age_by_gender(.x, .y, age_weights)) |>
   list_rbind()
 
-
+# assign ages to all first enrolment records that are missing ages
 extract_no_age <- extract_no_age |>
   select(-AGE_AT_ENROL_DATE) |>
   left_join(
@@ -366,16 +367,12 @@ extract_no_age <- extract_no_age |>
   )
 
 # calculate missing ages from first enrolments
-# Arrange to ensure the first record (baseline) is chronologically first
 calc_ages <- extract_no_age |>
   arrange(PSI_STUDENT_NUMBER, PSI_CODE, PSI_MIN_START_DATE_D) |>
   group_by(PSI_STUDENT_NUMBER, PSI_CODE) |>
   mutate(
-    # Get the baseline date and age from the first record in the group
     base_date = first(PSI_MIN_START_DATE_D),
     base_age = first(AGE_AT_ENROL_DATE),
-
-    # Only calculate if the first record has an age (as per your 'if' logic)
     AGE_AT_ENROL_DATE = if_else(
       is.na(AGE_AT_ENROL_DATE) & !is.na(base_age),
       base_age +
@@ -388,6 +385,7 @@ calc_ages <- extract_no_age |>
 
 calc_ages <- calc_ages %>% select(ID, AGE_AT_ENROL_DATE)
 
+# 
 extract_no_age <- extract_no_age |>
   left_join(
     calc_ages |> rename(AGE_AT_ENROL_DATE_to_update = AGE_AT_ENROL_DATE)

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -295,7 +295,7 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-PSI_GENDER_IMPUTED.pen, -PSI_GENDER_IMPUTED.nopen)
 
-
+# reviewed to here
 # ---- Create Age and Gender Distrbutions ----
 # SQL version starts at line 163 on branch main
 # Replicates: qry07a-qry07b2

--- a/docs/technical-documentation-module-01.qmd
+++ b/docs/technical-documentation-module-01.qmd
@@ -318,31 +318,30 @@ For students with qualifying secondary awards, the script selects the most recen
 The final processing phase applies institutional and categorical identifiers to standardize records for sector-level reporting. A binary flag, RESEARCH_UNIVERSITY, is assigned to records originating from research-intensive institutions (SFU, UBC, UNBC, UVic, RRU). PSI_CREDENTIAL_CATEGORY is standardized to ensure collapses disparate institutional titles into consistent categories required for provincial performance metrics.
 
 
-#### Data Dictionary (Not Completed)
-
 ### STP Enrolment Data Analysis: 
 
 Source Script: 01d-enrolment-analysis.R
 
 #### Descriptive Methods
 
-**Entry Consolidation and Attribute Refinement**
-Raw administrative enrollment records are merged with derived supplemental variables to establish a baseline cohort characterized by student entry points.  A primary analytical view is constructed of pre-initialized supplemental variables. Only those records flagged as `RecordStatus` == 0 and `MinEnrolment` == 1 (the earliest valid record within a specific reporting cycle) are retained.
+**Cohort Definition and Baseline Initialization**
 
-`AGE_AT_ENROL_DATE` is calculated as the duration between the student’s cleaned birthdate and their minimum start date.  Each student is assigned to a discrete demographic grouping (e.g., "Age 18–24").  
+The analytical cohort is established from enrolment records with $RecordStatus = 0$ and $MinEnrolment = 1$ (the earliest valid record within a specific reporting cycle). A baseline age, $AGE_AT_ENROL_DATE{base}$, is calculated as the number of yearts between the student’s birthdate and their $MinEnrolment$ date.  
 
-**Gender Recovery and Missing Genders**
-Genders are recovered by cross-referencing existing credential data in two-passes: For those with valid `ENCRYPTED_TRUE_PEN`, followed by those without.  For student records with a missing EPEN, a composite of `PSI_STUDENT_NUMBER` and `PSI_CODE` is used.
+**Gender Recovery and Imputation**
 
-Where a single student is associated with multiple conflicting gender or birthdate records across the longitudinal set, the first seen enrolment is used.
+Missing gender identifiers are addressed through a hierarchical recovery protocol. 
 
-For the remaining "Unknown" or missing entries, proportional imputation is performed; the observed frequency distribution of known gender labels within the first-time enrolment cohort is calculated and used as statistical weights to impute the missing population.
+1. `NA` genders are first propogated with a valid gender from `stp_credential`.
+2. Genders from first enrolment records are assigned as the "true" gender for all `NA` records.
+3. A weighting schema,  The remaining gender identifiers classified as "Unknown" are assigned a gender by random draw, with probabiliy equal taken from $W_g = \frac{n_g}{\sum n}$, derived from the frequency distribution of valid genders (Male, Female, Gender Diverse). This  maintains population-level representative ratios. Consequent to the forward-fill procedures established in preceding stages, imputed genders are propagated forward in time for each student.
 
-**Missing AGE_AT_ENROL_DATE**
+**Age Imputation**
 
-To address missing ages, a stratified proportional imputation based on gender-specific age distributions is employed to ensure that the imputed ages are statistically representative. Empirical age distributions are generated from the known population, stratified by gender, as age profiles may vary significantly across gender demographics.  Distributions then become the weights for a weighted random draw, performed for each unknown record. If a specific gender-age profile is unavailable, a global population weight is used.
+For records lacking a calculated age, a baseline value is established via a weighted random draw from gender-specific age distributions, denoted as $A_{imputed} \sim P(A \mid G)$. In instances where gender-specific distributions are unavailable, a global population weight is applied. 
 
-Following the assignment of a baseline age to a student's first enrolment record, subsequent enrolment records for the same student are updated through chronological increments (Current Year - Baseline Year), maintaining longitudinal consistency across the student's entire academic history.
+Subsequent enrollment records for the same student are updated via chronological increments, $\Delta t$, defined as:
+$$A_{t} = A_{base} + (Year_{t} - Year_{base})$$
 
 **Final Distributions for Enrolment Forecasting**
 


### PR DESCRIPTION
Please review the following files in this branch: 
[‎R/01d-enrolment-analysis.R‎](https://github.com/bcgov/post-secondary-supply-model/pull/68/changes#diff-7a8f386215044ca1a58e0151bda8483e7a8048e860de19c98caad5674f3d53f7): please review the full file.  I have QA'd the key output table, `min_enrolment`, and find it is comparable to `dbo.min_enrolment`. The final distributions, _dbo.qry09c_MinEnrolment_xxx_,  are statistically the same.  Note: the code for the R-version of the final distributions was moved to 01e.

[‎docs/technical-documentation-module-01.qmd](https://github.com/bcgov/post-secondary-supply-model/pull/68/changes#diff-7d0a431c6730f533db58b400fa031a67d4bf6f49cdc7b6f6d413b7100f6e82ea) Accompanying technical documentation, see section 01d of the methodology, ~ lines 321:351


**notes**
If running equivalent SQL versions on main: the query definition for qry01d1_MinEnrolmentSupVar as is missing a ")". you'll need to manually change it or the script breaks. It was too small of a change to make a PR for it.

