### PR TITLE
01e-stp-distributions

### DIFF
--- a/R/01e-stp-distibutions.R
+++ b/R/01e-stp-distibutions.R
@@ -11,11 +11,68 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-# IMPORTANT!!! THE NEXT SECTION CAN ONLY BE RUN AFTER THE PROGRAM MATCHING WORK HAS BEEN DONE
+library(tidyverse)
 
-# ---- 20 Final Distributions ----
-# NOTE: Exclude_CIPs queries end up with Invalid column name 'FINAL_CIP_CLUSTER_CODE'.
-credential_by_year_age_group <- tbl_credential_highest_rank |>
+required_tables <- c(
+  "age_group_lookup",
+  "min_enrolment",
+  "credential_non_dup",
+  "tbl_credential_highest_rank"
+)
+
+missing <- required_tables[!sapply(required_tables, exists, where = .GlobalEnv)]
+
+if (length(missing) > 0) {
+  stop(paste(
+    "The following required tables are missing from the environment:",
+    paste(missing, collapse = ", ")
+  ))
+}
+
+non_dup_cols <- c(
+  "id",
+  "FINAL_CIP_CLUSTER_CODE",
+  "FINAL_CIP_CODE_4"
+)
+
+min_enrol_cols <- c(
+  "PSI_SCHOOL_YEAR",
+  "PSI_CREDENTIAL_CATEGORY",
+  "PSI_CIP_CODE",
+  "PSI_GENDER",
+  "AGE_GROUP_ENROL_DATE",
+  "PSI_VISA_STATUS"
+)
+
+h_rank_cols <- c(
+  "id",
+  "psi_gender_cleaned",
+  "AGE_GROUP_AT_GRAD",
+  "PSI_CREDENTIAL_CATEGORY",
+  "PSI_AWARD_SCHOOL_YEAR_DELAYED",
+  "PSI_VISA_STATUS",
+  "RESEARCH_UNIVERSITY",
+  "OUTCOMES_CRED"
+)
+
+tbl_credential_highest_rank <- tbl_credential_highest_rank |>
+  select(h_rank_cols)
+min_enrolment <- min_enrolment |> select(min_enrol_cols)
+credential_non_dup <- credential_non_dup |> select(non_dup_cols)
+
+# ---- 20 Final Credential Distributions ----
+# From 01c-credential-analysis.R
+# SQL version starts at line 472 on branch main
+# Replicates: qry20a_ series
+# What the code does: Generate aggregated counts of the highest credential earned by various combinations of
+# gender, school year, age group, credential category, cip code and visa status
+# BA Notes:
+# there were two others that require a table we don't have:
+# dbGetQuery(con, qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs)
+# dbGetQuery(con, qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs_Not_Highest)
+# Several were created for different use cases; only Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+# was used last model run (PSSM 2023/2024)
+qry20a1_credential_by_year_age_group <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |> #filters out invalid ages
   filter(PSI_CREDENTIAL_CATEGORY != "Apprenticeship") |>
   group_by(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED) |>
@@ -23,7 +80,7 @@ credential_by_year_age_group <- tbl_credential_highest_rank |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # Exclude CIP clusters 09 and 10
-credential_by_year_age_group_exclude_cips <- tbl_credential_highest_rank |>
+qry20a1_credential_by_year_age_group_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
@@ -39,7 +96,7 @@ credential_by_year_age_group_exclude_cips <- tbl_credential_highest_rank |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # Domestic only
-credential_by_year_age_group_domestic <- tbl_credential_highest_rank |>
+qry20a2_credential_by_year_age_group_domestic <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -50,7 +107,7 @@ credential_by_year_age_group_domestic <- tbl_credential_highest_rank |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # Domestic only, exclude CIPs
-credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_highest_rank |>
+qry20a2_credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
@@ -67,7 +124,7 @@ credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_highest_ran
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # Domestic only, exclude research universities and DACSO
-credential_by_year_age_group_domestic_exclude_ru_dacso <- tbl_credential_highest_rank |>
+qry20a3_credential_by_year_age_group_domestic_exclude_ru_dacso <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -80,7 +137,7 @@ credential_by_year_age_group_domestic_exclude_ru_dacso <- tbl_credential_highest
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # CIP4, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
-credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
+qry20a4_credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
@@ -109,10 +166,11 @@ credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_c
   )
 
 # CIP4, Gender, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
-credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
+qry20a4_credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
+    credential_non_dup |>
+      select(id, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
     by = "id"
   ) |>
   filter(
@@ -140,10 +198,11 @@ credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <
   )
 
 # Gender, AgeGroup, Domestic, Exclude CIPs
-credential_by_year_gender_agegroup_domestic_exclude_cips <- tbl_credential_highest_rank |>
+qry20a4_credential_by_year_gender_agegroup_domestic_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
+    credential_non_dup |>
+      select(id, FINAL_CIP_CLUSTER_CODE),
     by = "id"
   ) |>
   filter(
@@ -167,10 +226,11 @@ credential_by_year_gender_agegroup_domestic_exclude_cips <- tbl_credential_highe
   )
 
 # Gender, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
-credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
+qry20a4_credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
+    credential_non_dup |>
+      select(id, FINAL_CIP_CLUSTER_CODE),
     by = "id"
   ) |>
   filter(
@@ -195,13 +255,14 @@ credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl
     PSI_AWARD_SCHOOL_YEAR_DELAYED
   )
 
-# ---- Final Distributions ----
+# ---- Final Enrolment Distributions ----
 # From 01d-enrolment-analysis.R
 # SQL version starts at line 283 on branch main
 # Replicates: qry09c_ series
-# What the code does: Execute relational joins to generate standardized gender-age cohorts and academic datasets.
-# Followed by frequency analysis of enrollment metrics stratified by residency status, credential category, and field of study.
-# BA Notes: The original SQL filters on a single school year, but the filter is commented out.
+# What the code does: Generate aggregated counts of the minimum enrolment records by various combinations of
+# gender, school year, age group, credential category and cip code.
+# Several were created for looking at different scenarios but
+# only qry09c_MinEnrolment was used in enrolment forecasting for 2023/2024 (last model run)
 
 qry09c_MinEnrolment_by_Credential_and_CIP_Code <- min_enrolment |>
   count(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, name = "Expr1")
@@ -216,25 +277,20 @@ qry09c_MinEnrolment <- min_enrolment |>
   mutate("Groups" = paste0(PSI_GENDER, AgeGroup)) |>
   count(PSI_GENDER, PSI_SCHOOL_YEAR, Groups, name = "Expr1")
 
-# refine this list as we refactor
+# ---- Clean Up ----
 tables_to_keep <- c(
-  "stp_enrolment",
-  "stp_credential",
-  "stp_enrolment_record_type",
-  "stp_credential_record_type",
-  "stp_enrolment_valid",
-  "age_group_lookup",
-  "credential_rank",
-  "credential",
-  "credential_non_dup",
-  "credential_sup_vars",
-  "tbl_credential_highest_rank",
-  "tbl_credential_delay_effect",
-  "outcome_credential",
-  "min_enrolment",
-  "qry09c_MinEnrolment_by_Credential_and_CIP_Code",
-  "qry09c_MinEnrolment_Domestic",
-  "qry09c_MinEnrolment"
+  'qry20a1_credential_by_year_age_group',
+  'qry20a2_credential_by_year_age_group_domestic',
+  'qry20a2_credential_by_year_age_group_domestic_exclude_cips',
+  'qry20a3_credential_by_year_age_group_domestic_exclude_ru_dacso',
+  'qry20a1_credential_by_year_age_group_exclude_cips',
+  'qry20a4_credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips',
+  'qry20a4_credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips',
+  'qry20a4_credential_by_year_gender_agegroup_domestic_exclude_cips',
+  'qry20a4_credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips',
+  'qry09c_MinEnrolment_by_Credential_and_CIP_Code',
+  'qry09c_MinEnrolment_Domestic',
+  'qry09c_MinEnrolment'
 )
 
 rm(list = setdiff(ls(), tables_to_keep))

--- a/R/01e-stp-distibutions.R
+++ b/R/01e-stp-distibutions.R
@@ -132,6 +132,8 @@ qry20a2_credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_hig
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
 # Domestic only, exclude research universities and DACSO
+# Notes from 2019 docs suggest we exclude credentials which are 
+# included in DACSO but that are granted by research universities.
 qry20a3_credential_by_year_age_group_domestic_exclude_ru_dacso <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   filter(

--- a/R/01e-stp-distibutions.R
+++ b/R/01e-stp-distibutions.R
@@ -31,6 +31,8 @@ if (length(missing) > 0) {
 
 non_dup_cols <- c(
   "id",
+  "RESEARCH_UNIVERSITY",
+  "OUTCOMES_CRED",
   "FINAL_CIP_CLUSTER_CODE",
   "FINAL_CIP_CODE_4"
 )
@@ -50,15 +52,21 @@ h_rank_cols <- c(
   "AGE_GROUP_AT_GRAD",
   "PSI_CREDENTIAL_CATEGORY",
   "PSI_AWARD_SCHOOL_YEAR_DELAYED",
-  "PSI_VISA_STATUS",
-  "RESEARCH_UNIVERSITY",
-  "OUTCOMES_CRED"
+  "PSI_VISA_STATUS"
 )
 
 tbl_credential_highest_rank <- tbl_credential_highest_rank |>
   select(h_rank_cols)
 min_enrolment <- min_enrolment |> select(min_enrol_cols)
 credential_non_dup <- credential_non_dup |> select(non_dup_cols)
+
+# bring research university and outcomes credential into tbl_credential_highest_rank 
+# this should have been done at end of 01c-credential-analysis.R
+tbl_credential_highest_rank <- tbl_credential_highest_rank |>
+  left_join(
+    credential_non_dup |> select(id, RESEARCH_UNIVERSITY, OUTCOMES_CRED),
+    by = "id"
+  ) 
 
 # ---- 20 Final Credential Distributions ----
 # From 01c-credential-analysis.R


### PR DESCRIPTION
This code in this PR creates aggregations of credential data by different variables such as gender, CIP, PSI_VISA_STATUS, age.  Only one was used downstream (`qry20a3_credential_by_year_age_group_domestic_exclude_ru_dacso`) but several are made here.

Similarly, aggregations of enrolment data are also created, only one is used later.

Files in this PR are here: [‎R/01e-stp-distibutions.R‎](https://github.com/bcgov/post-secondary-supply-model/pull/70/changes#diff-0c4668eb79ba99a6f981ce70f3c933adbdaa253577077b0c65d2b682b87552c8)

Technical documentations is here: 