### PR TITLE
02a dacso program matching: Refactor DACSO program matching step from SQL-style joins to clearer R dplyr joins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ R/02a-dacso-program-matching-test-id.R
 sql/Notebook-refactor-1.ipynb
 sql/test_refactor.r
 sql/test_refactor.sql
+R/test-sql-r-comparison.r
+.gitignore
+sql/pssm-refactor01-code-review.txt

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ sql/test_refactor.sql
 R/test-sql-r-comparison.r
 .gitignore
 sql/pssm-refactor01-code-review.txt
+R/pssm_sql_dplyr_validation.qmd

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@
 config.yml
 scratch/*
 *_log.txt
+BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos_orig.csv
+BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos.csv
+T_BGS_Data_Unmatched_CIPS_to_review.csv
+T_BGS_Data_Unmatched_CIPS_to_update.csv
+R/02a-appso-programs.txt
+R/02a-bgs-program-matching-backup-2.R
+R/02a-dacso-program-matching-test-id.R
+sql/Notebook-refactor-1.ipynb
+sql/test_refactor.r
+sql/test_refactor.sql

--- a/R/.gitignore
+++ b/R/.gitignore
@@ -1,2 +1,4 @@
 execution_log.txt
 gender_cleaning.R
+*.txt
+*.csv

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -1143,7 +1143,11 @@ xwalk_exact <- xwalk %>%
     PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
-  ) |> slice_head(n=1, by = c(PSI_CODE_KEY, PSI_PROGRAM_CODE_KEY, PSI_CREDENTIAL_PROGRAM_DESC_KEY))
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(PSI_CODE_KEY, PSI_PROGRAM_CODE_KEY, PSI_CREDENTIAL_PROGRAM_DESC_KEY)
+  )
 
 stp_dacso <- stp_dacso %>%
   left_join(
@@ -1153,8 +1157,7 @@ stp_dacso <- stp_dacso %>%
       "PSI_CODE_KEY" = "PSI_CODE_KEY",
       "PSI_PROGRAM_CODE_KEY" = "PSI_PROGRAM_CODE_KEY",
       "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided
+    )
   ) %>%
   mutate(
     Already_Matched = if_else(
@@ -1167,11 +1170,6 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-
-# ℹ Row 14 of `x` matches multiple rows in `y`.
-# ℹ Row 2465 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # thia is not in the original code
-# 5462
 
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_PROGRAM_CODE
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE + PSI_CREDENTIAL_PROGRAM_DESCRIPTION

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -1143,7 +1143,7 @@ xwalk_exact <- xwalk %>%
     PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
-  )
+  ) |> slice_head(n=1, by = c(PSI_CODE_KEY, PSI_PROGRAM_CODE_KEY, PSI_CREDENTIAL_PROGRAM_DESC_KEY))
 
 stp_dacso <- stp_dacso %>%
   left_join(

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -50,6 +50,81 @@ sch_tbl <- function(name) {
   tbl(con, dbplyr::in_schema(my_schema, name))
 }
 
+# -----------------------------------------------------------------------------
+# Helper functions for SQL-like joins on character business keys
+# -----------------------------------------------------------------------------
+# SQL Server usually compares character join fields case-insensitively.
+# R joins are case-sensitive. To make the translation safer and easier to audit,
+# we create explicit *_KEY columns for the business keys that are most likely to
+# differ by case or extra spaces.
+
+norm_chr <- function(x) {
+  x <- as.character(x)
+  x <- trimws(x)
+  toupper(x)
+}
+
+# Add one or more normalized join-key columns to a data frame.
+# mappings is a named character vector:
+#   new_key_name = existing_column_name
+add_join_keys <- function(df, mappings) {
+  if (length(mappings) == 0) {
+    return(df)
+  }
+
+  for (new_nm in names(mappings)) {
+    src_nm <- unname(mappings[[new_nm]])
+    if (src_nm %in% names(df)) {
+      df[[new_nm]] <- norm_chr(df[[src_nm]])
+    }
+  }
+
+  df
+}
+
+# Remove helper key columns before writing final outputs.
+drop_join_keys <- function(df) {
+  df %>% select(-matches("_KEY$"))
+}
+
+# Standard key sets used repeatedly in this script.
+refresh_programs_join_keys <- function(df) {
+  add_join_keys(
+    df,
+    c(
+      PRGM_INST_CD_KEY = "PRGM_INST_CD",
+      PRGM_LCPC_CD_KEY = "PRGM_LCPC_CD",
+      PRGM_INST_PROGRAM_NAME_KEY = "PRGM_INST_PROGRAM_NAME"
+    )
+  )
+}
+
+refresh_xwalk_join_keys <- function(df) {
+  add_join_keys(
+    df,
+    c(
+      PSI_CODE_KEY = "PSI_CODE",
+      COCI_INST_CD_KEY = "COCI_INST_CD",
+      PSI_PROGRAM_CODE_KEY = "PSI_PROGRAM_CODE",
+      PRGM_LCPC_CD_KEY = "PRGM_LCPC_CD",
+      PSI_CREDENTIAL_PROGRAM_DESC_KEY = "PSI_CREDENTIAL_PROGRAM_DESC",
+      PRGM_INST_PROGRAM_NAME_KEY = "PRGM_INST_PROGRAM_NAME"
+    )
+  )
+}
+
+refresh_stp_join_keys <- function(df) {
+  add_join_keys(
+    df,
+    c(
+      PSI_CODE_KEY = "PSI_CODE",
+      COCI_INST_CD_KEY = "COCI_INST_CD",
+      PSI_PROGRAM_CODE_KEY = "PSI_PROGRAM_CODE",
+      PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY = "PSI_CREDENTIAL_PROGRAM_DESCRIPTION"
+    )
+  )
+}
+
 
 ## ---- Read in INFOWARE tables ----
 # iw_config <- config::get("infoware")
@@ -64,17 +139,17 @@ sch_tbl <- function(name) {
 #   iw_config$pwd
 # )
 # new way to load data from infoware
-iw_config <- config::get("infoware")
+# iw_config <- config::get("infoware")
 
-# odbcListDrivers()
+# # odbcListDrivers()
 
-iw_con <- dbConnect(
-  odbc::odbc(),
-  Driver = "Oracle in instantclient_19_30",
-  DBQ = "DEV01.world",
-  UID = iw_config$uid,
-  PWD = iw_config$pwd
-)
+# iw_con <- dbConnect(
+#   odbc::odbc(),
+#   Driver = "Oracle in instantclient_19_30",
+#   DBQ = "DEV01.world",
+#   UID = iw_config$uid,
+#   PWD = iw_config$pwd
+# )
 # all the comment-outed data steps are only running for once.
 # now infoware has INFOWARE.L_CIP_6DIGITS_CIP2021 table. We may need to update soon.
 
@@ -112,16 +187,16 @@ iw_con <- dbConnect(
 
 # odbcClose(acc_con)
 
-# ## ---- Connect to Decimal ----
-# config <- config::get("decimal")
-# con <- dbConnect(
-#   odbc(),
-#   Driver = config$driver,
-#   Server = config$server,
-#   Database = config$database,
-#   Trusted_Connection = "True"
-# )
-# my_schema <- config::get("myschema")
+## ---- Connect to Decimal ----
+config <- config::get("decimal")
+con <- dbConnect(
+  odbc(),
+  Driver = config$driver,
+  Server = config$server,
+  Database = config$database,
+  Trusted_Connection = "True"
+)
+my_schema <- config::get("myschema")
 
 # ## ---- Write initial tables to Decimal ----
 # ## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
@@ -206,7 +281,8 @@ programs_table <- tbl(con, "INFOWARE_PROGRAMS_2016") %>%
     LCIP_LCP4_CD,
     LCP4_CIP_4DIGITS_NAME
   ) %>%
-  collect()
+  collect() %>%
+  refresh_programs_join_keys()
 
 ## ---- Make new XWALK from last years XWALK ----
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- tbl(
@@ -214,7 +290,10 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- tbl(
   "DACSO_STP_ProgramsCIP4_XWALK_ALL_2020"
 ) %>%
   collect() %>%
-  mutate(CIP_CODE_4 = str_pad(CIP_CODE_4, width = 4, side = "left", pad = "0"))
+  mutate(
+    CIP_CODE_4 = str_pad(CIP_CODE_4, width = 4, side = "left", pad = "0")
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- Add to XWALK: New DACSO prgms WITHOUT historical linkages ----
 ## review the HAS_HISTORICAL_PRGM_ID_LINK values
@@ -248,7 +327,7 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
         )
       ) %>%
       select(
-        COCI_INST_CD = PRGM_INST_CD,
+        COCI_INST_CD = PRGM_INST_CD, #why change name?
         PRGM_LCPC_CD,
         PRGM_INST_PROGRAM_NAME,
         CIP_CODE_4 = LCIP_LCP4_CD,
@@ -325,57 +404,78 @@ Updated_DACSO_Programs_in_2021_with_links <- Updated_DACSO_Programs_in_2021_with
   )
 
 ## ---- 2021 Update to XWALK: Updated DACSO programs WITH historical linkages ----
+# Use generated key columns for the business-key join below.
+# This keeps the original columns unchanged and makes the SQL-like matching rule explicit.
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2021_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
+      add_join_keys(
+        c(
+          COCI_INST_CD_KEY = "PRGM_INST_CD",
+          PRGM_LCPC_CD_KEY = "HISTORICAL_CPC_CD",
+          PRGM_INST_PROGRAM_NAME_KEY = "HISTORICAL_PROGRAM_NAME"
+        )
+      ) %>%
       select(
-        PRGM_INST_CD,
-        HISTORICAL_CPC_CD,
-        HISTORICAL_PROGRAM_NAME,
+        COCI_INST_CD_KEY,
+        PRGM_LCPC_CD_KEY,
+        PRGM_INST_PROGRAM_NAME_KEY,
         HISTORICAL_CIP4_CD,
-        PRGM_LCPC_CD,
-        PRGM_INST_PROGRAM_NAME,
+        PRGM_LCPC_CD_NEW = PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME_NEW = PRGM_INST_PROGRAM_NAME,
         LCIP_LCP4_CD,
-        LCP4_CIP_4DIGITS_NAME,
+        LCP4_CIP_4DIGITS_NAME_NEW = LCP4_CIP_4DIGITS_NAME,
         Updated_DACSO_CPC2021 = Updated_CPC_Flag,
         Updated_DACSO_CIP2021 = Updated_CIP_Flag
       ),
     by = c(
-      COCI_INST_CD = "PRGM_INST_CD",
-      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
-      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
-      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+      "COCI_INST_CD_KEY",
+      "PRGM_LCPC_CD_KEY",
+      "PRGM_INST_PROGRAM_NAME_KEY",
+      "CIP_CODE_4" = "HISTORICAL_CIP4_CD"
     )
   ) %>%
   mutate(
-    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_LCPC_CD = ifelse(
+      !is.na(PRGM_LCPC_CD_NEW),
+      PRGM_LCPC_CD_NEW,
+      PRGM_LCPC_CD
+    ),
     PRGM_INST_PROGRAM_NAME = ifelse(
-      !is.na(PRGM_INST_PROGRAM_NAME.y),
-      PRGM_INST_PROGRAM_NAME.y,
+      !is.na(PRGM_INST_PROGRAM_NAME_NEW),
+      PRGM_INST_PROGRAM_NAME_NEW,
       PRGM_INST_PROGRAM_NAME
     ),
-    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
-  ) %>%
-  mutate(
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4),
     LCP4_CIP_4DIGITS_NAME = ifelse(
-      !is.na(LCP4_CIP_4DIGITS_NAME.y),
-      LCP4_CIP_4DIGITS_NAME.y,
-      LCP4_CIP_4DIGITS_NAME.x
-    ),
-    .after = "CIP_CODE_4"
+      !is.na(LCP4_CIP_4DIGITS_NAME_NEW),
+      LCP4_CIP_4DIGITS_NAME_NEW,
+      LCP4_CIP_4DIGITS_NAME
+    )
   ) %>%
-  select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
+  select(
+    -PRGM_LCPC_CD_NEW,
+    -PRGM_INST_PROGRAM_NAME_NEW,
+    -LCIP_LCP4_CD,
+    -LCP4_CIP_4DIGITS_NAME_NEW
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- 2021 Find Remaining updated DACSO missing from XWALK for match to STP program ----
+# Use normalized helper keys for the anti-join so case-only differences do not create false misses.
 Remaining_DACSO_Updates_CPCS_2021 <- Updated_DACSO_Programs_in_2021_with_links %>%
-  anti_join(
-    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-    by = c(
-      PRGM_LCPC_CD = "PRGM_LCPC_CD",
-      PRGM_INST_CD = "COCI_INST_CD",
-      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+  add_join_keys(
+    c(
+      PRGM_LCPC_CD_KEY = "PRGM_LCPC_CD",
+      COCI_INST_CD_KEY = "PRGM_INST_CD",
+      PRGM_INST_PROGRAM_NAME_KEY = "PRGM_INST_PROGRAM_NAME"
     )
+  ) %>%
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+      select(PRGM_LCPC_CD_KEY, COCI_INST_CD_KEY, PRGM_INST_PROGRAM_NAME_KEY),
+    by = c("PRGM_LCPC_CD_KEY", "COCI_INST_CD_KEY", "PRGM_INST_PROGRAM_NAME_KEY")
   )
 
 # ***** manual work needed *****
@@ -409,7 +509,8 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       PRGM_ID == 3119 ~ "Yes",
       TRUE ~ Updated_DACSO_CPC2021
     )
-  )
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- 2022 Find DACSO prgms WITH historical linkages ----
 Updated_DACSO_Programs_in_2022_with_links <- programs_table %>%
@@ -472,57 +573,78 @@ Updated_DACSO_Programs_in_2022_with_links <- Updated_DACSO_Programs_in_2022_with
   )
 
 ## ---- 2022 Update to XWALK: Updated DACSO programs WITH historical linkages ----
+# Use generated key columns for the business-key join below.
+# This keeps the original columns unchanged and makes the SQL-like matching rule explicit.
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2022_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
+      add_join_keys(
+        c(
+          COCI_INST_CD_KEY = "PRGM_INST_CD",
+          PRGM_LCPC_CD_KEY = "HISTORICAL_CPC_CD",
+          PRGM_INST_PROGRAM_NAME_KEY = "HISTORICAL_PROGRAM_NAME"
+        )
+      ) %>%
       select(
-        PRGM_INST_CD,
-        HISTORICAL_CPC_CD,
-        HISTORICAL_PROGRAM_NAME,
+        COCI_INST_CD_KEY,
+        PRGM_LCPC_CD_KEY,
+        PRGM_INST_PROGRAM_NAME_KEY,
         HISTORICAL_CIP4_CD,
-        PRGM_LCPC_CD,
-        PRGM_INST_PROGRAM_NAME,
+        PRGM_LCPC_CD_NEW = PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME_NEW = PRGM_INST_PROGRAM_NAME,
         LCIP_LCP4_CD,
-        LCP4_CIP_4DIGITS_NAME,
+        LCP4_CIP_4DIGITS_NAME_NEW = LCP4_CIP_4DIGITS_NAME,
         Updated_DACSO_CPC2022 = Updated_CPC_Flag,
         Updated_DACSO_CIP2022 = Updated_CIP_Flag
       ),
     by = c(
-      COCI_INST_CD = "PRGM_INST_CD",
-      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
-      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
-      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+      "COCI_INST_CD_KEY",
+      "PRGM_LCPC_CD_KEY",
+      "PRGM_INST_PROGRAM_NAME_KEY",
+      "CIP_CODE_4" = "HISTORICAL_CIP4_CD"
     )
   ) %>%
   mutate(
-    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_LCPC_CD = ifelse(
+      !is.na(PRGM_LCPC_CD_NEW),
+      PRGM_LCPC_CD_NEW,
+      PRGM_LCPC_CD
+    ),
     PRGM_INST_PROGRAM_NAME = ifelse(
-      !is.na(PRGM_INST_PROGRAM_NAME.y),
-      PRGM_INST_PROGRAM_NAME.y,
+      !is.na(PRGM_INST_PROGRAM_NAME_NEW),
+      PRGM_INST_PROGRAM_NAME_NEW,
       PRGM_INST_PROGRAM_NAME
     ),
-    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
-  ) %>%
-  mutate(
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4),
     LCP4_CIP_4DIGITS_NAME = ifelse(
-      !is.na(LCP4_CIP_4DIGITS_NAME.y),
-      LCP4_CIP_4DIGITS_NAME.y,
-      LCP4_CIP_4DIGITS_NAME.x
-    ),
-    .after = "CIP_CODE_4"
+      !is.na(LCP4_CIP_4DIGITS_NAME_NEW),
+      LCP4_CIP_4DIGITS_NAME_NEW,
+      LCP4_CIP_4DIGITS_NAME
+    )
   ) %>%
-  select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
+  select(
+    -PRGM_LCPC_CD_NEW,
+    -PRGM_INST_PROGRAM_NAME_NEW,
+    -LCIP_LCP4_CD,
+    -LCP4_CIP_4DIGITS_NAME_NEW
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- 2022 Find Remaining updated DACSO missing from XWALK for match to STP program ----
+# Use normalized helper keys for the anti-join so case-only differences do not create false misses.
 Remaining_DACSO_Updates_CPCS_2022 <- Updated_DACSO_Programs_in_2022_with_links %>%
-  anti_join(
-    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-    by = c(
-      PRGM_LCPC_CD = "PRGM_LCPC_CD",
-      PRGM_INST_CD = "COCI_INST_CD",
-      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+  add_join_keys(
+    c(
+      PRGM_LCPC_CD_KEY = "PRGM_LCPC_CD",
+      COCI_INST_CD_KEY = "PRGM_INST_CD",
+      PRGM_INST_PROGRAM_NAME_KEY = "PRGM_INST_PROGRAM_NAME"
     )
+  ) %>%
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+      select(PRGM_LCPC_CD_KEY, COCI_INST_CD_KEY, PRGM_INST_PROGRAM_NAME_KEY),
+    by = c("PRGM_LCPC_CD_KEY", "COCI_INST_CD_KEY", "PRGM_INST_PROGRAM_NAME_KEY")
   )
 
 # ***** manual work needed *****
@@ -596,7 +718,8 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       PRGM_ID == 131 ~ "Yes",
       TRUE ~ Updated_DACSO_CPC2022
     )
-  )
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- 2023 Find DACSO prgms WITH historical linkages ----
 Updated_DACSO_Programs_in_2023_with_links <- programs_table %>%
@@ -659,57 +782,78 @@ Updated_DACSO_Programs_in_2023_with_links <- Updated_DACSO_Programs_in_2023_with
   )
 
 ## ---- 2023 Update to XWALK: Updated DACSO programs WITH historical linkages ----
+# Use generated key columns for the business-key join below.
+# This keeps the original columns unchanged and makes the SQL-like matching rule explicit.
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2023_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
+      add_join_keys(
+        c(
+          COCI_INST_CD_KEY = "PRGM_INST_CD",
+          PRGM_LCPC_CD_KEY = "HISTORICAL_CPC_CD",
+          PRGM_INST_PROGRAM_NAME_KEY = "HISTORICAL_PROGRAM_NAME"
+        )
+      ) %>%
       select(
-        PRGM_INST_CD,
-        HISTORICAL_CPC_CD,
-        HISTORICAL_PROGRAM_NAME,
+        COCI_INST_CD_KEY,
+        PRGM_LCPC_CD_KEY,
+        PRGM_INST_PROGRAM_NAME_KEY,
         HISTORICAL_CIP4_CD,
-        PRGM_LCPC_CD,
-        PRGM_INST_PROGRAM_NAME,
+        PRGM_LCPC_CD_NEW = PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME_NEW = PRGM_INST_PROGRAM_NAME,
         LCIP_LCP4_CD,
-        LCP4_CIP_4DIGITS_NAME,
+        LCP4_CIP_4DIGITS_NAME_NEW = LCP4_CIP_4DIGITS_NAME,
         Updated_DACSO_CPC2023 = Updated_CPC_Flag,
         Updated_DACSO_CIP2023 = Updated_CIP_Flag
       ),
     by = c(
-      COCI_INST_CD = "PRGM_INST_CD",
-      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
-      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
-      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+      "COCI_INST_CD_KEY",
+      "PRGM_LCPC_CD_KEY",
+      "PRGM_INST_PROGRAM_NAME_KEY",
+      "CIP_CODE_4" = "HISTORICAL_CIP4_CD"
     )
   ) %>%
   mutate(
-    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_LCPC_CD = ifelse(
+      !is.na(PRGM_LCPC_CD_NEW),
+      PRGM_LCPC_CD_NEW,
+      PRGM_LCPC_CD
+    ),
     PRGM_INST_PROGRAM_NAME = ifelse(
-      !is.na(PRGM_INST_PROGRAM_NAME.y),
-      PRGM_INST_PROGRAM_NAME.y,
+      !is.na(PRGM_INST_PROGRAM_NAME_NEW),
+      PRGM_INST_PROGRAM_NAME_NEW,
       PRGM_INST_PROGRAM_NAME
     ),
-    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
-  ) %>%
-  mutate(
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4),
     LCP4_CIP_4DIGITS_NAME = ifelse(
-      !is.na(LCP4_CIP_4DIGITS_NAME.y),
-      LCP4_CIP_4DIGITS_NAME.y,
-      LCP4_CIP_4DIGITS_NAME.x
-    ),
-    .after = "CIP_CODE_4"
+      !is.na(LCP4_CIP_4DIGITS_NAME_NEW),
+      LCP4_CIP_4DIGITS_NAME_NEW,
+      LCP4_CIP_4DIGITS_NAME
+    )
   ) %>%
-  select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
+  select(
+    -PRGM_LCPC_CD_NEW,
+    -PRGM_INST_PROGRAM_NAME_NEW,
+    -LCIP_LCP4_CD,
+    -LCP4_CIP_4DIGITS_NAME_NEW
+  ) %>%
+  refresh_xwalk_join_keys()
 
 ## ---- 2023 Find Remaining updated DACSO missing from XWALK for match to STP program ----
+# Use normalized helper keys for the anti-join so case-only differences do not create false misses.
 Remaining_DACSO_Updates_CPCS_2023 <- Updated_DACSO_Programs_in_2023_with_links %>%
-  anti_join(
-    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-    by = c(
-      PRGM_LCPC_CD = "PRGM_LCPC_CD",
-      PRGM_INST_CD = "COCI_INST_CD",
-      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+  add_join_keys(
+    c(
+      PRGM_LCPC_CD_KEY = "PRGM_LCPC_CD",
+      COCI_INST_CD_KEY = "PRGM_INST_CD",
+      PRGM_INST_PROGRAM_NAME_KEY = "PRGM_INST_PROGRAM_NAME"
     )
+  ) %>%
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+      select(PRGM_LCPC_CD_KEY, COCI_INST_CD_KEY, PRGM_INST_PROGRAM_NAME_KEY),
+    by = c("PRGM_LCPC_CD_KEY", "COCI_INST_CD_KEY", "PRGM_INST_PROGRAM_NAME_KEY")
   )
 
 # ***** manual work needed *****
@@ -743,7 +887,7 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
         PRGM_LCPC_CD,
         PRGM_INST_PROGRAM_NAME,
         PRGM_CREDENTIAL,
-        CIP_CODE_4 = LCIP_LCP4_CD,
+        CIP_CODE_4 = LCIP_LCP4_CD, #why change name?
         LCP4_CIP_4DIGITS_NAME,
         PRGM_ID,
         New_DACSO_Program2021to23
@@ -854,7 +998,8 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
 dbWriteTable(
   con,
   "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_r",
-  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
+  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+  overwrite = TRUE
 )
 
 
@@ -884,6 +1029,8 @@ credential_non_dup <- sch_tbl("Credential_Non_Dup") |>
   ) %>%
   collect()
 
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  refresh_xwalk_join_keys()
 xwalk <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
 
 # Pull INFOWARE CIP reference tables
@@ -949,7 +1096,8 @@ stp_dacso <- stp_dacso %>%
     by = "PSI_CODE"
   ) %>%
   mutate(COCI_INST_CD = coalesce(COCI_INST_CD_MAP, COCI_INST_CD)) %>%
-  select(-COCI_INST_CD_MAP)
+  select(-COCI_INST_CD_MAP) %>%
+  refresh_stp_join_keys()
 
 
 ## ---- Populate STP_CIP_CODE_4, STP_CIP_CODE_4_NAME ----
@@ -990,9 +1138,9 @@ xwalk_exact <- xwalk %>%
       !is.na(PSI_CREDENTIAL_PROGRAM_DESC)
   ) %>%
   select(
-    PSI_CODE,
-    PSI_PROGRAM_CODE,
-    PSI_CREDENTIAL_PROGRAM_DESC,
+    PSI_CODE_KEY,
+    PSI_PROGRAM_CODE_KEY,
+    PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
   )
@@ -1002,9 +1150,9 @@ stp_dacso <- stp_dacso %>%
     xwalk_exact %>%
       rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
     by = c(
-      "PSI_CODE",
-      "PSI_PROGRAM_CODE" = "PSI_PROGRAM_CODE",
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PSI_CREDENTIAL_PROGRAM_DESC"
+      "PSI_CODE_KEY" = "PSI_CODE_KEY",
+      "PSI_PROGRAM_CODE_KEY" = "PSI_PROGRAM_CODE_KEY",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
     ),
     relationship = "many-to-many" # no reason is provided
   ) %>%
@@ -1023,6 +1171,7 @@ stp_dacso <- stp_dacso %>%
 # ℹ Row 14 of `x` matches multiple rows in `y`.
 # ℹ Row 2465 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # thia is not in the original code
+# 5462
 
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_PROGRAM_CODE
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE + PSI_CREDENTIAL_PROGRAM_DESCRIPTION
@@ -1033,9 +1182,9 @@ xwalk_coci <- xwalk %>%
       !is.na(PSI_CREDENTIAL_PROGRAM_DESC)
   ) %>%
   select(
-    COCI_INST_CD,
-    PSI_PROGRAM_CODE,
-    PSI_CREDENTIAL_PROGRAM_DESC,
+    COCI_INST_CD_KEY,
+    PSI_PROGRAM_CODE_KEY,
+    PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
   )
@@ -1045,10 +1194,11 @@ stp_dacso <- stp_dacso %>%
     xwalk_coci %>%
       rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
     by = c(
-      "COCI_INST_CD",
-      "PSI_PROGRAM_CODE" = "PSI_PROGRAM_CODE",
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PSI_CREDENTIAL_PROGRAM_DESC"
-    )
+      "COCI_INST_CD_KEY" = "COCI_INST_CD_KEY",
+      "PSI_PROGRAM_CODE_KEY" = "PSI_PROGRAM_CODE_KEY",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
+    ),
+    relationship = "many-to-many" # no reason is provided
   ) %>%
   mutate(
     Already_Matched = if_else(
@@ -1081,7 +1231,7 @@ stp_dacso <- stp_dacso %>%
 # ℹ Row 14 of `x` matches multiple rows in `y`.
 # ℹ Row 1251 of `y` matches multiple rows in `x`
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5450 rows
+# 5462 rows
 
 ## ---- Newly matched programs ----
 # reference: to check after each query to see counts of matched
@@ -1098,9 +1248,9 @@ xwalk_new_a <- xwalk %>%
     !is.na(PSI_CODE) & !is.na(PRGM_LCPC_CD) & !is.na(PRGM_INST_PROGRAM_NAME)
   ) %>%
   select(
-    PSI_CODE,
-    PRGM_LCPC_CD,
-    PRGM_INST_PROGRAM_NAME,
+    PSI_CODE_KEY,
+    PRGM_LCPC_CD_KEY,
+    PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
   )
@@ -1110,10 +1260,11 @@ stp_dacso <- stp_dacso %>%
     xwalk_new_a %>%
       rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
     by = c(
-      "PSI_CODE",
-      "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD",
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
-    )
+      "PSI_CODE_KEY",
+      "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
+    ),
+    relationship = "many-to-many" # no reason is provided
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1138,7 +1289,7 @@ stp_dacso <- stp_dacso %>%
 # ℹ Row 1608 of `y` matches multiple rows in `x`.
 
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5450 rows
+# 5462 rows
 
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD + DESC=PRGM_INST_PROGRAM_NAME
@@ -1147,9 +1298,9 @@ xwalk_new_a2 <- xwalk %>%
     !is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD) & !is.na(PRGM_INST_PROGRAM_NAME)
   ) %>%
   select(
-    COCI_INST_CD,
-    PRGM_LCPC_CD,
-    PRGM_INST_PROGRAM_NAME,
+    COCI_INST_CD_KEY,
+    PRGM_LCPC_CD_KEY,
+    PRGM_INST_PROGRAM_NAME_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
   )
@@ -1159,10 +1310,11 @@ stp_dacso <- stp_dacso %>%
     xwalk_new_a2 %>%
       rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
     by = c(
-      "COCI_INST_CD",
-      "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD",
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
-    )
+      "COCI_INST_CD_KEY",
+      "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PRGM_INST_PROGRAM_NAME_KEY"
+    ),
+    relationship = "many-to-many" # no reason is provided
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1191,9 +1343,11 @@ stp_dacso <- stp_dacso %>%
 # ℹ Row 1716 of `y` matches multiple rows in `x`.
 
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5450 rows
+# 5462 rows
 
 ## ---- Add to XWALK: newly matched STP programs ----
+## qry_STP_Credential_DACSO_Programs_NewMatches_b ----
+
 # join on PSI_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # where New_Auto_Match = Yes, copy PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, STP_CIP4_CODE into STP_CIP_CODE_4, CTP_SIP4_NAME into STP_CIP_CODE_4_NAME
 # - Set New_STP_Program20XX = Yes and One_To_One_Match = Yes20XX
@@ -1201,15 +1355,19 @@ stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
 # the XWALK with the STP program info so future runs can find them as "already matched".
 
 # Get the newly matched STP programs
+# Carry both the original columns and normalized keys so the join is easy to read.
 newly_matched <- stp_dacso %>%
   filter(New_Auto_Match == "Yes") %>%
   select(
-    PSI_CODE,
     PSI_PROGRAM_CODE,
     PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+    PSI_CODE_KEY,
+    PSI_PROGRAM_CODE_KEY,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY,
     STP_CIP_CODE_4,
     STP_CIP_CODE_4_NAME
   )
+# 227
 
 # Update XWALK for PSI_CODE matches
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
@@ -1222,15 +1380,13 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
         XW_STP_CIP4_NAME = STP_CIP_CODE_4_NAME
       ),
     by = c(
-      "PSI_CODE" = "PSI_CODE",
-      "PRGM_LCPC_CD" = "XW_STP_PGM_CODE",
-      "PRGM_INST_PROGRAM_NAME" = "XW_STP_PGM_DESC"
+      "PSI_CODE_KEY" = "PSI_CODE_KEY",
+      "PRGM_LCPC_CD_KEY" = "PSI_PROGRAM_CODE_KEY",
+      "PRGM_INST_PROGRAM_NAME_KEY" = "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY"
     ),
-    keep = TRUE,
     relationship = "many-to-many" # no reason is provided yet
   ) %>%
   mutate(
-    PSI_CODE = PSI_CODE.x,
     PSI_PROGRAM_CODE = if_else(
       !is.na(XW_STP_PGM_CODE),
       XW_STP_PGM_CODE,
@@ -1262,19 +1418,33 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       One_To_One_Match
     )
   ) %>%
-  select(-starts_with("XW_STP"), -ends_with(".x"), -ends_with(".y"))
+  select(-starts_with("XW_STP"))
 
 #
 
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   distinct()
-# 4595
+# 4487
 
+## qry_STP_Credential_DACSO_Programs_NewMatches_b_step2 ----
 # same as above but join on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # Update XWALK for COCI_INST_CD matches (only rows not yet updated)
+
+newly_matched_2 <- stp_dacso %>%
+  filter(New_Auto_Match == "Yes") %>%
+  select(
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+    COCI_INST_CD_KEY,
+    PSI_PROGRAM_CODE_KEY,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY,
+    STP_CIP_CODE_4,
+    STP_CIP_CODE_4_NAME
+  )
+
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
-    newly_matched %>%
+    newly_matched_2 %>%
       rename(
         XW_STP_PGM_CODE = PSI_PROGRAM_CODE,
         XW_STP_PGM_DESC = PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
@@ -1282,15 +1452,13 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
         XW_STP_CIP4_NAME = STP_CIP_CODE_4_NAME
       ),
     by = c(
-      "COCI_INST_CD" = "PSI_CODE",
-      "PRGM_LCPC_CD" = "XW_STP_PGM_CODE",
-      "PRGM_INST_PROGRAM_NAME" = "XW_STP_PGM_DESC"
+      "COCI_INST_CD_KEY" = "COCI_INST_CD_KEY",
+      "PRGM_LCPC_CD_KEY" = "PSI_PROGRAM_CODE_KEY",
+      "PRGM_INST_PROGRAM_NAME_KEY" = "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY"
     ),
-    keep = TRUE,
     relationship = "many-to-many" # no reason is provided yet
   ) %>%
   mutate(
-    PSI_CODE = PSI_CODE.x,
     PSI_PROGRAM_CODE = if_else(
       is.na(New_STP_Program2021_23) & !is.na(XW_STP_PGM_CODE),
       XW_STP_PGM_CODE,
@@ -1322,16 +1490,19 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       One_To_One_Match
     )
   ) %>%
-  select(-starts_with("XW_STP"), -ends_with(".x"), -ends_with(".y"))
+  select(-starts_with("XW_STP"))
 
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   distinct()
-# 4486
+# 4487
 
 # simplify the name
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  refresh_xwalk_join_keys()
+
 xwalk <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
 rm(newly_matched)
-
+rm(newly_matched_2)
 # ******************************************************************************
 # PART 3: INSTITUTION-SPECIFIC CUSTOM MATCHING
 # ******************************************************************************
@@ -1391,45 +1562,49 @@ match_on_test_code <- function(
   match_flag,
   join_cols_desc = TRUE
 ) {
-  if (join_cols_desc) {
-    by <- c(
-      "COCI_INST_CD" = "COCI_INST_CD",
-      setNames("PRGM_LCPC_CD", test_col),
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
-    )
+  # Generate a normalized key for the institution-specific test code, then use
+  # a plain join on the generated keys. This keeps the matching rule visible in
+  # the script and avoids hidden side effects from a custom join wrapper.
+  stp_df <- stp_df %>%
+    add_join_keys(c(TEST_PROGRAM_CODE_KEY = test_col))
 
+  if (join_cols_desc) {
     stp_df <- stp_df %>%
       left_join(
         xwalk_df %>%
-          filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
+          filter(!is.na(COCI_INST_CD_KEY) & !is.na(PRGM_LCPC_CD_KEY)) %>%
           select(
-            COCI_INST_CD,
-            PRGM_LCPC_CD,
-            PRGM_INST_PROGRAM_NAME,
+            COCI_INST_CD_KEY,
+            PRGM_LCPC_CD_KEY,
+            PRGM_INST_PROGRAM_NAME_KEY,
             CIP_CODE_4,
             LCP4_CIP_4DIGITS_NAME
           ),
-        by = by
+        by = c(
+          "COCI_INST_CD_KEY",
+          "TEST_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY",
+          "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PRGM_INST_PROGRAM_NAME_KEY"
+        )
       )
   } else {
-    by <- c("COCI_INST_CD" = "COCI_INST_CD", setNames("PRGM_LCPC_CD", test_col))
-
     stp_df <- stp_df %>%
       left_join(
         xwalk_df %>%
-          filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
+          filter(!is.na(COCI_INST_CD_KEY) & !is.na(PRGM_LCPC_CD_KEY)) %>%
           select(
-            COCI_INST_CD,
-            PRGM_LCPC_CD,
-            # PRGM_INST_PROGRAM_NAME,
+            COCI_INST_CD_KEY,
+            PRGM_LCPC_CD_KEY,
             CIP_CODE_4,
             LCP4_CIP_4DIGITS_NAME
           ),
-        by = by
+        by = c(
+          "COCI_INST_CD_KEY",
+          "TEST_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY"
+        )
       )
   }
 
-  stp_df <- stp_df %>%
+  stp_df %>%
     mutate(
       New_Auto_Match = if_else(
         is.na(OUTCOMES_CIP_CODE_4) &
@@ -1450,9 +1625,8 @@ match_on_test_code <- function(
         OUTCOMES_CIP_CODE_4_NAME
       )
     ) %>%
-    select(-CIP_CODE_4, -LCP4_CIP_4DIGITS_NAME)
+    select(-CIP_CODE_4, -LCP4_CIP_4DIGITS_NAME, -TEST_PROGRAM_CODE_KEY)
 }
-
 
 ## ---- Update BCIT ----
 ## BCIT submits CPC codes to STP that include the credential abbreviation suffix (e.g. _TTDIPL, _CERTTS...)
@@ -1460,6 +1634,10 @@ match_on_test_code <- function(
 xwalk %>%
   filter(PSI_CODE == "BCIT") %>%
   pull(PRGM_LCPC_CD)
+xwalk %>%
+  filter(PSI_CODE == "BCIT") %>%
+  pull(PSI_PROGRAM_CODE)
+
 stp_unmatched %>% filter(PSI_CODE == "BCIT") %>% pull(PSI_PROGRAM_CODE)
 
 
@@ -1492,9 +1670,9 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 2739 of `y` matches multiple rows in `x`.
 
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5450
+# 5462
 
-# join STP data to XWALK on COCI_INST_CD, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD
+# join STP data to XWALK on COCI_INST_CD, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD without PSI_CREDENTIAL_PROGRAM_DESCRIPTION
 # dbGetQuery(con, qry_Update_BCIT_Programs_b)
 # BCIT: match without description (code only)
 stp_dacso <- match_on_test_code(
@@ -1506,8 +1684,9 @@ stp_dacso <- match_on_test_code(
 )
 # ℹ Row 7 of `x` matches multiple rows in `y`.
 # ℹ Row 2739 of `y` matches multiple rows in `x`
+# less constrain in join, so more duplications
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5450
+# 5462
 
 ## ---- Update CAPU ----
 # CAPU submits CPC codes to STP that are 6 digits long, but in DACSO they are generally 3 or 4 digits long
@@ -1516,6 +1695,9 @@ stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
 xwalk %>%
   filter(PSI_CODE == "CAP") %>%
   pull(PRGM_LCPC_CD)
+xwalk %>%
+  filter(PSI_CODE == "CAP") %>%
+  pull(PSI_PROGRAM_CODE)
 stp_unmatched %>% filter(PSI_CODE == "CAPU") %>% pull(PSI_PROGRAM_CODE)
 
 
@@ -1547,7 +1729,7 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 2269 of `x` matches multiple rows in `y`.
 # ℹ Row 4175 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
 
 stp_dacso <- match_on_test_code(
   stp_dacso,
@@ -1559,9 +1741,9 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 1647 of `x` matches multiple rows in `y`.
 # ℹ Row 4175 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
 
-# 4 digits
+# 4 digits, another way of matching
 # Try 4-digit prefix
 stp_dacso <- stp_dacso %>%
   mutate(
@@ -1583,7 +1765,7 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 1202 of `x` matches multiple rows in `y`.
 # ℹ Row 1684 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
 stp_dacso <- match_on_test_code(
   stp_dacso,
   xwalk,
@@ -1594,7 +1776,9 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 1200 of `x` matches multiple rows in `y`.
 # ℹ Row 1684 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
+
+# 3 digits, another way of matching
 
 # Try 3-digit prefix
 stp_dacso <- stp_dacso %>%
@@ -1616,7 +1800,7 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 1348 of `x` matches multiple rows in `y`.
 # ℹ Row 2219 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
 stp_dacso <- match_on_test_code(
   stp_dacso,
   xwalk,
@@ -1627,7 +1811,7 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 1151 of `x` matches multiple rows in `y`.
 # ℹ Row 2219 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5508
+# 5462
 
 ## ---- Update VIU ----
 # STP versions seem longer (e.g., CERT-WELDM_01) versus DACSO (e.g.,WELDM)
@@ -1671,7 +1855,8 @@ stp_dacso <- match_on_test_code(
 # ℹ Row 5389 of `x` matches multiple rows in `y`.
 # ℹ Row 936 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5513
+# 5462
+
 ## Update remaining matching ----
 
 # ---- Remaining catch-all matching ----
@@ -1681,7 +1866,7 @@ stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD
 xwalk_remaining <- xwalk %>%
   filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
-  select(COCI_INST_CD, PRGM_LCPC_CD, CIP_CODE_4, LCP4_CIP_4DIGITS_NAME)
+  select(COCI_INST_CD_KEY, PRGM_LCPC_CD_KEY, CIP_CODE_4, LCP4_CIP_4DIGITS_NAME)
 
 stp_dacso <- stp_dacso %>%
   left_join(
@@ -1690,7 +1875,7 @@ stp_dacso <- stp_dacso %>%
         XW_CIP4 = CIP_CODE_4,
         XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME
       ),
-    by = c("COCI_INST_CD", "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD"),
+    by = c("COCI_INST_CD_KEY", "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY"),
     relationship = "many-to-many" # no reason is provided yet
   ) %>%
   mutate(
@@ -1713,19 +1898,20 @@ stp_dacso <- stp_dacso %>%
       OUTCOMES_CIP_CODE_4_NAME
     )
   ) %>%
-  select(-XW_CIP4, -XW_CIP4_NAME, -ends_with(".x"), -ends_with(".y"))
+  select(-XW_CIP4, -XW_CIP4_NAME)
 
 
 # ℹ Row 841 of `x` matches multiple rows in `y`.
 # ℹ Row 1651 of `y` matches multiple rows in `x`.
 stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5513
+# 5462
+
 # Match on COCI_INST_CD + PSI_CREDENTIAL_PROGRAM_DESCRIPTION=PRGM_INST_PROGRAM_NAME
 xwalk_remaining_desc <- xwalk %>%
   filter(!is.na(COCI_INST_CD) & !is.na(PRGM_INST_PROGRAM_NAME)) %>%
   select(
-    COCI_INST_CD,
-    PRGM_INST_PROGRAM_NAME,
+    COCI_INST_CD_KEY,
+    PRGM_INST_PROGRAM_NAME_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
   )
@@ -1735,8 +1921,8 @@ stp_dacso <- stp_dacso %>%
     xwalk_remaining_desc %>%
       rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
     by = c(
-      "COCI_INST_CD",
-      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
+      "COCI_INST_CD_KEY",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PRGM_INST_PROGRAM_NAME_KEY"
     ),
     # keep = TRUE,
     relationship = "many-to-many" # no reason is provided yet
@@ -1763,6 +1949,8 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5462
 rm(xwalk_remaining, xwalk_remaining_desc)
 
 
@@ -1926,30 +2114,40 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-LCP2_DIGITS_NAME)
 
+
+# still
+# 5462
+
 # check the # of changed CIPS
 # ---- Review CIP changes ----
 # WHY: Diagnostic — shows programs where the final CIP differs from the original
 # STP CIP. Useful for catching incorrect matches.
 review_changed_cips <- stp_dacso %>%
   filter(FINAL_CIP_CODE_4 != STP_CIP_CODE_4)
-# 232
+# 193
 # ---- Write final output tables ----
+# Drop helper *_KEY columns before writing final outputs.
+stp_dacso_out <- drop_join_keys(stp_dacso)
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_out <- drop_join_keys(
+  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
+)
+
 dbWriteTable(
   con,
   "STP_Credential_Non_Dup_Programs_DACSO_r",
-  stp_dacso,
+  stp_dacso_out,
   overwrite = TRUE
 )
 dbWriteTable(
   con,
   "Credential_Non_Dup_Programs_DACSO_FinalCIPS_r",
-  stp_dacso,
+  stp_dacso_out,
   overwrite = TRUE
 )
 dbWriteTable(
   con,
   "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_r",
-  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_out,
   overwrite = TRUE
 )
 

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -12,7 +12,7 @@
 
 # ******************************************************************************
 # Aligns CIP codes between DACSO and STP data
-# 
+#
 # Required Tables
 #   DACSO_STP_ProgramsCIP4_XWALK_ALL_20XX (previous PSSM XWALK)
 #   INFOWARE_PROGRAMS
@@ -28,7 +28,7 @@
 #
 # STEPS:
 # Setup: import and save required tables
-# 
+#
 # Part 1: Add DACSO programs to XWALK
 # Part 2: Add STP programs to XWALK
 # Part 3: Manual/custom STP to XWALK matching
@@ -45,239 +45,493 @@ library(RJDBC) ## loads DBI
 
 # Setup ----
 
+lan <- config::get("lan")
+sch_tbl <- function(name) {
+  tbl(con, dbplyr::in_schema(my_schema, name))
+}
+
+
 ## ---- Read in INFOWARE tables ----
+# iw_config <- config::get("infoware")
+# jdbc_config <- config::get("jdbc")
+
+# jdbcDriver <- JDBC(jdbc_config$class, classPath = jdbc_config$path)
+
+# iw_con <- dbConnect(
+#   jdbcDriver,
+#   iw_config$database,
+#   iw_config$uid,
+#   iw_config$pwd
+# )
+# new way to load data from infoware
 iw_config <- config::get("infoware")
-jdbc_config <- config::get("jdbc")
 
-jdbcDriver <- JDBC(jdbc_config$class,
-                   classPath=jdbc_config$path)
+# odbcListDrivers()
 
-iw_con <- dbConnect(jdbcDriver, 
-                    iw_config$database,
-                    iw_config$uid,
-                    iw_config$pwd)
+iw_con <- dbConnect(
+  odbc::odbc(),
+  Driver = "Oracle in instantclient_19_30",
+  DBQ = "DEV01.world",
+  UID = iw_config$uid,
+  PWD = iw_config$pwd
+)
+# all the comment-outed data steps are only running for once.
+# now infoware has INFOWARE.L_CIP_6DIGITS_CIP2021 table. We may need to update soon.
 
-INFOWARE_PROGRAMS <- dbReadTable(iw_con, "INFOWARE.PROGRAMS")
-INFOWARE_L_CIP_6DIGITS_CIP2016 <- dbReadTable(iw_con, "INFOWARE.L_CIP_6DIGITS_CIP2016")
-INFOWARE_L_CIP_4DIGITS_CIP2016 <- dbReadTable(iw_con, "INFOWARE.L_CIP_4DIGITS_CIP2016")
-INFOWARE_L_CIP_2DIGITS_CIP2016 <- dbReadTable(iw_con, "INFOWARE.L_CIP_2DIGITS_CIP2016")
-INFOWARE_PROGRAMS_HIST_PRGMID_XREF <- dbReadTable(iw_con, "INFOWARE.PROGRAMS_HIST_PRGMID_XREF")
+# INFOWARE_PROGRAMS <- dbReadTable(iw_con, DBI::SQL("INFOWARE.PROGRAMS"))
+# INFOWARE_PROGRAMS_2016 <- dbReadTable(iw_con, DBI::SQL("INFOWARE.PROGRAMS_BKUP_NOV_2024_CIP2016_CIP2021"))
+# INFOWARE_L_CIP_6DIGITS_CIP2016 <- dbReadTable(
+#   iw_con,
+#   DBI::SQL("INFOWARE.L_CIP_6DIGITS_CIP2016")
+# )
+# INFOWARE_L_CIP_4DIGITS_CIP2016 <- dbReadTable(
+#   iw_con,
+#   DBI::SQL("INFOWARE.L_CIP_4DIGITS_CIP2016")
+# )
+# INFOWARE_L_CIP_2DIGITS_CIP2016 <- dbReadTable(
+#   iw_con,
+#   DBI::SQL("INFOWARE.L_CIP_2DIGITS_CIP2016")
+# )
+# INFOWARE_PROGRAMS_HIST_PRGMID_XREF <- dbReadTable(
+#   iw_con,
+#   DBI::SQL("INFOWARE.PROGRAMS_HIST_PRGMID_XREF")
+# )
 
-dbDisconnect(iw_con)
+# dbDisconnect(iw_con)
 
-## ---- Read in last years XWALK ----
-## connect to outcomes (access) database
-connection <- config::get("connection")$outcomes_dacso
-acc_con <- odbcDriverConnect(connection)
+# ## ---- Read in last years XWALK ----
+# ## connect to outcomes (access) database
+# # not working now
+# connection <- config::get("connection")$outcomes_dacso
+# acc_con <- odbcDriverConnect(connection)
 
-DACSO_STP_ProgramsCIP4_XWALK_ALL_2020 <- sqlQuery(acc_con, "SELECT * FROM DACSO_STP_ProgramsCIP4_XWALK_ALL_2020;")
+# DACSO_STP_ProgramsCIP4_XWALK_ALL_2020 <- sqlQuery(
+#   acc_con,
+#   "SELECT * FROM DACSO_STP_ProgramsCIP4_XWALK_ALL_2020;"
+# )
 
-odbcClose(acc_con)
+# odbcClose(acc_con)
 
-## ---- Connect to Decimal ----
-config <- config::get("decimal")
-con <- dbConnect(odbc(),
-                     Driver = config$driver,
-                     Server = config$server,
-                     Database = config$database,
-                     Trusted_Connection = "True")
-my_schema <- config::get("myschema")
+# ## ---- Connect to Decimal ----
+# config <- config::get("decimal")
+# con <- dbConnect(
+#   odbc(),
+#   Driver = config$driver,
+#   Server = config$server,
+#   Database = config$database,
+#   Trusted_Connection = "True"
+# )
+# my_schema <- config::get("myschema")
 
-## ---- Write initial tables to Decimal ----
-## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."DACSO_STP_ProgramsCIP4_XWALK_ALL_2020"')), DACSO_STP_ProgramsCIP4_XWALK_ALL_2020)
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS"')), INFOWARE_PROGRAMS)
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_6DIGITS_CIP2016"')), INFOWARE_L_CIP_6DIGITS_CIP2016)
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_4DIGITS_CIP2016"')), INFOWARE_L_CIP_4DIGITS_CIP2016)
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_2DIGITS_CIP2016"')), INFOWARE_L_CIP_2DIGITS_CIP2016)
-dbWriteTable(con, SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS_HIST_PRGMID_XREF"')), INFOWARE_PROGRAMS_HIST_PRGMID_XREF)
+# ## ---- Write initial tables to Decimal ----
+# ## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
+# # this one is missing
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."DACSO_STP_ProgramsCIP4_XWALK_ALL_2020"')),
+#   DACSO_STP_ProgramsCIP4_XWALK_ALL_2020
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS"')),
+#   INFOWARE_PROGRAMS
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS_2016"')),
+#   INFOWARE_PROGRAMS_2016
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_6DIGITS_CIP2016"')),
+#   INFOWARE_L_CIP_6DIGITS_CIP2016
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_4DIGITS_CIP2016"')),
+#   INFOWARE_L_CIP_4DIGITS_CIP2016
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_2DIGITS_CIP2016"')),
+#   INFOWARE_L_CIP_2DIGITS_CIP2016
+# )
+# dbWriteTable(
+#   con,
+#   SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS_HIST_PRGMID_XREF"')),
+#   INFOWARE_PROGRAMS_HIST_PRGMID_XREF
+# )
 
-## remove tables and use decimal versions for remainder of code
-rm(DACSO_STP_ProgramsCIP4_XWALK_ALL_2020, INFOWARE_PROGRAMS, INFOWARE_L_CIP_6DIGITS_CIP2016, 
-   INFOWARE_L_CIP_4DIGITS_CIP2016, INFOWARE_L_CIP_2DIGITS_CIP2016, INFOWARE_PROGRAMS_HIST_PRGMID_XREF )
+# ## remove tables and use decimal versions for remainder of code
+# rm(
+#   DACSO_STP_ProgramsCIP4_XWALK_ALL_2020,
+#   INFOWARE_PROGRAMS,
+#   INFOWARE_L_CIP_6DIGITS_CIP2016,
+#   INFOWARE_L_CIP_4DIGITS_CIP2016,
+#   INFOWARE_L_CIP_2DIGITS_CIP2016,
+#   INFOWARE_PROGRAMS_HIST_PRGMID_XREF
+# )
 
 # Part 1 ----
 
 ## ---- Create programs_table from combining INFOWARE tables ----
 ## define programs_table from which to grab new programs (with and without historical linkages)
-programs_table <- tbl(con, "INFOWARE_PROGRAMS") %>%
-  inner_join(tbl(con, "INFOWARE_L_CIP_6DIGITS_CIP2016"), by = c("LCIP_CD_CIP2016" = "LCIP_CD")) %>%
-  inner_join(tbl(con, "INFOWARE_L_CIP_4DIGITS_CIP2016"), by = c("LCIP_LCP4_CD" = "LCP4_CD")) %>%
-  select(PRGM_ID, PRGM_FIRST_SEEN_SUBM_CD, PRGM_INST_CD, PRGM_INST_PROGRAM_NAME,
-         PRGM_INST_PROGRAM_NAME_CLEANED,
-         PRGM_LCPC_CD, PRGM_TTRAIN_FLAG, LCIP_CD_CIP2016, LCIP_NAME_CIP2016,
-         PRGM_CREDENTIAL, NOTES, HAS_HISTORICAL_PRGM_ID_LINK,
-         CIP_CLUSTER_ARTS_APPLIED, DACSO_OLD_PRGM_ID_DO_NOT_USE, DUP_PROGRAM_USE_THIS_PRGM_ID,
-         LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME) %>%
+# INFOWARE_PROGRAMS does not have LCIP_CD_CIP2016 anymore, instead, it has LCIP_CD_CIP2021
+# so we use the backup version of the PROGRAMS table which has the LCIP_CD_CIP2016 column
+programs_table <- tbl(con, "INFOWARE_PROGRAMS_2016") %>%
+  inner_join(
+    tbl(con, "INFOWARE_L_CIP_6DIGITS_CIP2016"),
+    by = c("LCIP_CD_CIP2016" = "LCIP_CD")
+  ) %>%
+  inner_join(
+    tbl(con, "INFOWARE_L_CIP_4DIGITS_CIP2016"),
+    by = c("LCIP_LCP4_CD" = "LCP4_CD")
+  ) %>%
+  select(
+    PRGM_ID,
+    PRGM_FIRST_SEEN_SUBM_CD,
+    PRGM_INST_CD,
+    PRGM_INST_PROGRAM_NAME,
+    PRGM_INST_PROGRAM_NAME_CLEANED,
+    PRGM_LCPC_CD,
+    PRGM_TTRAIN_FLAG,
+    LCIP_CD_CIP2016,
+    LCIP_NAME_CIP2016,
+    PRGM_CREDENTIAL,
+    NOTES,
+    HAS_HISTORICAL_PRGM_ID_LINK,
+    CIP_CLUSTER_ARTS_APPLIED,
+    DACSO_OLD_PRGM_ID_DO_NOT_USE,
+    DUP_PROGRAM_USE_THIS_PRGM_ID,
+    LCIP_LCP4_CD,
+    LCP4_CIP_4DIGITS_NAME
+  ) %>%
   collect()
 
 ## ---- Make new XWALK from last years XWALK ----
-DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- tbl(con, "DACSO_STP_ProgramsCIP4_XWALK_ALL_2020") %>%
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- tbl(
+  con,
+  "DACSO_STP_ProgramsCIP4_XWALK_ALL_2020"
+) %>%
   collect() %>%
   mutate(CIP_CODE_4 = str_pad(CIP_CODE_4, width = 4, side = "left", pad = "0"))
 
 ## ---- Add to XWALK: New DACSO prgms WITHOUT historical linkages ----
 ## review the HAS_HISTORICAL_PRGM_ID_LINK values
 programs_table %>%
-  filter(PRGM_FIRST_SEEN_SUBM_CD %in% c('C_Outc21','C_Outc22','C_Outc23')) %>% 
-  group_by(PRGM_FIRST_SEEN_SUBM_CD,HAS_HISTORICAL_PRGM_ID_LINK) %>% tally()
+  filter(PRGM_FIRST_SEEN_SUBM_CD %in% c('C_Outc21', 'C_Outc22', 'C_Outc23')) %>%
+  group_by(PRGM_FIRST_SEEN_SUBM_CD, HAS_HISTORICAL_PRGM_ID_LINK) %>%
+  tally()
 
 new_dacso_programs_21_23 <- programs_table %>%
-  filter(PRGM_FIRST_SEEN_SUBM_CD %in% c('C_Outc21','C_Outc22','C_Outc23') & (is.na(HAS_HISTORICAL_PRGM_ID_LINK) | HAS_HISTORICAL_PRGM_ID_LINK==" "))
+  filter(
+    PRGM_FIRST_SEEN_SUBM_CD %in%
+      c('C_Outc21', 'C_Outc22', 'C_Outc23') &
+      (is.na(HAS_HISTORICAL_PRGM_ID_LINK) | HAS_HISTORICAL_PRGM_ID_LINK == " ")
+  )
 new_dacso_programs_21_23 %>% count(PRGM_FIRST_SEEN_SUBM_CD)
 
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   bind_rows(
     programs_table %>%
-      filter(PRGM_FIRST_SEEN_SUBM_CD %in% c('C_Outc21','C_Outc22','C_Outc23') & (is.na(HAS_HISTORICAL_PRGM_ID_LINK) | HAS_HISTORICAL_PRGM_ID_LINK==" ")) %>%
-      mutate(New_DACSO_Program2021_23 = case_when(PRGM_FIRST_SEEN_SUBM_CD == "C_Outc21" ~ "Yes2021",
-                                                   PRGM_FIRST_SEEN_SUBM_CD == "C_Outc22" ~ "Yes2022",
-                                                   PRGM_FIRST_SEEN_SUBM_CD == "C_Outc23"~ "Yes2023")) %>%
-      select(COCI_INST_CD = PRGM_INST_CD,
-             PRGM_LCPC_CD,
-             PRGM_INST_PROGRAM_NAME,
-             CIP_CODE_4 = LCIP_LCP4_CD,
-             LCP4_CIP_4DIGITS_NAME,
-             PRGM_ID,
-             PRGM_CREDENTIAL,
-             New_DACSO_Program2021_23))
+      filter(
+        PRGM_FIRST_SEEN_SUBM_CD %in%
+          c('C_Outc21', 'C_Outc22', 'C_Outc23') &
+          (is.na(HAS_HISTORICAL_PRGM_ID_LINK) |
+            HAS_HISTORICAL_PRGM_ID_LINK == " ")
+      ) %>%
+      mutate(
+        New_DACSO_Program2021_23 = case_when(
+          PRGM_FIRST_SEEN_SUBM_CD == "C_Outc21" ~ "Yes2021",
+          PRGM_FIRST_SEEN_SUBM_CD == "C_Outc22" ~ "Yes2022",
+          PRGM_FIRST_SEEN_SUBM_CD == "C_Outc23" ~ "Yes2023"
+        )
+      ) %>%
+      select(
+        COCI_INST_CD = PRGM_INST_CD,
+        PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME,
+        CIP_CODE_4 = LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        PRGM_ID,
+        PRGM_CREDENTIAL,
+        New_DACSO_Program2021_23
+      )
+  )
 
 # The following steps are repeated for each year since last PSSM:
 ##  Find DACSO prgms WITH historical linkages
-##  Get historical linkages for DACSO prgms 
+##  Get historical linkages for DACSO prgms
 ##  Update to XWALK: Updated DACSO programs WITH historical linkages
 ##  Find Remaining updated DACSO missing from XWALK for match to STP program
 
 ## ---- 2021 Find DACSO prgms WITH historical linkages ----
 Updated_DACSO_Programs_in_2021_with_links <- programs_table %>%
-  filter(PRGM_FIRST_SEEN_SUBM_CD =='C_Outc21' & HAS_HISTORICAL_PRGM_ID_LINK =='Y') %>%
-  inner_join(tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
-               filter(YEAR_LINK_CREATED =='C_Outc21' & SURVEY_CODE=='DACSO') %>%
-               collect(), 
-             by = "PRGM_ID") %>%
-  select(PRGM_ID, PRGM_FIRST_SEEN_SUBM_CD, PRGM_INST_CD, PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, 
-         PRGM_TTRAIN_FLAG, PRGM_CREDENTIAL, PRGM_INST_PROGRAM_NAME_CLEANED, NOTES, 
-         HAS_HISTORICAL_PRGM_ID_LINK, DUP_PROGRAM_USE_THIS_PRGM_ID, CIP_CLUSTER_ARTS_APPLIED, 
-         DACSO_OLD_PRGM_ID_DO_NOT_USE, LCIP_CD_CIP2016, LCIP_NAME_CIP2016, LCIP_LCP4_CD, 
-         LCP4_CIP_4DIGITS_NAME, HISTORICAL_PRGM_ID, YEAR_LINK_CREATED, SURVEY_CODE)
+  filter(
+    PRGM_FIRST_SEEN_SUBM_CD == 'C_Outc21' & HAS_HISTORICAL_PRGM_ID_LINK == 'Y'
+  ) %>%
+  inner_join(
+    tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
+      filter(YEAR_LINK_CREATED == 'C_Outc21' & SURVEY_CODE == 'DACSO') %>%
+      collect(),
+    by = "PRGM_ID"
+  ) %>%
+  select(
+    PRGM_ID,
+    PRGM_FIRST_SEEN_SUBM_CD,
+    PRGM_INST_CD,
+    PRGM_LCPC_CD,
+    PRGM_INST_PROGRAM_NAME,
+    PRGM_TTRAIN_FLAG,
+    PRGM_CREDENTIAL,
+    PRGM_INST_PROGRAM_NAME_CLEANED,
+    NOTES,
+    HAS_HISTORICAL_PRGM_ID_LINK,
+    DUP_PROGRAM_USE_THIS_PRGM_ID,
+    CIP_CLUSTER_ARTS_APPLIED,
+    DACSO_OLD_PRGM_ID_DO_NOT_USE,
+    LCIP_CD_CIP2016,
+    LCIP_NAME_CIP2016,
+    LCIP_LCP4_CD,
+    LCP4_CIP_4DIGITS_NAME,
+    HISTORICAL_PRGM_ID,
+    YEAR_LINK_CREATED,
+    SURVEY_CODE
+  )
 
 ## ---- 2021 Get historical linkages for DACSO prgms ----
-## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF 
+## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF
 ## to link back to the programs table to fill in the historical program details
 Updated_DACSO_Programs_in_2021_with_links <- Updated_DACSO_Programs_in_2021_with_links %>%
   inner_join(
     programs_table %>%
-      select(PRGM_ID, HISTORICAL_CPC_CD = PRGM_LCPC_CD, 
-             HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME, 
-             HISTORICAL_CIP4_CD = LCIP_LCP4_CD),
+      select(
+        PRGM_ID,
+        HISTORICAL_CPC_CD = PRGM_LCPC_CD,
+        HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD = LCIP_LCP4_CD
+      ),
     by = c(HISTORICAL_PRGM_ID = "PRGM_ID")
   ) %>%
-   mutate(Updated_CPC_Flag = case_when(PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes', 
-                                       TRUE ~ NA),
-         Updated_CIP_Flag = case_when(LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes', 
-                                      TRUE ~ NA))
+  mutate(
+    Updated_CPC_Flag = case_when(
+      PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes',
+      TRUE ~ NA
+    ),
+    Updated_CIP_Flag = case_when(
+      LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes',
+      TRUE ~ NA
+    )
+  )
 
 ## ---- 2021 Update to XWALK: Updated DACSO programs WITH historical linkages ----
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2021_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
-      select(PRGM_INST_CD, HISTORICAL_CPC_CD, HISTORICAL_PROGRAM_NAME, HISTORICAL_CIP4_CD,
-             PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME,
-             Updated_DACSO_CPC2021 = Updated_CPC_Flag, Updated_DACSO_CIP2021 = Updated_CIP_Flag),
-    by = c(COCI_INST_CD = "PRGM_INST_CD", PRGM_LCPC_CD = "HISTORICAL_CPC_CD", 
-           PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME", CIP_CODE_4 = "HISTORICAL_CIP4_CD")) %>%
-  mutate(PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = ifelse(!is.na(PRGM_INST_PROGRAM_NAME.y), PRGM_INST_PROGRAM_NAME.y, PRGM_INST_PROGRAM_NAME),
-         CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)) %>%
-  mutate(LCP4_CIP_4DIGITS_NAME = ifelse(!is.na(LCP4_CIP_4DIGITS_NAME.y), LCP4_CIP_4DIGITS_NAME.y, LCP4_CIP_4DIGITS_NAME.x), .after = "CIP_CODE_4") %>%
+      select(
+        PRGM_INST_CD,
+        HISTORICAL_CPC_CD,
+        HISTORICAL_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD,
+        PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME,
+        LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        Updated_DACSO_CPC2021 = Updated_CPC_Flag,
+        Updated_DACSO_CIP2021 = Updated_CIP_Flag
+      ),
+    by = c(
+      COCI_INST_CD = "PRGM_INST_CD",
+      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
+      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
+      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+    )
+  ) %>%
+  mutate(
+    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_INST_PROGRAM_NAME = ifelse(
+      !is.na(PRGM_INST_PROGRAM_NAME.y),
+      PRGM_INST_PROGRAM_NAME.y,
+      PRGM_INST_PROGRAM_NAME
+    ),
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
+  ) %>%
+  mutate(
+    LCP4_CIP_4DIGITS_NAME = ifelse(
+      !is.na(LCP4_CIP_4DIGITS_NAME.y),
+      LCP4_CIP_4DIGITS_NAME.y,
+      LCP4_CIP_4DIGITS_NAME.x
+    ),
+    .after = "CIP_CODE_4"
+  ) %>%
   select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
 
 ## ---- 2021 Find Remaining updated DACSO missing from XWALK for match to STP program ----
 Remaining_DACSO_Updates_CPCS_2021 <- Updated_DACSO_Programs_in_2021_with_links %>%
-  anti_join(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-            by = c(PRGM_LCPC_CD = "PRGM_LCPC_CD", PRGM_INST_CD = "COCI_INST_CD",
-                   PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"))
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+    by = c(
+      PRGM_LCPC_CD = "PRGM_LCPC_CD",
+      PRGM_INST_CD = "COCI_INST_CD",
+      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+    )
+  )
 
 # ***** manual work needed *****
 # review infoware notes
-programs_table %>% filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2021$PRGM_ID) %>% pull(PRGM_ID,NOTES)
+programs_table %>%
+  filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2021$PRGM_ID) %>%
+  pull(PRGM_ID, NOTES)
 
 # PRGM_ID 10132 links to 3119
 programs_table %>% filter(PRGM_ID == "3119") %>% pull(NOTES)
 
 # update based on review
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  mutate(CIP_CODE_4 = case_when(PRGM_ID == 3119 ~ "1907", 
-                                TRUE ~ CIP_CODE_4),
-         LCP4_CIP_4DIGITS_NAME = case_when(PRGM_ID == 3119 ~ "Human development, family studies and related services", 
-                                           TRUE ~ LCP4_CIP_4DIGITS_NAME),
-         Updated_DACSO_CIP2021 = case_when(PRGM_ID == 3119 ~ "Yes", 
-                                           TRUE ~ Updated_DACSO_CIP2021),
-         PRGM_LCPC_CD = case_when(PRGM_ID == 3119 ~ "EACSW", 
-                                TRUE ~ PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = case_when(PRGM_ID == 3119 ~ "Education Assistant and Community Support Worker", 
-                                           TRUE ~ PRGM_INST_PROGRAM_NAME),
-         Updated_DACSO_CPC2021 = case_when(PRGM_ID == 3119 ~ "Yes", 
-                                           TRUE ~ Updated_DACSO_CPC2021))
+  mutate(
+    CIP_CODE_4 = case_when(PRGM_ID == 3119 ~ "1907", TRUE ~ CIP_CODE_4), # ? how can we know why 1907
+    LCP4_CIP_4DIGITS_NAME = case_when(
+      PRGM_ID ==
+        3119 ~ "Human development, family studies and related services",
+      TRUE ~ LCP4_CIP_4DIGITS_NAME
+    ),
+    Updated_DACSO_CIP2021 = case_when(
+      PRGM_ID == 3119 ~ "Yes",
+      TRUE ~ Updated_DACSO_CIP2021
+    ),
+    PRGM_LCPC_CD = case_when(PRGM_ID == 3119 ~ "EACSW", TRUE ~ PRGM_LCPC_CD),
+    PRGM_INST_PROGRAM_NAME = case_when(
+      PRGM_ID == 3119 ~ "Education Assistant and Community Support Worker",
+      TRUE ~ PRGM_INST_PROGRAM_NAME
+    ),
+    Updated_DACSO_CPC2021 = case_when(
+      PRGM_ID == 3119 ~ "Yes",
+      TRUE ~ Updated_DACSO_CPC2021
+    )
+  )
 
 ## ---- 2022 Find DACSO prgms WITH historical linkages ----
 Updated_DACSO_Programs_in_2022_with_links <- programs_table %>%
-  filter(PRGM_FIRST_SEEN_SUBM_CD =='C_Outc22' & HAS_HISTORICAL_PRGM_ID_LINK =='Y') %>%
-  inner_join(tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
-               filter(YEAR_LINK_CREATED =='C_Outc22' & SURVEY_CODE=='DACSO') %>%
-               collect(), 
-             by = "PRGM_ID") %>%
-  select(PRGM_ID, PRGM_FIRST_SEEN_SUBM_CD, PRGM_INST_CD, PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, 
-         PRGM_TTRAIN_FLAG, PRGM_CREDENTIAL, PRGM_INST_PROGRAM_NAME_CLEANED, NOTES, 
-         HAS_HISTORICAL_PRGM_ID_LINK, DUP_PROGRAM_USE_THIS_PRGM_ID, CIP_CLUSTER_ARTS_APPLIED, 
-         DACSO_OLD_PRGM_ID_DO_NOT_USE, LCIP_CD_CIP2016, LCIP_NAME_CIP2016, LCIP_LCP4_CD, 
-         LCP4_CIP_4DIGITS_NAME, HISTORICAL_PRGM_ID, YEAR_LINK_CREATED, SURVEY_CODE)
+  filter(
+    PRGM_FIRST_SEEN_SUBM_CD == 'C_Outc22' & HAS_HISTORICAL_PRGM_ID_LINK == 'Y'
+  ) %>%
+  inner_join(
+    tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
+      filter(YEAR_LINK_CREATED == 'C_Outc22' & SURVEY_CODE == 'DACSO') %>%
+      collect(),
+    by = "PRGM_ID"
+  ) %>%
+  select(
+    PRGM_ID,
+    PRGM_FIRST_SEEN_SUBM_CD,
+    PRGM_INST_CD,
+    PRGM_LCPC_CD,
+    PRGM_INST_PROGRAM_NAME,
+    PRGM_TTRAIN_FLAG,
+    PRGM_CREDENTIAL,
+    PRGM_INST_PROGRAM_NAME_CLEANED,
+    NOTES,
+    HAS_HISTORICAL_PRGM_ID_LINK,
+    DUP_PROGRAM_USE_THIS_PRGM_ID,
+    CIP_CLUSTER_ARTS_APPLIED,
+    DACSO_OLD_PRGM_ID_DO_NOT_USE,
+    LCIP_CD_CIP2016,
+    LCIP_NAME_CIP2016,
+    LCIP_LCP4_CD,
+    LCP4_CIP_4DIGITS_NAME,
+    HISTORICAL_PRGM_ID,
+    YEAR_LINK_CREATED,
+    SURVEY_CODE
+  )
 
 
 ## ---- 2022 Get historical linkages for DACSO prgms ----
-## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF 
+## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF
 ## to link back to the programs table to fill in the historical program details
 Updated_DACSO_Programs_in_2022_with_links <- Updated_DACSO_Programs_in_2022_with_links %>%
   inner_join(
     programs_table %>%
-      select(PRGM_ID, HISTORICAL_CPC_CD = PRGM_LCPC_CD, 
-             HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME, 
-             HISTORICAL_CIP4_CD = LCIP_LCP4_CD),
+      select(
+        PRGM_ID,
+        HISTORICAL_CPC_CD = PRGM_LCPC_CD,
+        HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD = LCIP_LCP4_CD
+      ),
     by = c(HISTORICAL_PRGM_ID = "PRGM_ID")
   ) %>%
-  mutate(Updated_CPC_Flag = case_when(PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes', 
-                                      TRUE ~ NA),
-         Updated_CIP_Flag = case_when(LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes', 
-                                      TRUE ~ NA))
+  mutate(
+    Updated_CPC_Flag = case_when(
+      PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes',
+      TRUE ~ NA
+    ),
+    Updated_CIP_Flag = case_when(
+      LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes',
+      TRUE ~ NA
+    )
+  )
 
 ## ---- 2022 Update to XWALK: Updated DACSO programs WITH historical linkages ----
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2022_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
-      select(PRGM_INST_CD, HISTORICAL_CPC_CD, HISTORICAL_PROGRAM_NAME, HISTORICAL_CIP4_CD,
-             PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME,
-             Updated_DACSO_CPC2022 = Updated_CPC_Flag, Updated_DACSO_CIP2022 = Updated_CIP_Flag),
-    by = c(COCI_INST_CD = "PRGM_INST_CD", PRGM_LCPC_CD = "HISTORICAL_CPC_CD", 
-           PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME", CIP_CODE_4 = "HISTORICAL_CIP4_CD")) %>%
-  mutate(PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = ifelse(!is.na(PRGM_INST_PROGRAM_NAME.y), PRGM_INST_PROGRAM_NAME.y, PRGM_INST_PROGRAM_NAME),
-         CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)) %>%
-  mutate(LCP4_CIP_4DIGITS_NAME = ifelse(!is.na(LCP4_CIP_4DIGITS_NAME.y), LCP4_CIP_4DIGITS_NAME.y, LCP4_CIP_4DIGITS_NAME.x), .after = "CIP_CODE_4") %>%
+      select(
+        PRGM_INST_CD,
+        HISTORICAL_CPC_CD,
+        HISTORICAL_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD,
+        PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME,
+        LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        Updated_DACSO_CPC2022 = Updated_CPC_Flag,
+        Updated_DACSO_CIP2022 = Updated_CIP_Flag
+      ),
+    by = c(
+      COCI_INST_CD = "PRGM_INST_CD",
+      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
+      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
+      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+    )
+  ) %>%
+  mutate(
+    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_INST_PROGRAM_NAME = ifelse(
+      !is.na(PRGM_INST_PROGRAM_NAME.y),
+      PRGM_INST_PROGRAM_NAME.y,
+      PRGM_INST_PROGRAM_NAME
+    ),
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
+  ) %>%
+  mutate(
+    LCP4_CIP_4DIGITS_NAME = ifelse(
+      !is.na(LCP4_CIP_4DIGITS_NAME.y),
+      LCP4_CIP_4DIGITS_NAME.y,
+      LCP4_CIP_4DIGITS_NAME.x
+    ),
+    .after = "CIP_CODE_4"
+  ) %>%
   select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
 
 ## ---- 2022 Find Remaining updated DACSO missing from XWALK for match to STP program ----
 Remaining_DACSO_Updates_CPCS_2022 <- Updated_DACSO_Programs_in_2022_with_links %>%
-  anti_join(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-            by = c(PRGM_LCPC_CD = "PRGM_LCPC_CD", PRGM_INST_CD = "COCI_INST_CD",
-                   PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"))
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+    by = c(
+      PRGM_LCPC_CD = "PRGM_LCPC_CD",
+      PRGM_INST_CD = "COCI_INST_CD",
+      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+    )
+  )
 
 # ***** manual work needed *****
 # review infoware notes
-programs_table %>% filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2022$PRGM_ID) %>% pull(PRGM_ID,NOTES)
+programs_table %>%
+  filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2022$PRGM_ID) %>%
+  pull(PRGM_ID, NOTES)
 # 7 PRGM_IDs remaining CPCs had historical links for their historical links
-##  i.e., they could be linked to more codes back 
+##  i.e., they could be linked to more codes back
 # review notes for each historical, to find the last historical link:
 # 10355 -> 9855 -> 115 (update CIP and CPC to most recent)
 # 10359 -> 9856 -> 9006 -> 4760 (4760 doesn't exist in XWALK, update 9006 - CPC & CIP)
@@ -289,99 +543,181 @@ programs_table %>% filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2022$PRGM_ID
 
 # apply necessary updates
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  mutate(CIP_CODE_4 = case_when(PRGM_ID == 115 ~ "1502",
-                                PRGM_ID == 9006 ~ "1110",
-                                PRGM_ID == 131 ~ "5001",
-                                TRUE ~ CIP_CODE_4),
-         LCP4_CIP_4DIGITS_NAME = case_when(PRGM_ID == 115 ~ "Civil engineering technology/technician", 
-                                           PRGM_ID == 9006 ~ "Computer/information technology administration and management",
-                                           PRGM_ID == 131 ~ "Visual, digital and performing arts, general", 
-                                           TRUE ~ LCP4_CIP_4DIGITS_NAME),
-         Updated_DACSO_CIP2022 = case_when(PRGM_ID == 115 ~ "Yes", 
-                                           PRGM_ID == 9006 ~ "Yes",
-                                           PRGM_ID == 131 ~ "Yes",
-                                           TRUE ~ Updated_DACSO_CIP2022),
-         PRGM_LCPC_CD = case_when(PRGM_ID == 115 ~ "CENG.DIP",
-                                  PRGM_ID == 9006 ~ "CNET.CERT",
-                                  PRGM_ID == 5952 ~ "ECENG.RE.DIP",
-                                  PRGM_ID == 9008 ~ "ECENG.UVIC.ADIP",
-                                  PRGM_ID == 4960 ~ "ICS.DIP",
-                                  PRGM_ID == 117 ~ "MENG.DIP",
-                                  PRGM_ID == 131 ~ "VART.DIP",
-                                  TRUE ~ PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = case_when(PRGM_ID == 115 ~ "Civil Engineering Technology (Diploma)",
-                                            PRGM_ID == 9006 ~ "Computer Network Electronics Support Tech (Certificate)",
-                                            PRGM_ID == 5952 ~ "Electronics & Computer Eng - Renewable Energy (Diploma)",
-                                            PRGM_ID == 9008 ~ "Electrical & Computer Eng - Bridge to UVic (Adv Diploma)",
-                                            PRGM_ID == 4960 ~ "Information & Computer Systems Technology (Diploma)",
-                                            PRGM_ID == 117 ~ "Mechanical Engineering Technology (Diploma)",
-                                            PRGM_ID == 131 ~ "Visual Arts (Diploma)",
-                                            TRUE ~ PRGM_INST_PROGRAM_NAME),
-         Updated_DACSO_CPC2022 = case_when(PRGM_ID == 115 ~ "Yes",
-                                           PRGM_ID == 9006 ~ "Yes",
-                                           PRGM_ID == 5952 ~ "Yes",
-                                           PRGM_ID == 9008 ~ "Yes",
-                                           PRGM_ID == 4960 ~ "Yes",
-                                           PRGM_ID == 117 ~ "Yes",
-                                           PRGM_ID == 131 ~ "Yes",
-                                           TRUE ~ Updated_DACSO_CPC2022))
+  mutate(
+    CIP_CODE_4 = case_when(
+      PRGM_ID == 115 ~ "1502",
+      PRGM_ID == 9006 ~ "1110",
+      PRGM_ID == 131 ~ "5001",
+      TRUE ~ CIP_CODE_4
+    ),
+    LCP4_CIP_4DIGITS_NAME = case_when(
+      PRGM_ID == 115 ~ "Civil engineering technology/technician",
+      PRGM_ID ==
+        9006 ~ "Computer/information technology administration and management",
+      PRGM_ID == 131 ~ "Visual, digital and performing arts, general",
+      TRUE ~ LCP4_CIP_4DIGITS_NAME
+    ),
+    Updated_DACSO_CIP2022 = case_when(
+      PRGM_ID == 115 ~ "Yes",
+      PRGM_ID == 9006 ~ "Yes",
+      PRGM_ID == 131 ~ "Yes",
+      TRUE ~ Updated_DACSO_CIP2022
+    ),
+    PRGM_LCPC_CD = case_when(
+      PRGM_ID == 115 ~ "CENG.DIP",
+      PRGM_ID == 9006 ~ "CNET.CERT",
+      PRGM_ID == 5952 ~ "ECENG.RE.DIP",
+      PRGM_ID == 9008 ~ "ECENG.UVIC.ADIP",
+      PRGM_ID == 4960 ~ "ICS.DIP",
+      PRGM_ID == 117 ~ "MENG.DIP",
+      PRGM_ID == 131 ~ "VART.DIP",
+      TRUE ~ PRGM_LCPC_CD
+    ),
+    PRGM_INST_PROGRAM_NAME = case_when(
+      PRGM_ID == 115 ~ "Civil Engineering Technology (Diploma)",
+      PRGM_ID ==
+        9006 ~ "Computer Network Electronics Support Tech (Certificate)",
+      PRGM_ID ==
+        5952 ~ "Electronics & Computer Eng - Renewable Energy (Diploma)",
+      PRGM_ID ==
+        9008 ~ "Electrical & Computer Eng - Bridge to UVic (Adv Diploma)",
+      PRGM_ID == 4960 ~ "Information & Computer Systems Technology (Diploma)",
+      PRGM_ID == 117 ~ "Mechanical Engineering Technology (Diploma)",
+      PRGM_ID == 131 ~ "Visual Arts (Diploma)",
+      TRUE ~ PRGM_INST_PROGRAM_NAME
+    ),
+    Updated_DACSO_CPC2022 = case_when(
+      PRGM_ID == 115 ~ "Yes",
+      PRGM_ID == 9006 ~ "Yes",
+      PRGM_ID == 5952 ~ "Yes",
+      PRGM_ID == 9008 ~ "Yes",
+      PRGM_ID == 4960 ~ "Yes",
+      PRGM_ID == 117 ~ "Yes",
+      PRGM_ID == 131 ~ "Yes",
+      TRUE ~ Updated_DACSO_CPC2022
+    )
+  )
 
 ## ---- 2023 Find DACSO prgms WITH historical linkages ----
 Updated_DACSO_Programs_in_2023_with_links <- programs_table %>%
-  filter(PRGM_FIRST_SEEN_SUBM_CD =='C_Outc23' & HAS_HISTORICAL_PRGM_ID_LINK =='Y') %>%
-  inner_join(tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
-               filter(YEAR_LINK_CREATED =='C_Outc23' & SURVEY_CODE=='DACSO') %>%
-               collect(), 
-             by = "PRGM_ID") %>%
-  select(PRGM_ID, PRGM_FIRST_SEEN_SUBM_CD, PRGM_INST_CD, PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, 
-         PRGM_TTRAIN_FLAG, PRGM_CREDENTIAL, PRGM_INST_PROGRAM_NAME_CLEANED, NOTES, 
-         HAS_HISTORICAL_PRGM_ID_LINK, DUP_PROGRAM_USE_THIS_PRGM_ID, CIP_CLUSTER_ARTS_APPLIED, 
-         DACSO_OLD_PRGM_ID_DO_NOT_USE, LCIP_CD_CIP2016, LCIP_NAME_CIP2016, LCIP_LCP4_CD, 
-         LCP4_CIP_4DIGITS_NAME, HISTORICAL_PRGM_ID, YEAR_LINK_CREATED, SURVEY_CODE)
+  filter(
+    PRGM_FIRST_SEEN_SUBM_CD == 'C_Outc23' & HAS_HISTORICAL_PRGM_ID_LINK == 'Y'
+  ) %>%
+  inner_join(
+    tbl(con, "INFOWARE_PROGRAMS_HIST_PRGMID_XREF") %>%
+      filter(YEAR_LINK_CREATED == 'C_Outc23' & SURVEY_CODE == 'DACSO') %>%
+      collect(),
+    by = "PRGM_ID"
+  ) %>%
+  select(
+    PRGM_ID,
+    PRGM_FIRST_SEEN_SUBM_CD,
+    PRGM_INST_CD,
+    PRGM_LCPC_CD,
+    PRGM_INST_PROGRAM_NAME,
+    PRGM_TTRAIN_FLAG,
+    PRGM_CREDENTIAL,
+    PRGM_INST_PROGRAM_NAME_CLEANED,
+    NOTES,
+    HAS_HISTORICAL_PRGM_ID_LINK,
+    DUP_PROGRAM_USE_THIS_PRGM_ID,
+    CIP_CLUSTER_ARTS_APPLIED,
+    DACSO_OLD_PRGM_ID_DO_NOT_USE,
+    LCIP_CD_CIP2016,
+    LCIP_NAME_CIP2016,
+    LCIP_LCP4_CD,
+    LCP4_CIP_4DIGITS_NAME,
+    HISTORICAL_PRGM_ID,
+    YEAR_LINK_CREATED,
+    SURVEY_CODE
+  )
 
 
 ## ---- 2023 Get historical linkages for DACSO prgms ----
-## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF 
+## use the historical linkage added from INFOWARE_PROGRAMS_HIST_PRGMID_XREF
 ## to link back to the programs table to fill in the historical program details
 Updated_DACSO_Programs_in_2023_with_links <- Updated_DACSO_Programs_in_2023_with_links %>%
   inner_join(
     programs_table %>%
-      select(PRGM_ID, HISTORICAL_CPC_CD = PRGM_LCPC_CD, 
-             HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME, 
-             HISTORICAL_CIP4_CD = LCIP_LCP4_CD),
+      select(
+        PRGM_ID,
+        HISTORICAL_CPC_CD = PRGM_LCPC_CD,
+        HISTORICAL_PROGRAM_NAME = PRGM_INST_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD = LCIP_LCP4_CD
+      ),
     by = c(HISTORICAL_PRGM_ID = "PRGM_ID")
   ) %>%
-  mutate(Updated_CPC_Flag = case_when(PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes', 
-                                      TRUE ~ NA),
-         Updated_CIP_Flag = case_when(LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes', 
-                                      TRUE ~ NA))
+  mutate(
+    Updated_CPC_Flag = case_when(
+      PRGM_LCPC_CD != HISTORICAL_CPC_CD ~ 'Yes',
+      TRUE ~ NA
+    ),
+    Updated_CIP_Flag = case_when(
+      LCIP_LCP4_CD != HISTORICAL_CIP4_CD ~ 'Yes',
+      TRUE ~ NA
+    )
+  )
 
 ## ---- 2023 Update to XWALK: Updated DACSO programs WITH historical linkages ----
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     Updated_DACSO_Programs_in_2023_with_links %>%
       mutate(HISTORICAL_CPC_CD = as.character(HISTORICAL_CPC_CD)) %>%
-      select(PRGM_INST_CD, HISTORICAL_CPC_CD, HISTORICAL_PROGRAM_NAME, HISTORICAL_CIP4_CD,
-             PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME,
-             Updated_DACSO_CPC2023 = Updated_CPC_Flag, Updated_DACSO_CIP2023 = Updated_CIP_Flag),
-    by = c(COCI_INST_CD = "PRGM_INST_CD", PRGM_LCPC_CD = "HISTORICAL_CPC_CD", 
-           PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME", CIP_CODE_4 = "HISTORICAL_CIP4_CD")) %>%
-  mutate(PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = ifelse(!is.na(PRGM_INST_PROGRAM_NAME.y), PRGM_INST_PROGRAM_NAME.y, PRGM_INST_PROGRAM_NAME),
-         CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)) %>%
-  mutate(LCP4_CIP_4DIGITS_NAME = ifelse(!is.na(LCP4_CIP_4DIGITS_NAME.y), LCP4_CIP_4DIGITS_NAME.y, LCP4_CIP_4DIGITS_NAME.x), .after = "CIP_CODE_4") %>%
+      select(
+        PRGM_INST_CD,
+        HISTORICAL_CPC_CD,
+        HISTORICAL_PROGRAM_NAME,
+        HISTORICAL_CIP4_CD,
+        PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME,
+        LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        Updated_DACSO_CPC2023 = Updated_CPC_Flag,
+        Updated_DACSO_CIP2023 = Updated_CIP_Flag
+      ),
+    by = c(
+      COCI_INST_CD = "PRGM_INST_CD",
+      PRGM_LCPC_CD = "HISTORICAL_CPC_CD",
+      PRGM_INST_PROGRAM_NAME = "HISTORICAL_PROGRAM_NAME",
+      CIP_CODE_4 = "HISTORICAL_CIP4_CD"
+    )
+  ) %>%
+  mutate(
+    PRGM_LCPC_CD = ifelse(!is.na(PRGM_LCPC_CD.y), PRGM_LCPC_CD.y, PRGM_LCPC_CD),
+    PRGM_INST_PROGRAM_NAME = ifelse(
+      !is.na(PRGM_INST_PROGRAM_NAME.y),
+      PRGM_INST_PROGRAM_NAME.y,
+      PRGM_INST_PROGRAM_NAME
+    ),
+    CIP_CODE_4 = ifelse(!is.na(LCIP_LCP4_CD), LCIP_LCP4_CD, CIP_CODE_4)
+  ) %>%
+  mutate(
+    LCP4_CIP_4DIGITS_NAME = ifelse(
+      !is.na(LCP4_CIP_4DIGITS_NAME.y),
+      LCP4_CIP_4DIGITS_NAME.y,
+      LCP4_CIP_4DIGITS_NAME.x
+    ),
+    .after = "CIP_CODE_4"
+  ) %>%
   select(-ends_with(".x"), -ends_with(".y"), -LCIP_LCP4_CD)
 
 ## ---- 2023 Find Remaining updated DACSO missing from XWALK for match to STP program ----
 Remaining_DACSO_Updates_CPCS_2023 <- Updated_DACSO_Programs_in_2023_with_links %>%
-  anti_join(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
-            by = c(PRGM_LCPC_CD = "PRGM_LCPC_CD", PRGM_INST_CD = "COCI_INST_CD",
-                   PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"))
+  anti_join(
+    DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+    by = c(
+      PRGM_LCPC_CD = "PRGM_LCPC_CD",
+      PRGM_INST_CD = "COCI_INST_CD",
+      PRGM_INST_PROGRAM_NAME = "PRGM_INST_PROGRAM_NAME"
+    )
+  )
 
 # ***** manual work needed *****
 # review infoware notes
-programs_table %>% filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2023$PRGM_ID) %>% pull(PRGM_ID,NOTES)
-# 3 PRGM_IDs remaining CPCs 
+programs_table %>%
+  filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2023$PRGM_ID) %>%
+  pull(PRGM_ID, NOTES)
+# 3 PRGM_IDs remaining CPCs
 # 1 linked to multiple historic codes: 10413 -> 9841 -> 9237 -> 9017 -> 6036 (9017 & 6036 doesn't exist in XWALK, update 9237 - CPC only)
 # 1 was updated by 2022 update (10234 updated the CPC): 10475 -> 1158 (update CPC only)
 # 1 has historical match not in XWALK: 10493 -> 9810 (9810 does not exist in XWALK - add 10493 info as 9810 PRGM_ID)
@@ -390,263 +726,1231 @@ programs_table %>% filter(PRGM_ID %in% Remaining_DACSO_Updates_CPCS_2023$PRGM_ID
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   bind_rows(
     Remaining_DACSO_Updates_CPCS_2023 %>%
-      filter(PRGM_ID=="10493") %>% 
-      mutate(PSI_CODE = PRGM_INST_CD,
-             COCI_INST_CD = PRGM_INST_CD,
-             PSI_PROGRAM_CODE = PRGM_LCPC_CD,
-             PSI_CREDENTIAL_PROGRAM_DESC = PRGM_INST_PROGRAM_NAME,
-             PRGM_ID = 9810,
-             New_DACSO_Program2021to23 = "Yes2023") %>%
-      select(PSI_CODE, COCI_INST_CD, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESC, PRGM_LCPC_CD,
-             PRGM_INST_PROGRAM_NAME, PRGM_CREDENTIAL,CIP_CODE_4 = LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME,
-             PRGM_ID, New_DACSO_Program2021to23)
+      filter(PRGM_ID == "10493") %>%
+      mutate(
+        PSI_CODE = PRGM_INST_CD,
+        COCI_INST_CD = PRGM_INST_CD,
+        PSI_PROGRAM_CODE = PRGM_LCPC_CD,
+        PSI_CREDENTIAL_PROGRAM_DESC = PRGM_INST_PROGRAM_NAME,
+        PRGM_ID = 9810,
+        New_DACSO_Program2021to23 = "Yes2023"
+      ) %>%
+      select(
+        PSI_CODE,
+        COCI_INST_CD,
+        PSI_PROGRAM_CODE,
+        PSI_CREDENTIAL_PROGRAM_DESC,
+        PRGM_LCPC_CD,
+        PRGM_INST_PROGRAM_NAME,
+        PRGM_CREDENTIAL,
+        CIP_CODE_4 = LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        PRGM_ID,
+        New_DACSO_Program2021to23
+      )
   )
 
 # update necessary values
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  mutate(PRGM_LCPC_CD = case_when(PRGM_ID == 9237 ~ "BCPRPC",
-                                  PRGM_ID == 1158 ~ "DIPLHKIN",
-                                  TRUE ~ PRGM_LCPC_CD),
-         PRGM_INST_PROGRAM_NAME = case_when(PRGM_ID == 9237 ~ "BC Police Recruit Training: Qualified Municipal Constable",
-                                            PRGM_ID == 1158 ~ "Human Kinetics",
-                                            TRUE ~ PRGM_INST_PROGRAM_NAME),
-         Updated_DACSO_CPC2023 = case_when(PRGM_ID == 9237 ~ "Yes",
-                                           PRGM_ID == 1158 ~ "Yes",
-                                           TRUE ~ Updated_DACSO_CPC2023))
+  mutate(
+    PRGM_LCPC_CD = case_when(
+      PRGM_ID == 9237 ~ "BCPRPC",
+      PRGM_ID == 1158 ~ "DIPLHKIN",
+      TRUE ~ PRGM_LCPC_CD
+    ),
+    PRGM_INST_PROGRAM_NAME = case_when(
+      PRGM_ID ==
+        9237 ~ "BC Police Recruit Training: Qualified Municipal Constable",
+      PRGM_ID == 1158 ~ "Human Kinetics",
+      TRUE ~ PRGM_INST_PROGRAM_NAME
+    ),
+    Updated_DACSO_CPC2023 = case_when(
+      PRGM_ID == 9237 ~ "Yes",
+      PRGM_ID == 1158 ~ "Yes",
+      TRUE ~ Updated_DACSO_CPC2023
+    )
+  )
 
 ## ---- Update to XWALK: DACSO programs with updated CIPS ----
 ## find the updated CIPs
 updated_cips <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  left_join(programs_table %>%
-              select(PRGM_ID, CIP_CODE_4 = LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME, NOTES),
-            by = "PRGM_ID") %>%
-  filter(CIP_CODE_4.x != CIP_CODE_4.y | LCP4_CIP_4DIGITS_NAME.x != LCP4_CIP_4DIGITS_NAME.y)
+  left_join(
+    programs_table %>%
+      select(PRGM_ID, CIP_CODE_4 = LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME, NOTES),
+    by = "PRGM_ID"
+  ) %>%
+  filter(
+    CIP_CODE_4.x != CIP_CODE_4.y |
+      LCP4_CIP_4DIGITS_NAME.x != LCP4_CIP_4DIGITS_NAME.y
+  )
 
 # filter out the known updates
-updated_cips <- updated_cips %>% 
-  filter(is.na(Updated_DACSO_CIP2021) & is.na(Updated_DACSO_CIP2022) & is.na(Updated_DACSO_CIP2023))
+updated_cips <- updated_cips %>%
+  filter(
+    is.na(Updated_DACSO_CIP2021) &
+      is.na(Updated_DACSO_CIP2022) &
+      is.na(Updated_DACSO_CIP2023)
+  )
 
 # review NOTES column where word "CIP" exists
-updated_cips %>% 
-  filter(grepl("CIP",NOTES)) %>%
-  select(CIP_CODE_4.x,CIP_CODE_4.y,NOTES,PRGM_ID) %>% print(n=100)
+updated_cips %>%
+  filter(grepl("CIP", NOTES)) %>%
+  select(CIP_CODE_4.x, CIP_CODE_4.y, NOTES, PRGM_ID) %>%
+  print(n = 100)
 
 # review NOTES column where word "CIP" doesn't exist
-updated_cips %>% 
-  filter(!grepl("CIP",NOTES)) %>% 
-  select(CIP_CODE_4.x,CIP_CODE_4.y,NOTES,PRGM_ID) %>% print(n=100)
+updated_cips %>%
+  filter(!grepl("CIP", NOTES)) %>%
+  select(CIP_CODE_4.x, CIP_CODE_4.y, NOTES, PRGM_ID) %>%
+  print(n = 100)
 
-updated_cips %>% 
-  filter(!grepl("CIP",NOTES)) %>% 
-  select(LCP4_CIP_4DIGITS_NAME.x,LCP4_CIP_4DIGITS_NAME.y,NOTES,PRGM_ID) %>% print(n=100)
+updated_cips %>%
+  filter(!grepl("CIP", NOTES)) %>%
+  select(LCP4_CIP_4DIGITS_NAME.x, LCP4_CIP_4DIGITS_NAME.y, NOTES, PRGM_ID) %>%
+  print(n = 100)
 
-# Decision: PRGM_ID 9018 shouldn't be changed; the rest seem like acceptable changes
+# Decision: PRGM_ID 9018 shouldn't be changed; the rest seem like acceptable changes, why?
 # filter out from updated cips file
-updated_cips <- updated_cips %>% 
-  filter(PRGM_ID!=9018)
+updated_cips <- updated_cips %>%
+  filter(PRGM_ID != 9018)
 
 # update CIPS in XWALK
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  left_join(updated_cips %>%
-              distinct(PRGM_ID, CIP_CODE_4 = CIP_CODE_4.y, LCP4_CIP_4DIGITS_NAME = LCP4_CIP_4DIGITS_NAME.y),
-            by = "PRGM_ID") %>%
-  mutate(CIP_CODE_4 = ifelse(!is.na(CIP_CODE_4.y), CIP_CODE_4.y, CIP_CODE_4.x),
-         LCP4_CIP_4DIGITS_NAME = ifelse(!is.na(LCP4_CIP_4DIGITS_NAME.y), LCP4_CIP_4DIGITS_NAME.y, LCP4_CIP_4DIGITS_NAME.x),
-         # adding all of these to only the most recent year updated cip column
-         Updated_DACSO_CIP2023 = ifelse(!is.na(CIP_CODE_4.y), "Yes", Updated_DACSO_CIP2023)) %>%
+  left_join(
+    updated_cips %>%
+      distinct(
+        PRGM_ID,
+        CIP_CODE_4 = CIP_CODE_4.y,
+        LCP4_CIP_4DIGITS_NAME = LCP4_CIP_4DIGITS_NAME.y
+      ),
+    by = "PRGM_ID"
+  ) %>%
+  mutate(
+    CIP_CODE_4 = ifelse(!is.na(CIP_CODE_4.y), CIP_CODE_4.y, CIP_CODE_4.x),
+    LCP4_CIP_4DIGITS_NAME = ifelse(
+      !is.na(LCP4_CIP_4DIGITS_NAME.y),
+      LCP4_CIP_4DIGITS_NAME.y,
+      LCP4_CIP_4DIGITS_NAME.x
+    ),
+    # adding all of these to only the most recent year updated cip column
+    Updated_DACSO_CIP2023 = ifelse(
+      !is.na(CIP_CODE_4.y),
+      "Yes",
+      Updated_DACSO_CIP2023
+    )
+  ) %>%
   select(-ends_with(".x"), -ends_with(".y"))
 
+
+# ---- Add STP matching columns to XWALK ----
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  mutate(
+    New_STP_Program2021_23 = NA_character_,
+    Updated_DACSO_CDTL2021_23 = NA_character_
+  )
+
 ## ---- Write XWALK to Decimal ----
-dbWriteTable(con, "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23", DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23)
+# append a suffix "_r" to the table name in decmile database to indicate which is created in R.
+dbWriteTable(
+  con,
+  "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_r",
+  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
+)
 
-## Add two variables needed for STP program matching
-dbGetQuery(con, "ALTER TABLE DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 
-                  ADD  
-                  New_STP_Program2021_23 VARCHAR(255), 
-                  Updated_DACSO_CDTL2021_23 VARCHAR(255)")
 
-# Part 2 ----
-# import sql queries
-## ** IMPORTANT - update queries with table years **
-source("./sql/02a-program-matching/02a-dacso-program-matching.R")
+# ******************************************************************************
+# PART 2: UPDATE XWALK WITH NEW STP CREDENTIAL DATA
+# ******************************************************************************
+# WHY: STP credential programs need to be matched to the XWALK to get their CIP
+# codes. First, programs already in the XWALK are matched; then new programs are
+# auto-matched on program code and description.
+#
+# Original: ~12 SQL operations (SELECT INTO, ALTER TABLE, UPDATE...FROM JOIN)
+# Translated: Pull tables into R, perform sequential left_join + mutate operations.
 
 # check for required table
 dbExistsTable(con, SQL(glue::glue('"{my_schema}"."credential_non_dup"')))
 
+credential_non_dup <- sch_tbl("Credential_Non_Dup") |>
+  rename_with(toupper) %>%
+  select(
+    PSI_CODE,
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+    PSI_CREDENTIAL_CIP,
+    PSI_CREDENTIAL_LEVEL,
+    PSI_CREDENTIAL_CATEGORY,
+    OUTCOMES_CRED
+  ) %>%
+  collect()
+
+xwalk <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
+
+# Pull INFOWARE CIP reference tables
+cip6 <- sch_tbl("INFOWARE_L_CIP_6DIGITS_CIP2016") %>%
+  collect() |>
+  rename_with(toupper)
+cip4_ref <- sch_tbl("INFOWARE_L_CIP_4DIGITS_CIP2016") %>%
+  collect() |>
+  rename_with(toupper)
+cip2_ref <- sch_tbl("INFOWARE_L_CIP_2DIGITS_CIP2016") %>%
+  collect() |>
+  rename_with(toupper)
+
 ## ---- Make STP_Credential_Non_Dup_Programs_DACSO ----
 # Create a DACSO version of Credential_non_dup table with subset of columns
-dbGetQuery(con, qry_DASCO_STP_Credential_Programs)
+# WHY: Create a DACSO-only subset of Credential_Non_Dup, grouped by program attributes.
+# Original: SELECT INTO with GROUP BY HAVING
+stp_dacso <- credential_non_dup %>%
+  filter(OUTCOMES_CRED == "DACSO") %>%
+  count(
+    PSI_CODE,
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+    PSI_CREDENTIAL_CIP,
+    PSI_CREDENTIAL_LEVEL,
+    PSI_CREDENTIAL_CATEGORY,
+    OUTCOMES_CRED,
+    name = "EXPR1"
+  ) %>%
+  ## ---- Restructure and populate imported STP data ----
+  # Add empty columns that will be filled by matching steps
+  mutate(
+    OUTCOMES_CIP_CODE_4 = NA_character_,
+    OUTCOMES_CIP_CODE_4_NAME = NA_character_,
+    FINAL_CIP_CODE_4 = NA_character_,
+    FINAL_CIP_CODE_4_NAME = NA_character_,
+    FINAL_CIP_CODE_2 = NA_character_,
+    FINAL_CIP_CODE_2_NAME = NA_character_,
+    FINAL_CIP_CLUSTER_CODE = NA_character_,
+    FINAL_CIP_CLUSTER_NAME = NA_character_,
+    STP_CIP_CODE_4 = NA_character_,
+    STP_CIP_CODE_4_NAME = NA_character_,
+    Already_Matched = NA_character_,
+    New_Auto_Match = NA_character_,
+    New_Manual_Match = NA_character_,
+    COCI_INST_CD = NA_character_
+  )
 
-## ---- Restructure and populate imported STP data ----
-dbGetQuery(con, qry_DASCO_STP_Credential_Programs_Add_Columns)
 
 # Create PSI_CODE to COCI_INST_CD lookup table
-dbGetQuery(con, "SELECT DISTINCT PSI_CODE, COCI_INST_CD
-           INTO tbl_STP_PSI_CODE_INST_CD_Lookup
-           FROM DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
-           WHERE PSI_CODE IS NOT NULL and COCI_INST_CD IS NOT NULL")
+# ---- Add COCI_INST_CD from XWALK ----
+# WHY: PSI_CODE and COCI_INST_CD are different code systems for institutions.
+# The XWALK maps between them.
+psi_to_coci <- xwalk %>%
+  filter(!is.na(PSI_CODE) & !is.na(COCI_INST_CD)) %>%
+  distinct(PSI_CODE, COCI_INST_CD)
+
 
 # Add COCI_INST_CD to STP table
-dbGetQuery(con, "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.COCI_INST_CD = tbl_STP_PSI_CODE_INST_CD_Lookup.COCI_INST_CD
-FROM STP_Credential_Non_Dup_Programs_DACSO INNER JOIN tbl_STP_PSI_CODE_INST_CD_Lookup 
-ON STP_Credential_Non_Dup_Programs_DACSO.PSI_CODE = tbl_STP_PSI_CODE_INST_CD_Lookup.PSI_CODE")
+stp_dacso <- stp_dacso %>%
+  left_join(
+    psi_to_coci %>% rename(COCI_INST_CD_MAP = COCI_INST_CD),
+    by = "PSI_CODE"
+  ) %>%
+  mutate(COCI_INST_CD = coalesce(COCI_INST_CD_MAP, COCI_INST_CD)) %>%
+  select(-COCI_INST_CD_MAP)
+
 
 ## ---- Populate STP_CIP_CODE_4, STP_CIP_CODE_4_NAME ----
-dbGetQuery(con, qry_Update_STP_CIP_CODE4)
+# WHY: Match PSI_CREDENTIAL_CIP to the 6-digit CIP taxonomy to get 4-digit codes.
+# Original: UPDATE with 3-table JOIN (STP INNER JOIN CIP6 ON CIP, then CIP4 ON LCP4_CD)
+cip6_lookup <- cip6 %>%
+  select(LCIP_CD_WITH_PERIOD, LCIP_LCP4_CD) %>%
+  inner_join(
+    cip4_ref %>% select(LCP4_CD, LCP4_CIP_4DIGITS_NAME),
+    by = c("LCIP_LCP4_CD" = "LCP4_CD")
+  )
+stp_dacso <- stp_dacso %>%
+  left_join(
+    cip6_lookup %>%
+      select(LCIP_CD_WITH_PERIOD, LCIP_LCP4_CD, LCP4_CIP_4DIGITS_NAME),
+    by = c("PSI_CREDENTIAL_CIP" = "LCIP_CD_WITH_PERIOD")
+  ) %>%
+  mutate(
+    STP_CIP_CODE_4 = coalesce(STP_CIP_CODE_4, LCIP_LCP4_CD), # STP_CIP_CODE_4 are created in previous step, so all are NA
+    STP_CIP_CODE_4_NAME = coalesce(STP_CIP_CODE_4_NAME, LCP4_CIP_4DIGITS_NAME)
+  ) %>%
+  select(-LCIP_LCP4_CD, -LCP4_CIP_4DIGITS_NAME)
 
 ## ---- Already matched programs (might have new CIPs) ----
 # reference: to check after each query to see counts of matched
-# tbl(con,"STP_Credential_Non_Dup_Programs_DACSO") %>% collect() %>% count(Already_Matched)
+# stp_dacso %>% count(Already_Matched)
+
+# WHY: Programs already in the XWALK (matched from previous cycles) inherit
+# their CIP codes. Try matching on PSI_CODE first, then COCI_INST_CD.
 
 # Queries set Already_Matched column to Yes if match
 # join STP data to XWALK on PSI_CODE, PSI_PROGRAM_CREDENTIAL_DESCRIPTION, PSI_PROGRAM_CODE
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_AlreadyMatched)
+# Match on PSI_CODE + PSI_PROGRAM_CODE + PSI_CREDENTIAL_PROGRAM_DESCRIPTION
+xwalk_exact <- xwalk %>%
+  filter(
+    !is.na(PSI_CODE) &
+      !is.na(PSI_PROGRAM_CODE) &
+      !is.na(PSI_CREDENTIAL_PROGRAM_DESC)
+  ) %>%
+  select(
+    PSI_CODE,
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESC,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  )
 
-# join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_PROGRAM_CODE  
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_AlreadyMatched_b)
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_exact %>%
+      rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
+    by = c(
+      "PSI_CODE",
+      "PSI_PROGRAM_CODE" = "PSI_PROGRAM_CODE",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PSI_CREDENTIAL_PROGRAM_DESC"
+    ),
+    relationship = "many-to-many" # no reason is provided
+  ) %>%
+  mutate(
+    Already_Matched = if_else(
+      !is.na(XW_CIP4) & is.na(Already_Matched),
+      "Yes",
+      Already_Matched
+    ),
+    OUTCOMES_CIP_CODE_4 = coalesce(OUTCOMES_CIP_CODE_4, XW_CIP4), # OUTCOMES_CIP_CODE_4 are created in previous step, so all are NA
+    OUTCOMES_CIP_CODE_4_NAME = coalesce(OUTCOMES_CIP_CODE_4_NAME, XW_CIP4_NAME)
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME)
+
+
+# ℹ Row 14 of `x` matches multiple rows in `y`.
+# ℹ Row 2465 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # thia is not in the original code
+
+# join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_PROGRAM_CODE
+# Match on COCI_INST_CD + PSI_PROGRAM_CODE + PSI_CREDENTIAL_PROGRAM_DESCRIPTION
+xwalk_coci <- xwalk %>%
+  filter(
+    !is.na(COCI_INST_CD) &
+      !is.na(PSI_PROGRAM_CODE) &
+      !is.na(PSI_CREDENTIAL_PROGRAM_DESC)
+  ) %>%
+  select(
+    COCI_INST_CD,
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESC,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  )
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_coci %>%
+      rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
+    by = c(
+      "COCI_INST_CD",
+      "PSI_PROGRAM_CODE" = "PSI_PROGRAM_CODE",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PSI_CREDENTIAL_PROGRAM_DESC"
+    )
+  ) %>%
+  mutate(
+    Already_Matched = if_else(
+      is.na(Already_Matched) &
+        is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        !is.na(XW_CIP4),
+      "Yes",
+      Already_Matched
+    ),
+    OUTCOMES_CIP_CODE_4 = if_else(
+      is.na(Already_Matched) &
+        is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        !is.na(XW_CIP4),
+      XW_CIP4,
+      OUTCOMES_CIP_CODE_4
+    ),
+    OUTCOMES_CIP_CODE_4_NAME = if_else(
+      is.na(Already_Matched) &
+        is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        !is.na(XW_CIP4_NAME),
+      XW_CIP4_NAME,
+      OUTCOMES_CIP_CODE_4_NAME
+    )
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME)
+
+# ℹ Row 14 of `x` matches multiple rows in `y`.
+# ℹ Row 1251 of `y` matches multiple rows in `x`
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5450 rows
 
 ## ---- Newly matched programs ----
 # reference: to check after each query to see counts of matched
-# tbl(con,"STP_Credential_Non_Dup_Programs_DACSO") %>% collect() %>% count(New_Auto_Match)
+# stp_dacso %>% count(New_Auto_Match)
 
 # Queries set New_Auto_Match column to Yes if match
 # join STP data to XWALK on PSI_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_NewMatches_a)
+# WHY: Programs not in the XWALK can be matched on DACSO program names/codes.
+# The XWALK has PRGM_INST_PROGRAM_NAME and PRGM_LCPC_CD fields from DACSO.
+
+# Match on PSI_CODE + PSI_PROGRAM_CODE=PRGM_LCPC_CD + DESC=PRGM_INST_PROGRAM_NAME
+xwalk_new_a <- xwalk %>%
+  filter(
+    !is.na(PSI_CODE) & !is.na(PRGM_LCPC_CD) & !is.na(PRGM_INST_PROGRAM_NAME)
+  ) %>%
+  select(
+    PSI_CODE,
+    PRGM_LCPC_CD,
+    PRGM_INST_PROGRAM_NAME,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  )
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_new_a %>%
+      rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
+    by = c(
+      "PSI_CODE",
+      "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
+    )
+  ) %>%
+  mutate(
+    New_Auto_Match = if_else(
+      is.na(Already_Matched) & !is.na(XW_CIP4),
+      "Yes",
+      New_Auto_Match
+    ),
+    OUTCOMES_CIP_CODE_4 = if_else(
+      is.na(Already_Matched) & !is.na(XW_CIP4),
+      XW_CIP4,
+      OUTCOMES_CIP_CODE_4
+    ),
+    OUTCOMES_CIP_CODE_4_NAME = if_else(
+      is.na(Already_Matched) & !is.na(XW_CIP4_NAME),
+      XW_CIP4_NAME,
+      OUTCOMES_CIP_CODE_4_NAME
+    )
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME)
+
+# ℹ Row 783 of `x` matches multiple rows in `y`.
+# ℹ Row 1608 of `y` matches multiple rows in `x`.
+
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5450 rows
 
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_NewMatches_a_step2)
+# Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD + DESC=PRGM_INST_PROGRAM_NAME
+xwalk_new_a2 <- xwalk %>%
+  filter(
+    !is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD) & !is.na(PRGM_INST_PROGRAM_NAME)
+  ) %>%
+  select(
+    COCI_INST_CD,
+    PRGM_LCPC_CD,
+    PRGM_INST_PROGRAM_NAME,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  )
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_new_a2 %>%
+      rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
+    by = c(
+      "COCI_INST_CD",
+      "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
+    )
+  ) %>%
+  mutate(
+    New_Auto_Match = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        is.na(New_Auto_Match) &
+        is.na(Already_Matched) &
+        !is.na(XW_CIP4),
+      "Yes",
+      New_Auto_Match
+    ),
+    OUTCOMES_CIP_CODE_4 = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) & !is.na(XW_CIP4),
+      XW_CIP4,
+      OUTCOMES_CIP_CODE_4
+    ),
+    OUTCOMES_CIP_CODE_4_NAME = if_else(
+      is.na(OUTCOMES_CIP_CODE_4_NAME) & !is.na(XW_CIP4_NAME),
+      XW_CIP4_NAME,
+      OUTCOMES_CIP_CODE_4_NAME
+    )
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME)
+
+# ℹ Row 783 of `x` matches multiple rows in `y`.
+# ℹ Row 1716 of `y` matches multiple rows in `x`.
+
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5450 rows
 
 ## ---- Add to XWALK: newly matched STP programs ----
 # join on PSI_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # where New_Auto_Match = Yes, copy PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, STP_CIP4_CODE into STP_CIP_CODE_4, CTP_SIP4_NAME into STP_CIP_CODE_4_NAME
 # - Set New_STP_Program20XX = Yes and One_To_One_Match = Yes20XX
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_NewMatches_b)
+# WHY: When new STP programs are matched to DACSO entries in the XWALK, we update
+# the XWALK with the STP program info so future runs can find them as "already matched".
+
+# Get the newly matched STP programs
+newly_matched <- stp_dacso %>%
+  filter(New_Auto_Match == "Yes") %>%
+  select(
+    PSI_CODE,
+    PSI_PROGRAM_CODE,
+    PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+    STP_CIP_CODE_4,
+    STP_CIP_CODE_4_NAME
+  )
+
+# Update XWALK for PSI_CODE matches
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  left_join(
+    newly_matched %>%
+      rename(
+        XW_STP_PGM_CODE = PSI_PROGRAM_CODE,
+        XW_STP_PGM_DESC = PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+        XW_STP_CIP4 = STP_CIP_CODE_4,
+        XW_STP_CIP4_NAME = STP_CIP_CODE_4_NAME
+      ),
+    by = c(
+      "PSI_CODE" = "PSI_CODE",
+      "PRGM_LCPC_CD" = "XW_STP_PGM_CODE",
+      "PRGM_INST_PROGRAM_NAME" = "XW_STP_PGM_DESC"
+    ),
+    keep = TRUE,
+    relationship = "many-to-many" # no reason is provided yet
+  ) %>%
+  mutate(
+    PSI_CODE = PSI_CODE.x,
+    PSI_PROGRAM_CODE = if_else(
+      !is.na(XW_STP_PGM_CODE),
+      XW_STP_PGM_CODE,
+      PSI_PROGRAM_CODE
+    ),
+    PSI_CREDENTIAL_PROGRAM_DESC = if_else(
+      !is.na(XW_STP_PGM_DESC),
+      XW_STP_PGM_DESC,
+      PSI_CREDENTIAL_PROGRAM_DESC
+    ),
+    STP_CIP4_CODE = if_else(
+      !is.na(XW_STP_CIP4),
+      XW_STP_CIP4,
+      as.character(STP_CIP4_CODE)
+    ),
+    STP_CIP4_NAME = if_else(
+      !is.na(XW_STP_CIP4_NAME),
+      XW_STP_CIP4_NAME,
+      STP_CIP4_NAME
+    ),
+    New_STP_Program2021_23 = if_else(
+      !is.na(XW_STP_PGM_CODE),
+      "Yes",
+      New_STP_Program2021_23
+    ),
+    One_To_One_Match = if_else(
+      !is.na(XW_STP_PGM_CODE),
+      "Yes2021_23",
+      One_To_One_Match
+    )
+  ) %>%
+  select(-starts_with("XW_STP"), -ends_with(".x"), -ends_with(".y"))
+
+#
+
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  distinct()
+# 4595
 
 # same as above but join on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
-dbGetQuery(con, qry_STP_Credential_DACSO_Programs_NewMatches_b_step2)
+# Update XWALK for COCI_INST_CD matches (only rows not yet updated)
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  left_join(
+    newly_matched %>%
+      rename(
+        XW_STP_PGM_CODE = PSI_PROGRAM_CODE,
+        XW_STP_PGM_DESC = PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+        XW_STP_CIP4 = STP_CIP_CODE_4,
+        XW_STP_CIP4_NAME = STP_CIP_CODE_4_NAME
+      ),
+    by = c(
+      "COCI_INST_CD" = "PSI_CODE",
+      "PRGM_LCPC_CD" = "XW_STP_PGM_CODE",
+      "PRGM_INST_PROGRAM_NAME" = "XW_STP_PGM_DESC"
+    ),
+    keep = TRUE,
+    relationship = "many-to-many" # no reason is provided yet
+  ) %>%
+  mutate(
+    PSI_CODE = PSI_CODE.x,
+    PSI_PROGRAM_CODE = if_else(
+      is.na(New_STP_Program2021_23) & !is.na(XW_STP_PGM_CODE),
+      XW_STP_PGM_CODE,
+      PSI_PROGRAM_CODE
+    ),
+    PSI_CREDENTIAL_PROGRAM_DESC = if_else(
+      is.na(New_STP_Program2021_23) & !is.na(XW_STP_PGM_DESC),
+      XW_STP_PGM_DESC,
+      PSI_CREDENTIAL_PROGRAM_DESC
+    ),
+    STP_CIP4_CODE = if_else(
+      is.na(New_STP_Program2021_23) & !is.na(XW_STP_CIP4),
+      XW_STP_CIP4,
+      STP_CIP4_CODE
+    ),
+    STP_CIP4_NAME = if_else(
+      is.na(New_STP_Program2021_23) & !is.na(XW_STP_CIP4_NAME),
+      XW_STP_CIP4_NAME,
+      STP_CIP4_NAME
+    ),
+    New_STP_Program2021_23 = if_else(
+      is.na(New_STP_Program2021_23) & !is.na(XW_STP_PGM_CODE),
+      "Yes",
+      New_STP_Program2021_23
+    ),
+    One_To_One_Match = if_else(
+      is.na(One_To_One_Match) & !is.na(XW_STP_PGM_CODE),
+      "Yes2021_23",
+      One_To_One_Match
+    )
+  ) %>%
+  select(-starts_with("XW_STP"), -ends_with(".x"), -ends_with(".y"))
 
-# Part 3 ----
+DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
+  distinct()
+# 4486
+
+# simplify the name
+xwalk <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
+rm(newly_matched)
+
+# ******************************************************************************
+# PART 3: INSTITUTION-SPECIFIC CUSTOM MATCHING
+# ******************************************************************************
+# WHY: Some institutions use different program code formats in STP vs DACSO.
+# BCIT includes credential suffixes, CAPU uses different code lengths, and VIU
+# wraps codes in credential-category prefixes. We extract the DACSO-compatible
+# portion and match on that.
 
 ## Find STP programs that are unmatched ----
-stp_unmatched <- tbl(con, "STP_Credential_Non_Dup_Programs_DACSO") %>%
-  filter((is.na(OUTCOMES_CIP_CODE_4) | is.na(OUTCOMES_CIP_CODE_4_NAME)) & is.na(Already_Matched) & is.na(New_Auto_Match)) %>%
-  collect()
+stp_unmatched <- stp_dacso %>%
+  filter(
+    (is.na(OUTCOMES_CIP_CODE_4) | is.na(OUTCOMES_CIP_CODE_4_NAME)) &
+      is.na(Already_Matched) &
+      is.na(New_Auto_Match)
+  )
 
 # !!! review the unmatched STP programs and the XWALK to determine if these institution matches are still relevant
 
 # reference: to check after each query to see counts of matched
-# tbl(con,"STP_Credential_Non_Dup_Programs_DACSO") %>% collect() %>% count(New_Auto_Match)
+# stp_dacso %>% count(New_Auto_Match)
+
+# Helper function: match STP to XWALK on test code
+#' Match STP programs to the DACSO XWALK using a test program code
+#'
+#' Perform an institution-aware join between STP program rows and the DACSO XWALK,
+#' optionally including program descriptions in the join. When a match is found
+#' the function sets New_Auto_Match to the supplied flag and populates the
+#' OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME fields (but only when they
+#' are not already set).
+#'
+#' @param stp_df A data.frame / tibble of STP credential program rows. Expected
+#'   to contain COCI_INST_CD and the test_col named column, and the OUTCOMES_*
+#'   and New_Auto_Match columns that will be updated.
+#' @param xwalk_df A data.frame / tibble of the DACSO XWALK. Expected to contain
+#'   COCI_INST_CD, PRGM_LCPC_CD, PRGM_INST_PROGRAM_NAME, CIP_CODE_4 and
+#'   LCP4_CIP_4DIGITS_NAME.
+#' @param test_col Character. The name of the column in stp_df to use as the
+#'   program code for matching (passed as a string).
+#' @param match_flag Character. The value to set for New_Auto_Match when a match
+#'   is made (for example, "YesXXBCIT").
+#' @param join_cols_desc Logical. If TRUE include program description in the
+#'   join (i.e. PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME);
+#'   if FALSE join only on institution + code.
+#' @return A tibble: a copy of stp_df with New_Auto_Match, OUTCOMES_CIP_CODE_4 and
+#'   OUTCOMES_CIP_CODE_4_NAME updated for newly matched rows. Temporary CIP and
+#'   name columns from the join are removed before returning.
+#' @details The function filters xwalk_df to rows with non-missing COCI_INST_CD
+#'   and PRGM_LCPC_CD, performs a left join according to the requested keys and
+#'   then updates the STP outcome fields only when they are currently unset.
+#' @examples
+#' # match_on_test_code(stp_df, xwalk_df, \"BCIT_TEST_PROGRAM_CODE\", \"YesXXBCIT\")
+#' @export
+match_on_test_code <- function(
+  stp_df,
+  xwalk_df,
+  test_col,
+  match_flag,
+  join_cols_desc = TRUE
+) {
+  if (join_cols_desc) {
+    by <- c(
+      "COCI_INST_CD" = "COCI_INST_CD",
+      setNames("PRGM_LCPC_CD", test_col),
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
+    )
+
+    stp_df <- stp_df %>%
+      left_join(
+        xwalk_df %>%
+          filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
+          select(
+            COCI_INST_CD,
+            PRGM_LCPC_CD,
+            PRGM_INST_PROGRAM_NAME,
+            CIP_CODE_4,
+            LCP4_CIP_4DIGITS_NAME
+          ),
+        by = by
+      )
+  } else {
+    by <- c("COCI_INST_CD" = "COCI_INST_CD", setNames("PRGM_LCPC_CD", test_col))
+
+    stp_df <- stp_df %>%
+      left_join(
+        xwalk_df %>%
+          filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
+          select(
+            COCI_INST_CD,
+            PRGM_LCPC_CD,
+            # PRGM_INST_PROGRAM_NAME,
+            CIP_CODE_4,
+            LCP4_CIP_4DIGITS_NAME
+          ),
+        by = by
+      )
+  }
+
+  stp_df <- stp_df %>%
+    mutate(
+      New_Auto_Match = if_else(
+        is.na(OUTCOMES_CIP_CODE_4) &
+          is.na(OUTCOMES_CIP_CODE_4_NAME) &
+          is.na(New_Auto_Match) &
+          !is.na(CIP_CODE_4),
+        match_flag,
+        New_Auto_Match
+      ),
+      OUTCOMES_CIP_CODE_4 = if_else(
+        is.na(OUTCOMES_CIP_CODE_4) & !is.na(CIP_CODE_4),
+        CIP_CODE_4,
+        OUTCOMES_CIP_CODE_4
+      ),
+      OUTCOMES_CIP_CODE_4_NAME = if_else(
+        is.na(OUTCOMES_CIP_CODE_4_NAME) & !is.na(LCP4_CIP_4DIGITS_NAME),
+        LCP4_CIP_4DIGITS_NAME,
+        OUTCOMES_CIP_CODE_4_NAME
+      )
+    ) %>%
+    select(-CIP_CODE_4, -LCP4_CIP_4DIGITS_NAME)
+}
+
 
 ## ---- Update BCIT ----
-## BCIT submits CPC codes to STP that include the credential abbreviation suffix (e.g. _TTDIPL, _CERTTS...) 
+## BCIT submits CPC codes to STP that include the credential abbreviation suffix (e.g. _TTDIPL, _CERTTS...)
 ## but in DACSO their codes do not have the suffix
-tbl(con, "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23") %>% filter(PSI_CODE=="BCIT") %>% pull(PRGM_LCPC_CD)
-stp_unmatched %>% filter(PSI_CODE=="BCIT") %>% pull(PSI_PROGRAM_CODE)
+xwalk %>%
+  filter(PSI_CODE == "BCIT") %>%
+  pull(PRGM_LCPC_CD)
+stp_unmatched %>% filter(PSI_CODE == "BCIT") %>% pull(PSI_PROGRAM_CODE)
+
 
 # add a new program code column, and use that to match
-dbGetQuery(con, "ALTER TABLE STP_Credential_Non_Dup_Programs_DACSO 
-               ADD  
-                  BCIT_TEST_PROGRAM_CODE VARCHAR(255)")
 
 # take the first 4 digits of the PSI_PROGRAM_CODE
-dbGetQuery(con,"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.BCIT_TEST_PROGRAM_CODE = Left([PSI_PROGRAM_CODE],4)
-WHERE (([PSI_CODE]='BCIT'))")
+# WHY: BCIT submits CPC codes with credential abbreviation suffixes (e.g., _TTDIPL)
+# but DACSO codes don't have the suffix. Take first 4 characters of PSI_PROGRAM_CODE.
+stp_dacso <- stp_dacso %>%
+  mutate(
+    BCIT_TEST_PROGRAM_CODE = if_else(
+      PSI_CODE == "BCIT",
+      substr(PSI_PROGRAM_CODE, 1, 4),
+      NA_character_
+    )
+  )
 
 # queries will set New_Auto_Match = 'YesXXBCIT'
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD
-dbGetQuery(con, qry_Update_BCIT_Programs)
+# dbGetQuery(con, qry_Update_BCIT_Programs)
+# BCIT: match with description
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  test_col = "BCIT_TEST_PROGRAM_CODE",
+  match_flag = "Yes2021_23BCIT",
+  join_cols_desc = TRUE
+)
+# ℹ Row 7 of `x` matches multiple rows in `y`.
+# ℹ Row 2739 of `y` matches multiple rows in `x`.
+
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5450
 
 # join STP data to XWALK on COCI_INST_CD, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD
-dbGetQuery(con, qry_Update_BCIT_Programs_b)
+# dbGetQuery(con, qry_Update_BCIT_Programs_b)
+# BCIT: match without description (code only)
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "BCIT_TEST_PROGRAM_CODE",
+  "Yes2021_23BCIT",
+  join_cols_desc = FALSE
+)
+# ℹ Row 7 of `x` matches multiple rows in `y`.
+# ℹ Row 2739 of `y` matches multiple rows in `x`
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5450
 
 ## ---- Update CAPU ----
 # CAPU submits CPC codes to STP that are 6 digits long, but in DACSO they are generally 3 or 4 digits long
 # run through twice - once for 4 digits, once for 3 digits
 # some also seem to have -YYY after CPC codes in STP but not in DACSO
-tbl(con, "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23") %>% filter(PSI_CODE=="CAP") %>% pull(PRGM_LCPC_CD)
-stp_unmatched %>% filter(PSI_CODE=="CAPU") %>% pull(PSI_PROGRAM_CODE)
+xwalk %>%
+  filter(PSI_CODE == "CAP") %>%
+  pull(PRGM_LCPC_CD)
+stp_unmatched %>% filter(PSI_CODE == "CAPU") %>% pull(PSI_PROGRAM_CODE)
 
-dbGetQuery(con, "ALTER TABLE STP_Credential_Non_Dup_Programs_DACSO 
-               ADD  
-                  CAP_TEST_PROGRAM_CODE VARCHAR(255)")
+
 # remove dashes
-dbGetQuery(con,"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.CAP_TEST_PROGRAM_CODE = LEFT([PSI_PROGRAM_CODE],CHARINDEX('-',[PSI_PROGRAM_CODE])-1)
-WHERE (([COCI_INST_CD]='CAPU') AND ([PSI_PROGRAM_CODE] like '%-%'))")
+# WHY: CAPU codes are 6 digits in STP but 3-4 digits in DACSO. Some also have
+# dash suffixes. Try multiple code lengths.
+stp_dacso <- stp_dacso %>%
+  mutate(
+    CAP_TEST_PROGRAM_CODE = if_else(
+      COCI_INST_CD == "CAPU" & grepl("-", PSI_PROGRAM_CODE),
+      substr(
+        PSI_PROGRAM_CODE,
+        1,
+        regexpr("-", PSI_PROGRAM_CODE, fixed = TRUE) - 1
+      ),
+      NA_character_
+    )
+  )
 
-dbGetQuery(con, qry_Update_CAPU_Programs_a)
-dbGetQuery(con, qry_Update_CAPU_Programs_b) 
+# Match with dash-removed codes + description
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = TRUE
+)
+
+# ℹ Row 2269 of `x` matches multiple rows in `y`.
+# ℹ Row 4175 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
+
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = FALSE
+)
+# ℹ Row 1647 of `x` matches multiple rows in `y`.
+# ℹ Row 4175 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
 
 # 4 digits
-dbGetQuery(con,"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.CAP_TEST_PROGRAM_CODE = Left([PSI_PROGRAM_CODE],4)
-WHERE (([COCI_INST_CD]='CAPU'))")
+# Try 4-digit prefix
+stp_dacso <- stp_dacso %>%
+  mutate(
+    CAP_TEST_PROGRAM_CODE = if_else(
+      COCI_INST_CD == "CAPU",
+      substr(PSI_PROGRAM_CODE, 1, 4),
+      CAP_TEST_PROGRAM_CODE
+    )
+  )
 
-dbGetQuery(con, qry_Update_CAPU_Programs_a)
-dbGetQuery(con, qry_Update_CAPU_Programs_b)
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = TRUE
+)
 
-# 3 digits
-dbGetQuery(con,"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.CAP_TEST_PROGRAM_CODE = Left([PSI_PROGRAM_CODE],3)
-WHERE (([COCI_INST_CD]='CAPU'))")
+# ℹ Row 1202 of `x` matches multiple rows in `y`.
+# ℹ Row 1684 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = FALSE
+)
+# ℹ Row 1200 of `x` matches multiple rows in `y`.
+# ℹ Row 1684 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
 
-dbGetQuery(con, qry_Update_CAPU_Programs_a)
-dbGetQuery(con, qry_Update_CAPU_Programs_b)
+# Try 3-digit prefix
+stp_dacso <- stp_dacso %>%
+  mutate(
+    CAP_TEST_PROGRAM_CODE = if_else(
+      COCI_INST_CD == "CAPU",
+      substr(PSI_PROGRAM_CODE, 1, 3),
+      CAP_TEST_PROGRAM_CODE
+    )
+  )
 
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = TRUE
+)
+# ℹ Row 1348 of `x` matches multiple rows in `y`.
+# ℹ Row 2219 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "CAP_TEST_PROGRAM_CODE",
+  "Yes2021_23CAPU",
+  join_cols_desc = FALSE
+)
+# ℹ Row 1151 of `x` matches multiple rows in `y`.
+# ℹ Row 2219 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5508
 
 ## ---- Update VIU ----
 # STP versions seem longer (e.g., CERT-WELDM_01) versus DACSO (e.g.,WELDM)
 # STP has the credential category (e.g., CERT) dash DACSO CPC followed by _01 or similar
-tbl(con, "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23") %>% filter(PSI_CODE=="VIU") %>% pull(PRGM_LCPC_CD)
-stp_unmatched %>% filter(PSI_CODE=="VIU") %>% pull(PSI_PROGRAM_CODE)
+# WHY: VIU codes in STP are like "CERT-WELDM_01" but DACSO just has "WELDM".
+# Extract the substring between "-" and "_".
+xwalk %>%
+  filter(PSI_CODE == "VIU") %>%
+  pull(PRGM_LCPC_CD)
+stp_unmatched %>% filter(PSI_CODE == "VIU") %>% pull(PSI_PROGRAM_CODE)
 
-dbGetQuery(con, "ALTER TABLE STP_Credential_Non_Dup_Programs_DACSO 
-               ADD  
-                  VIU_TEST_PROGRAM_CODE VARCHAR(255)")
+stp_dacso <- stp_dacso %>%
+  mutate(
+    VIU_TEST_PROGRAM_CODE = if_else(
+      PSI_CODE == "VIU" &
+        grepl("-", PSI_PROGRAM_CODE) &
+        grepl("_", PSI_PROGRAM_CODE),
+      substr(
+        PSI_PROGRAM_CODE,
+        regexpr("-", PSI_PROGRAM_CODE, fixed = TRUE) + 1,
+        regexpr("_", PSI_PROGRAM_CODE, fixed = TRUE) - 1
+      ),
+      NA_character_
+    )
+  )
 
-# populate with the value between the - and _
-dbGetQuery(con,"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
-SET STP_Credential_Non_Dup_Programs_DACSO.VIU_TEST_PROGRAM_CODE = SUBSTRING([PSI_PROGRAM_CODE],  charindex('-',[PSI_PROGRAM_CODE],1) + 1, charindex('_',[PSI_PROGRAM_CODE],1) - charindex('-',[PSI_PROGRAM_CODE],1) - 1 )
-WHERE (([PSI_CODE]='VIU') AND ([PSI_PROGRAM_CODE] like '%-%'))")
-
-dbGetQuery(con, qry_Update_VIU_Programs_a)
-dbGetQuery(con, qry_Update_VIU_Programs_b)
-
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "VIU_TEST_PROGRAM_CODE",
+  "Yes2021_23VIU",
+  join_cols_desc = TRUE
+)
+stp_dacso <- match_on_test_code(
+  stp_dacso,
+  xwalk,
+  "VIU_TEST_PROGRAM_CODE",
+  "Yes2021_23VIU",
+  join_cols_desc = FALSE
+)
+# ℹ Row 5389 of `x` matches multiple rows in `y`.
+# ℹ Row 936 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5513
 ## Update remaining matching ----
-dbGetQuery(con, qry_Update_Remaining_Programs_Matching_DACSO_Seen)
-dbGetQuery(con, qry_Update_Remaining_Programs_Matching_DACSO_Seen_b)
 
-# Part 4 ----
+# ---- Remaining catch-all matching ----
+# WHY: Try matching remaining unmatched programs on COCI_INST_CD + program code,
+# then on COCI_INST_CD + program description.
+
+# Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD
+xwalk_remaining <- xwalk %>%
+  filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
+  select(COCI_INST_CD, PRGM_LCPC_CD, CIP_CODE_4, LCP4_CIP_4DIGITS_NAME)
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_remaining %>%
+      rename(
+        XW_CIP4 = CIP_CODE_4,
+        XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME
+      ),
+    by = c("COCI_INST_CD", "PSI_PROGRAM_CODE" = "PRGM_LCPC_CD"),
+    relationship = "many-to-many" # no reason is provided yet
+  ) %>%
+  mutate(
+    New_Auto_Match = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        is.na(New_Auto_Match) &
+        !is.na(XW_CIP4),
+      "Yes_2021_23test",
+      New_Auto_Match
+    ),
+    OUTCOMES_CIP_CODE_4 = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) & !is.na(XW_CIP4),
+      XW_CIP4,
+      OUTCOMES_CIP_CODE_4
+    ),
+    OUTCOMES_CIP_CODE_4_NAME = if_else(
+      is.na(OUTCOMES_CIP_CODE_4_NAME) & !is.na(XW_CIP4_NAME),
+      XW_CIP4_NAME,
+      OUTCOMES_CIP_CODE_4_NAME
+    )
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME, -ends_with(".x"), -ends_with(".y"))
+
+
+# ℹ Row 841 of `x` matches multiple rows in `y`.
+# ℹ Row 1651 of `y` matches multiple rows in `x`.
+stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
+# 5513
+# Match on COCI_INST_CD + PSI_CREDENTIAL_PROGRAM_DESCRIPTION=PRGM_INST_PROGRAM_NAME
+xwalk_remaining_desc <- xwalk %>%
+  filter(!is.na(COCI_INST_CD) & !is.na(PRGM_INST_PROGRAM_NAME)) %>%
+  select(
+    COCI_INST_CD,
+    PRGM_INST_PROGRAM_NAME,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  )
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    xwalk_remaining_desc %>%
+      rename(XW_CIP4 = CIP_CODE_4, XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME),
+    by = c(
+      "COCI_INST_CD",
+      "PSI_CREDENTIAL_PROGRAM_DESCRIPTION" = "PRGM_INST_PROGRAM_NAME"
+    ),
+    # keep = TRUE,
+    relationship = "many-to-many" # no reason is provided yet
+  ) %>%
+  mutate(
+    New_Auto_Match = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) &
+        is.na(OUTCOMES_CIP_CODE_4_NAME) &
+        is.na(New_Auto_Match) &
+        !is.na(XW_CIP4),
+      "Yes_2021_23test",
+      New_Auto_Match
+    ),
+    OUTCOMES_CIP_CODE_4 = if_else(
+      is.na(OUTCOMES_CIP_CODE_4) & !is.na(XW_CIP4),
+      XW_CIP4,
+      OUTCOMES_CIP_CODE_4
+    ),
+    OUTCOMES_CIP_CODE_4_NAME = if_else(
+      is.na(OUTCOMES_CIP_CODE_4_NAME) & !is.na(XW_CIP4_NAME),
+      XW_CIP4_NAME,
+      OUTCOMES_CIP_CODE_4_NAME
+    )
+  ) %>%
+  select(-XW_CIP4, -XW_CIP4_NAME)
+
+rm(xwalk_remaining, xwalk_remaining_desc)
+
+
+# ******************************************************************************
+# PART 4: FINAL UPDATE TO STP CIPS
+# ******************************************************************************
+# WHY: Compute final CIP codes. Matched programs use the outcomes CIP; unmatched
+# programs use STP CIP from the INFOWARE taxonomy. Then fill 2-digit CIP and
+# cluster codes from the 4-digit code.
+#
+# Original: ~8 SQL operations (UPDATE, SELECT INTO, DROP TABLE)
+# Translated: Sequential mutate + left_join operations in memory.
 
 ## ---- Update STP_Credential_Non_Dup_Programs_DACSO with final CIPS ----
 # Use the outcomes cip4 data if there was a match for the final cip4
-dbGetQuery(con, qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_a)
+# Step 1: Where outcomes CIP exists, use it as final
+stp_dacso <- stp_dacso %>%
+  mutate(
+    FINAL_CIP_CODE_4 = if_else(
+      !is.na(OUTCOMES_CIP_CODE_4) & !is.na(OUTCOMES_CIP_CODE_4_NAME),
+      OUTCOMES_CIP_CODE_4,
+      FINAL_CIP_CODE_4
+    ),
+    FINAL_CIP_CODE_4_NAME = if_else(
+      !is.na(OUTCOMES_CIP_CODE_4) & !is.na(OUTCOMES_CIP_CODE_4_NAME),
+      OUTCOMES_CIP_CODE_4_NAME,
+      FINAL_CIP_CODE_4_NAME
+    )
+  )
+
+# Step 2: Where no outcomes match, use INFOWARE to derive CIP from PSI_CREDENTIAL_CIP
+# WHY: This fills FINAL_CIP for programs that weren't matched to DACSO outcomes.
+# It uses the full CIP hierarchy (6-digit → 4-digit → 2-digit → names → cluster).
+cip6_full <- cip6 %>%
+  select(
+    LCIP_CD_WITH_PERIOD,
+    LCIP_LCP4_CD,
+    LCIP_LCP2_CD,
+    LCIP_LCIPPC_CD,
+    LCIP_LCIPPC_NAME
+  ) %>%
+  inner_join(
+    cip4_ref %>% select(LCP4_CD, LCP4_CIP_4DIGITS_NAME),
+    by = c("LCIP_LCP4_CD" = "LCP4_CD")
+  ) %>%
+  inner_join(
+    cip2_ref %>% select(LCP2_CD, LCP2_DIGITS_NAME),
+    by = c("LCIP_LCP2_CD" = "LCP2_CD")
+  )
 
 # Use the STP CIP4 outcomes for the rest where there is no match
-dbGetQuery(con, qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_b)
-dbGetQuery(con, qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_c) 
+stp_dacso <- stp_dacso %>%
+  left_join(
+    cip6_full %>%
+      select(
+        LCIP_CD_WITH_PERIOD,
+        LCIP_LCP4_CD,
+        LCP4_CIP_4DIGITS_NAME,
+        LCIP_LCP2_CD,
+        LCP2_DIGITS_NAME
+      ),
+    by = c("PSI_CREDENTIAL_CIP" = "LCIP_CD_WITH_PERIOD")
+  ) %>%
+  mutate(
+    FINAL_CIP_CODE_4 = if_else(
+      is.na(FINAL_CIP_CODE_4) &
+        is.na(FINAL_CIP_CODE_4_NAME) &
+        is.na(FINAL_CIP_CODE_2) &
+        is.na(FINAL_CIP_CODE_2_NAME) &
+        is.na(OUTCOMES_CIP_CODE_4),
+      LCIP_LCP4_CD,
+      FINAL_CIP_CODE_4
+    ),
+    FINAL_CIP_CODE_4_NAME = if_else(
+      is.na(FINAL_CIP_CODE_4_NAME) &
+        is.na(FINAL_CIP_CODE_2) &
+        is.na(FINAL_CIP_CODE_2_NAME) &
+        is.na(OUTCOMES_CIP_CODE_4),
+      LCP4_CIP_4DIGITS_NAME,
+      FINAL_CIP_CODE_4_NAME
+    ),
+    FINAL_CIP_CODE_2 = if_else(
+      is.na(FINAL_CIP_CODE_2) &
+        is.na(FINAL_CIP_CODE_2_NAME) &
+        is.na(OUTCOMES_CIP_CODE_4),
+      LCIP_LCP2_CD,
+      FINAL_CIP_CODE_2
+    ),
+    FINAL_CIP_CODE_2_NAME = if_else(
+      is.na(FINAL_CIP_CODE_2_NAME) & is.na(OUTCOMES_CIP_CODE_4),
+      LCP2_DIGITS_NAME,
+      FINAL_CIP_CODE_2_NAME
+    )
+  ) %>%
+  select(
+    -LCIP_LCP4_CD,
+    -LCP4_CIP_4DIGITS_NAME,
+    -LCIP_LCP2_CD,
+    -LCP2_DIGITS_NAME
+  )
+
+
+# Step 3: Fill remaining NULL FINAL_CIP columns from the 4-digit code
+# WHY: Some records got FINAL_CIP_CODE_4 from Step 1 (outcomes) but still need
+# 4-digit name, 2-digit code, 2-digit name, and cluster codes.
+cip4_lookup <- cip6 %>%
+  select(LCIP_LCP4_CD, LCIP_LCP2_CD) %>%
+  distinct() %>%
+  inner_join(
+    cip4_ref %>% select(LCP4_CD, LCP4_CIP_4DIGITS_NAME),
+    by = c("LCIP_LCP4_CD" = "LCP4_CD")
+  ) %>%
+  inner_join(
+    cip2_ref %>% select(LCP2_CD, LCP2_DIGITS_NAME),
+    by = c("LCIP_LCP2_CD" = "LCP2_CD")
+  )
+
+stp_dacso <- stp_dacso %>%
+  left_join(
+    cip4_lookup,
+    by = c("FINAL_CIP_CODE_4" = "LCIP_LCP4_CD")
+  ) %>%
+  mutate(
+    FINAL_CIP_CODE_4_NAME = coalesce(
+      FINAL_CIP_CODE_4_NAME,
+      LCP4_CIP_4DIGITS_NAME
+    ),
+    FINAL_CIP_CODE_2 = coalesce(FINAL_CIP_CODE_2, LCIP_LCP2_CD),
+    FINAL_CIP_CODE_2_NAME = coalesce(FINAL_CIP_CODE_2_NAME, LCP2_DIGITS_NAME)
+  ) %>%
+  select(-LCIP_LCP2_CD, -LCP4_CIP_4DIGITS_NAME, -LCP2_DIGITS_NAME)
+
 
 # To update the final cip 2 and  final cip cluster based on the final cip4
-dbGetQuery(con, qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_a)
+
+# Step 4: Fill FINAL_CIP_CLUSTER from FINAL_CIP_CODE_4
+# WHY: The 6-digit CIP taxonomy maps each 4-digit code to a cluster code.
+cip6_cluster <- cip6 %>%
+  select(LCIP_LCP4_CD, LCIP_LCP2_CD, LCIP_LCIPPC_CD, LCIP_LCIPPC_NAME) %>%
+  distinct()
+
+stp_dacso <- stp_dacso %>%
+  left_join(cip6_cluster, by = c("FINAL_CIP_CODE_4" = "LCIP_LCP4_CD")) %>%
+  mutate(
+    FINAL_CIP_CODE_2 = coalesce(FINAL_CIP_CODE_2, LCIP_LCP2_CD),
+    FINAL_CIP_CLUSTER_CODE = coalesce(FINAL_CIP_CLUSTER_CODE, LCIP_LCIPPC_CD),
+    FINAL_CIP_CLUSTER_NAME = coalesce(FINAL_CIP_CLUSTER_NAME, LCIP_LCIPPC_NAME)
+  ) %>%
+  select(-LCIP_LCP2_CD, -LCIP_LCIPPC_CD, -LCIP_LCIPPC_NAME)
+
 
 # To update the final cip 2 name based on the final cip2
-dbGetQuery(con, qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_b) 
+# Step 5: Fill FINAL_CIP_CODE_2_NAME from 2-digit lookup
+stp_dacso <- stp_dacso %>%
+  left_join(
+    cip2_ref %>% select(LCP2_CD, LCP2_DIGITS_NAME),
+    by = c("FINAL_CIP_CODE_2" = "LCP2_CD")
+  ) %>%
+  mutate(
+    FINAL_CIP_CODE_2_NAME = coalesce(FINAL_CIP_CODE_2_NAME, LCP2_DIGITS_NAME)
+  ) %>%
+  select(-LCP2_DIGITS_NAME)
 
 # check the # of changed CIPS
-dbGetQuery(con, qry_Check_CIP_Changes_STP_Cred_Non_Dup_DACSO)
-nrow(tbl(con,"STP_Credential_Non_Dup_Programs_DACSO_CIPS_CHANGED_2021_23") %>% collect())
-review_changed_cips <- tbl(con,"STP_Credential_Non_Dup_Programs_DACSO_CIPS_CHANGED_2021_23") %>% collect()
+# ---- Review CIP changes ----
+# WHY: Diagnostic — shows programs where the final CIP differs from the original
+# STP CIP. Useful for catching incorrect matches.
+review_changed_cips <- stp_dacso %>%
+  filter(FINAL_CIP_CODE_4 != STP_CIP_CODE_4)
+# 232
+# ---- Write final output tables ----
+dbWriteTable(
+  con,
+  "STP_Credential_Non_Dup_Programs_DACSO_r",
+  stp_dacso,
+  overwrite = TRUE
+)
+dbWriteTable(
+  con,
+  "Credential_Non_Dup_Programs_DACSO_FinalCIPS_r",
+  stp_dacso,
+  overwrite = TRUE
+)
+dbWriteTable(
+  con,
+  "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_r",
+  DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
+  overwrite = TRUE
+)
 
-## Save to new table in DECIMAL: Credential_Non_Dup_Programs_DACSO_FinalCIPS ----
-dbExecute(con,"SELECT * 
-               INTO Credential_Non_Dup_Programs_DACSO_FinalCIPS
-               FROM STP_Credential_Non_Dup_Programs_DACSO;")
-
-# Clean up ----
-dbExecute(con, "DROP TABLE tbl_STP_PSI_CODE_INST_CD_Lookup")
-dbExecute(con, "DROP TABLE STP_Credential_Non_Dup_Programs_DACSO_CIPS_CHANGED_2021_23")
 dbDisconnect(con)
-
-

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -1185,6 +1185,14 @@ xwalk_coci <- xwalk %>%
     PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(
+      COCI_INST_CD_KEY,
+      PSI_PROGRAM_CODE_KEY,
+      PSI_CREDENTIAL_PROGRAM_DESC_KEY
+    )
   )
 
 stp_dacso <- stp_dacso %>%
@@ -1195,8 +1203,7 @@ stp_dacso <- stp_dacso %>%
       "COCI_INST_CD_KEY" = "COCI_INST_CD_KEY",
       "PSI_PROGRAM_CODE_KEY" = "PSI_PROGRAM_CODE_KEY",
       "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided
+    )
   ) %>%
   mutate(
     Already_Matched = if_else(
@@ -1226,10 +1233,6 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-# ℹ Row 14 of `x` matches multiple rows in `y`.
-# ℹ Row 1251 of `y` matches multiple rows in `x`
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462 rows
 
 ## ---- Newly matched programs ----
 # reference: to check after each query to see counts of matched
@@ -1251,6 +1254,14 @@ xwalk_new_a <- xwalk %>%
     PSI_CREDENTIAL_PROGRAM_DESC_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(
+      PSI_CODE_KEY,
+      PRGM_LCPC_CD_KEY,
+      PSI_CREDENTIAL_PROGRAM_DESC_KEY
+    )
   )
 
 stp_dacso <- stp_dacso %>%
@@ -1261,8 +1272,7 @@ stp_dacso <- stp_dacso %>%
       "PSI_CODE_KEY",
       "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY",
       "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PSI_CREDENTIAL_PROGRAM_DESC_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided
+    )
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1283,12 +1293,6 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-# ℹ Row 783 of `x` matches multiple rows in `y`.
-# ℹ Row 1608 of `y` matches multiple rows in `x`.
-
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462 rows
-
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD + DESC=PRGM_INST_PROGRAM_NAME
 xwalk_new_a2 <- xwalk %>%
@@ -1301,6 +1305,14 @@ xwalk_new_a2 <- xwalk %>%
     PRGM_INST_PROGRAM_NAME_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(
+      COCI_INST_CD_KEY,
+      PRGM_LCPC_CD_KEY,
+      PRGM_INST_PROGRAM_NAME_KEY
+    )
   )
 
 stp_dacso <- stp_dacso %>%
@@ -1311,8 +1323,7 @@ stp_dacso <- stp_dacso %>%
       "COCI_INST_CD_KEY",
       "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY",
       "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PRGM_INST_PROGRAM_NAME_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided
+    )
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1337,11 +1348,6 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-# ℹ Row 783 of `x` matches multiple rows in `y`.
-# ℹ Row 1716 of `y` matches multiple rows in `x`.
-
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462 rows
 
 ## ---- Add to XWALK: newly matched STP programs ----
 ## qry_STP_Credential_DACSO_Programs_NewMatches_b ----
@@ -1365,7 +1371,7 @@ newly_matched <- stp_dacso %>%
     STP_CIP_CODE_4,
     STP_CIP_CODE_4_NAME
   )
-# 227
+# 3 rows
 
 # Update XWALK for PSI_CODE matches
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
@@ -1381,8 +1387,7 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       "PSI_CODE_KEY" = "PSI_CODE_KEY",
       "PRGM_LCPC_CD_KEY" = "PSI_PROGRAM_CODE_KEY",
       "PRGM_INST_PROGRAM_NAME_KEY" = "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided yet
+    )
   ) %>%
   mutate(
     PSI_PROGRAM_CODE = if_else(
@@ -1420,10 +1425,6 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
 
 #
 
-DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  distinct()
-# 4487
-
 ## qry_STP_Credential_DACSO_Programs_NewMatches_b_step2 ----
 # same as above but join on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, PSI_PROGRAM_CODE = PRGM_LCPC_CD
 # Update XWALK for COCI_INST_CD matches (only rows not yet updated)
@@ -1439,7 +1440,9 @@ newly_matched_2 <- stp_dacso %>%
     STP_CIP_CODE_4,
     STP_CIP_CODE_4_NAME
   )
+# 3 rows
 
+# Update XWALK for COCI_INST_CD matches
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
   left_join(
     newly_matched_2 %>%
@@ -1453,8 +1456,7 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
       "COCI_INST_CD_KEY" = "COCI_INST_CD_KEY",
       "PRGM_LCPC_CD_KEY" = "PSI_PROGRAM_CODE_KEY",
       "PRGM_INST_PROGRAM_NAME_KEY" = "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY"
-    ),
-    relationship = "many-to-many" # no reason is provided yet
+    )
   ) %>%
   mutate(
     PSI_PROGRAM_CODE = if_else(
@@ -1490,9 +1492,6 @@ DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_202
   ) %>%
   select(-starts_with("XW_STP"))
 
-DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
-  distinct()
-# 4487
 
 # simplify the name
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 %>%
@@ -1577,6 +1576,14 @@ match_on_test_code <- function(
             PRGM_INST_PROGRAM_NAME_KEY,
             CIP_CODE_4,
             LCP4_CIP_4DIGITS_NAME
+          ) |>
+          slice_head(
+            n = 1,
+            by = c(
+              COCI_INST_CD_KEY,
+              PRGM_LCPC_CD_KEY,
+              PRGM_INST_PROGRAM_NAME_KEY
+            )
           ),
         by = c(
           "COCI_INST_CD_KEY",
@@ -1594,6 +1601,13 @@ match_on_test_code <- function(
             PRGM_LCPC_CD_KEY,
             CIP_CODE_4,
             LCP4_CIP_4DIGITS_NAME
+          ) |>
+          slice_head(
+            n = 1,
+            by = c(
+              COCI_INST_CD_KEY,
+              PRGM_LCPC_CD_KEY
+            )
           ),
         by = c(
           "COCI_INST_CD_KEY",
@@ -1664,11 +1678,7 @@ stp_dacso <- match_on_test_code(
   match_flag = "Yes2021_23BCIT",
   join_cols_desc = TRUE
 )
-# ℹ Row 7 of `x` matches multiple rows in `y`.
-# ℹ Row 2739 of `y` matches multiple rows in `x`.
 
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
 
 # join STP data to XWALK on COCI_INST_CD, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD without PSI_CREDENTIAL_PROGRAM_DESCRIPTION
 # dbGetQuery(con, qry_Update_BCIT_Programs_b)
@@ -1680,11 +1690,7 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23BCIT",
   join_cols_desc = FALSE
 )
-# ℹ Row 7 of `x` matches multiple rows in `y`.
-# ℹ Row 2739 of `y` matches multiple rows in `x`
-# less constrain in join, so more duplications
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 
 ## ---- Update CAPU ----
 # CAPU submits CPC codes to STP that are 6 digits long, but in DACSO they are generally 3 or 4 digits long
@@ -1724,10 +1730,6 @@ stp_dacso <- match_on_test_code(
   join_cols_desc = TRUE
 )
 
-# ℹ Row 2269 of `x` matches multiple rows in `y`.
-# ℹ Row 4175 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
 
 stp_dacso <- match_on_test_code(
   stp_dacso,
@@ -1736,10 +1738,7 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23CAPU",
   join_cols_desc = FALSE
 )
-# ℹ Row 1647 of `x` matches multiple rows in `y`.
-# ℹ Row 4175 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 
 # 4 digits, another way of matching
 # Try 4-digit prefix
@@ -1760,10 +1759,7 @@ stp_dacso <- match_on_test_code(
   join_cols_desc = TRUE
 )
 
-# ℹ Row 1202 of `x` matches multiple rows in `y`.
-# ℹ Row 1684 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 stp_dacso <- match_on_test_code(
   stp_dacso,
   xwalk,
@@ -1771,10 +1767,7 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23CAPU",
   join_cols_desc = FALSE
 )
-# ℹ Row 1200 of `x` matches multiple rows in `y`.
-# ℹ Row 1684 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 
 # 3 digits, another way of matching
 
@@ -1795,10 +1788,8 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23CAPU",
   join_cols_desc = TRUE
 )
-# ℹ Row 1348 of `x` matches multiple rows in `y`.
-# ℹ Row 2219 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
+
 stp_dacso <- match_on_test_code(
   stp_dacso,
   xwalk,
@@ -1806,10 +1797,7 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23CAPU",
   join_cols_desc = FALSE
 )
-# ℹ Row 1151 of `x` matches multiple rows in `y`.
-# ℹ Row 2219 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 
 ## ---- Update VIU ----
 # STP versions seem longer (e.g., CERT-WELDM_01) versus DACSO (e.g.,WELDM)
@@ -1850,10 +1838,7 @@ stp_dacso <- match_on_test_code(
   "Yes2021_23VIU",
   join_cols_desc = FALSE
 )
-# ℹ Row 5389 of `x` matches multiple rows in `y`.
-# ℹ Row 936 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 
 ## Update remaining matching ----
 
@@ -1864,7 +1849,19 @@ stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
 # Match on COCI_INST_CD + PSI_PROGRAM_CODE=PRGM_LCPC_CD
 xwalk_remaining <- xwalk %>%
   filter(!is.na(COCI_INST_CD) & !is.na(PRGM_LCPC_CD)) %>%
-  select(COCI_INST_CD_KEY, PRGM_LCPC_CD_KEY, CIP_CODE_4, LCP4_CIP_4DIGITS_NAME)
+  select(
+    COCI_INST_CD_KEY,
+    PRGM_LCPC_CD_KEY,
+    CIP_CODE_4,
+    LCP4_CIP_4DIGITS_NAME
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(
+      COCI_INST_CD_KEY,
+      PRGM_LCPC_CD_KEY
+    )
+  )
 
 stp_dacso <- stp_dacso %>%
   left_join(
@@ -1873,8 +1870,7 @@ stp_dacso <- stp_dacso %>%
         XW_CIP4 = CIP_CODE_4,
         XW_CIP4_NAME = LCP4_CIP_4DIGITS_NAME
       ),
-    by = c("COCI_INST_CD_KEY", "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY"),
-    relationship = "many-to-many" # no reason is provided yet
+    by = c("COCI_INST_CD_KEY", "PSI_PROGRAM_CODE_KEY" = "PRGM_LCPC_CD_KEY")
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1898,11 +1894,6 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-
-# ℹ Row 841 of `x` matches multiple rows in `y`.
-# ℹ Row 1651 of `y` matches multiple rows in `x`.
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
 
 # Match on COCI_INST_CD + PSI_CREDENTIAL_PROGRAM_DESCRIPTION=PRGM_INST_PROGRAM_NAME
 xwalk_remaining_desc <- xwalk %>%
@@ -1912,6 +1903,13 @@ xwalk_remaining_desc <- xwalk %>%
     PRGM_INST_PROGRAM_NAME_KEY,
     CIP_CODE_4,
     LCP4_CIP_4DIGITS_NAME
+  ) |>
+  slice_head(
+    n = 1,
+    by = c(
+      COCI_INST_CD_KEY,
+      PRGM_INST_PROGRAM_NAME_KEY
+    )
   )
 
 stp_dacso <- stp_dacso %>%
@@ -1921,9 +1919,7 @@ stp_dacso <- stp_dacso %>%
     by = c(
       "COCI_INST_CD_KEY",
       "PSI_CREDENTIAL_PROGRAM_DESCRIPTION_KEY" = "PRGM_INST_PROGRAM_NAME_KEY"
-    ),
-    # keep = TRUE,
-    relationship = "many-to-many" # no reason is provided yet
+    )
   ) %>%
   mutate(
     New_Auto_Match = if_else(
@@ -1947,8 +1943,7 @@ stp_dacso <- stp_dacso %>%
   ) %>%
   select(-XW_CIP4, -XW_CIP4_NAME)
 
-stp_dacso <- stp_dacso %>% distinct() # this is not in the original code
-# 5462
+
 rm(xwalk_remaining, xwalk_remaining_desc)
 
 

--- a/sql/pssm_sql_queris.txt
+++ b/sql/pssm_sql_queris.txt
@@ -1,0 +1,12720 @@
+##################################################################
+# SQL queries for PSSM 2012-23
+##################################################################
+# ---- Checks ----
+qry00a_check_null_epens <- "
+SELECT COUNT (*) AS n_null_epens FROM STP_Enrolment
+WHERE STP_Enrolment.ENCRYPTED_TRUE_PEN IN ('', ' ', '(Unspecified)') 
+OR STP_Enrolment.ENCRYPTED_TRUE_PEN IS NULL;"
+
+qry00b_check_unique_epens <- "
+  SELECT COUNT (DISTINCT ENCRYPTED_TRUE_PEN) AS n_epens
+  FROM STP_Enrolment"
+
+# ---- create id field as primary key ----
+qry00c_CreateIDinSTPEnrolment <- "
+  ALTER TABLE STP_Enrolment
+  ADD ID INT IDENTITY(1,1) NOT NULL"
+
+qry00d_SetPKeyinSTPEnrolment <- "
+  ALTER TABLE STP_Enrolment
+  ADD CONSTRAINT STP_Enrolment_PK_ID PRIMARY KEY (ID)"
+
+
+# ---- qry01_ExtractAllID_into_STP_Enrolment_Record_Type ----
+qry01_ExtractAllID_into_STP_Enrolment_Record_Type <- "
+   CREATE TABLE STP_Enrolment_Record_Type (
+   [ID] int NOT NULL,
+   [RecordStatus] smallint,
+   [MinEnrolment] smallint,
+   [FirstEnrolment] smallint
+   );
+
+   INSERT INTO STP_Enrolment_Record_Type (ID)
+   SELECT STP_Enrolment.ID
+   FROM STP_Enrolment;"
+
+
+# ---- qry02a_Record_With_PEN_Or_STUID ----
+qry02a_Record_With_PEN_Or_STUID <- "
+SELECT     id, PSI_STUDENT_NUMBER, PSI_CODE, ENCRYPTED_TRUE_PEN
+INTO       tmp_tbl_qry02a_Record_With_PEN_Or_STUID
+FROM       STP_Enrolment
+WHERE     (PSI_STUDENT_NUMBER NOT IN('',' ','(Unspecified)')
+AND        PSI_CODE NOT IN('',' ','(Unspecified)'))
+OR         (ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)'));"
+
+
+# ---- qry02b_Drop_No_PEN_Or_No_STUID ----
+qry02b_Drop_No_PEN_Or_No_STUID <- "
+SELECT      STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_CODE 
+INTO        Drop_No_PEN_or_No_STUID
+FROM        tmp_tbl_qry02a_Record_With_PEN_Or_STUID 
+RIGHT JOIN  STP_Enrolment 
+  ON        tmp_tbl_qry02a_Record_With_PEN_Or_STUID.ID = STP_Enrolment.ID
+WHERE       ((tmp_tbl_qry02a_Record_With_PEN_Or_STUID.ID) Is Null);"
+
+
+# ---- qry02c_Update_Drop_No_PEN_Or_No_STUID.SQL ----
+qry02c_Update_Drop_No_PEN_Or_No_STUID <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       RecordStatus = 1
+FROM      STP_Enrolment_Record_Type INNER JOIN
+          Drop_No_PEN_or_No_STUID ON STP_Enrolment_Record_Type.ID = Drop_No_PEN_or_No_STUID.ID;"
+
+# ---- qry03a_Drop_Record_Developmental ----
+qry03a_Drop_Record_Developmental <- "
+SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL
+INTO      Drop_Developmental
+FROM      STP_Enrolment
+WHERE     PSI_STUDY_LEVEL = 'DEVELOPMENTAL';"
+
+
+# ---- qry03b_Update_Drop_Record_Developmental ----
+qry03b_Update_Drop_Record_Developmental <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       RecordStatus = 2
+FROM      STP_Enrolment_Record_Type INNER JOIN
+          Drop_Developmental ON STP_Enrolment_Record_Type.ID = Drop_Developmental.ID;"
+
+# ---- qry03c_Drop_Skills_Based ----
+qry03c_Drop_Skills_Based <- "
+SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, 
+          PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
+INTO      Drop_Skills_Based
+FROM      STP_Enrolment
+WHERE     PSI_CONTINUING_EDUCATION_COURSE_ONLY = 'SKILLS CRS ONLY'
+  AND     PSI_STUDY_LEVEL <>'DEVELOPMENTAL'
+  AND     PSI_CREDENTIAL_CATEGORY IN ('NONE','OTHER');"
+
+# ---- qry03da_Keep_TeachEd ----
+qry03da_Keep_TeachEd <- "
+UPDATE    Drop_Skills_Based
+SET       KEEP = 'Y'
+WHERE     (PSI_CODE = 'UFV') AND (PSI_PROGRAM_CODE = 'TEACH ED') 
+  OR      (PSI_CODE = 'UCFV') AND (PSI_PROGRAM_CODE = 'TEACH ED');"
+
+# ---- qry03d_Update_Drop_Record_Skills_Based ----
+qry03d_Update_Drop_Record_Skills_Based <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       RecordStatus = 6
+FROM      STP_Enrolment_Record_Type 
+INNER JOIN Drop_Skills_Based 
+  ON STP_Enrolment_Record_Type.ID = Drop_Skills_Based.ID
+WHERE     RecordStatus is NULL and KEEP IS NULL;"
+
+# ---- qry03d_1_Drop_Continuing_Ed ----
+qry03d_1_Drop_Continuing_Ed <- "
+SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL
+INTO      Drop_ContinuingEd
+FROM      STP_Enrolment
+WHERE     (PSI_STUDY_LEVEL <> 'DEVELOPMENTAL'
+  AND     PSI_CONTINUING_EDUCATION_COURSE_ONLY <> 'SKILLS CRS ONLY'
+  AND     PSI_CREDENTIAL_CATEGORY IN ('NONE','OTHER')
+  AND     (Left(PSI_CIP_CODE,2) IN ('21', '32', '33', '34', '35', '36','37', '53', '89')));"
+
+# ---- qry03d_2_Update_Drop_Continuing_Ed ----
+qry03d_2_Update_Drop_Continuing_Ed <- "
+UPDATE    
+STP_Enrolment_Record_Type
+SET       RecordStatus = 6
+FROM      STP_Enrolment_Record_Type 
+INNER JOIN Drop_ContinuingEd 
+ON        STP_Enrolment_Record_Type.ID = Drop_ContinuingEd.ID
+WHERE     RecordStatus is NULL;"
+
+# ---- qry03d_3_Drop_More_Continuing_Ed ----
+qry03d_3_Drop_More_Continuing_Ed <- "
+SELECT    STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_CODE, 
+          STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, STP_Enrolment.PSI_PROGRAM_CODE, 
+          STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, STP_Enrolment.PSI_STUDY_LEVEL, STP_Enrolment_Record_Type.RecordStatus
+INTO      Drop_ContinuingEd_More
+FROM      STP_Enrolment 
+LEFT OUTER JOIN STP_Enrolment_Record_Type 
+  ON      STP_Enrolment.ID = STP_Enrolment_Record_Type.ID
+WHERE     ((STP_Enrolment_Record_Type.RecordStatus IS NULL) 
+  AND     ((STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Continuing Education') 
+  OR      (STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Continuing Studies') 
+  OR      (STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Audit%') 
+  OR      (STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE 'CE %')));"
+
+
+# ---- qry03d_4_Updated_Drop_ContinuingEdMore ----
+qry03d_4_Updated_Drop_ContinuingEdMore <- "
+UPDATE      STP_Enrolment_Record_Type
+SET         STP_Enrolment_Record_Type.RecordStatus = 6
+FROM        STP_Enrolment_Record_Type 
+INNER JOIN  Drop_ContinuingEd_More 
+  ON        STP_Enrolment_Record_Type.ID = Drop_ContinuingEd_More.ID
+WHERE       STP_Enrolment_Record_Type.RecordStatus is NULL;"
+
+
+# ---- qry03e_Keep_Skills_Based ----
+qry03e_Keep_Skills_Based <- "
+SELECT      ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, 
+            PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
+INTO        Keep_Skills_Based
+FROM        STP_Enrolment
+WHERE       (PSI_CONTINUING_EDUCATION_COURSE_ONLY = 'SKILLS CRS ONLY') 
+AND (PSI_STUDY_LEVEL <> 'DEVELOPMENTAL') 
+AND (PSI_CREDENTIAL_CATEGORY NOT IN ('NONE', 'OTHER', 'SHORT CERTIFICATE')) 
+AND (NOT (PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Continuing Studies')) 
+AND (NOT (PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Audit%')) 
+AND (NOT (PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE '%Continuing Education'))
+AND (NOT (PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE 'CE %'));"
+
+# ---- qry03ea_Exclude_Skills_Based_Programs ----
+qry03ea_Exclude_Skills_Based_Programs <- "
+UPDATE      Keep_Skills_Based
+SET         Exclude = 'Y'
+WHERE      (PSI_CODE = 'SEL'
+  AND       PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'COMMUNITY, CORPORATE & INTERNATIONAL DEVELOPMENT')
+  OR (PSI_CODE = 'NIC' AND CIP2 IN ('21', '32', '33', '34', '35', '36', '37', '53', '89'));"
+
+
+# ---- qry03f_Update_Keep_Record_Skills_Based ----
+qry03f_Update_Keep_Record_Skills_Based <- "
+UPDATE      STP_Enrolment_Record_Type
+SET         RecordStatus = 0
+FROM        STP_Enrolment_Record_Type 
+INNER JOIN  Keep_Skills_Based 
+ON          STP_Enrolment_Record_Type.ID = Keep_Skills_Based.ID
+WHERE       STP_Enrolment_Record_Type.RecordStatus IS NULL
+AND         Keep_Skills_Based.Exclude IS NULL;"
+
+
+# ---- qry03fb_Update_Keep_Record_Skills_Based ----
+qry03fb_Update_Keep_Record_Skills_Based <- "
+UPDATE      STP_Enrolment_Record_Type
+SET         RecordStatus = 6
+FROM        STP_Enrolment_Record_Type 
+INNER JOIN  Keep_Skills_Based 
+  ON        STP_Enrolment_Record_Type.ID = Keep_Skills_Based.ID
+WHERE       STP_Enrolment_Record_Type.RecordStatus IS NULL
+  AND       Keep_Skills_Based.Exclude ='Y';"
+
+
+# ---- qry03g_create_table_SkillsBasedCourses ----
+qry03g_create_table_SkillsBasedCourses <- "
+SELECT    STP_Enrolment.PSI_CODE, 
+          STP_Enrolment.PSI_PROGRAM_CODE, 
+          STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, 
+          STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+          STP_Enrolment.PSI_STUDY_LEVEL, 
+          STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, 
+          COUNT(*) AS Count
+INTO      tmp_tbl_SkillsBasedCourses
+FROM      STP_Enrolment_Record_Type 
+INNER JOIN STP_Enrolment 
+  ON STP_Enrolment_Record_Type.ID = STP_Enrolment.ID
+WHERE     STP_Enrolment_Record_Type.RecordStatus = 6
+GROUP BY STP_Enrolment.PSI_CODE, 
+          STP_Enrolment.PSI_PROGRAM_CODE, 
+          STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          LEFT(STP_Enrolment.PSI_CIP_CODE, 2), 
+          STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+          STP_Enrolment.PSI_STUDY_LEVEL, 
+          STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
+
+
+# ---- qry03g_b_Keep_More_Skills_Based ----
+qry03g_b_Keep_More_Skills_Based <- "
+SELECT        STP_Enrolment.ID, 
+              tmp_tbl_SkillsBasedCourses.PSI_CODE, 
+              tmp_tbl_SkillsBasedCourses.PSI_PROGRAM_CODE, tmp_tbl_SkillsBasedCourses.CIP2, 
+              tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+              tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_CATEGORY, 
+              tmp_tbl_SkillsBasedCourses.PSI_STUDY_LEVEL, 
+              tmp_tbl_SkillsBasedCourses.PSI_CONTINUING_EDUCATION_COURSE_ONLY
+INTO          tmp_MoreSkillsBased_to_Keep
+FROM          STP_Enrolment 
+INNER JOIN    tmp_tbl_SkillsBasedCourses 
+  ON          STP_Enrolment.PSI_CODE = tmp_tbl_SkillsBasedCourses.PSI_CODE 
+  AND         STP_Enrolment.PSI_PROGRAM_CODE = tmp_tbl_SkillsBasedCourses.PSI_PROGRAM_CODE 
+  AND         STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_PROGRAM_DESCRIPTION 
+  AND         STP_Enrolment.PSI_CREDENTIAL_CATEGORY = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_CATEGORY 
+  AND         STP_Enrolment.PSI_STUDY_LEVEL = tmp_tbl_SkillsBasedCourses.PSI_STUDY_LEVEL 
+  AND         STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY = tmp_tbl_SkillsBasedCourses.PSI_CONTINUING_EDUCATION_COURSE_ONLY
+WHERE        (tmp_tbl_SkillsBasedCourses.Keep = 'Yes');"
+
+
+# ---- qry03g_c_Update_Keep_More_Skills_Based ----
+qry03g_c_Update_Keep_More_Skills_Based <- "
+UPDATE        STP_Enrolment_Record_Type
+SET           RecordStatus = 0
+FROM          STP_Enrolment_Record_Type 
+INNER JOIN    tmp_MoreSkillsBased_to_Keep 
+  ON STP_Enrolment_Record_Type.ID = tmp_MoreSkillsBased_to_Keep.ID
+WHERE        (STP_Enrolment_Record_Type.RecordStatus=6);"
+
+
+# ---- qry03g_c2_Update_More_Selkirk ----
+qry03g_c2_Update_More_Selkirk <- "
+UPDATE STP_Enrolment_Record_Type 
+SET RecordStatus = 6 
+FROM STP_Enrolment_Record_Type 
+INNER JOIN STP_Enrolment 
+  ON STP_Enrolment_Record_Type.ID = STP_Enrolment.ID
+WHERE (STP_Enrolment.PSI_CODE = 'SEL') 
+  AND (STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'COMMUNITY, CORPORATE & INTERNATIONAL DEVELOPMENT') 
+  AND (STP_Enrolment_Record_Type.RecordStatus IS NULL)"
+
+
+# ---- qry03g_d_EnrolCoursesSeen ----
+qry03g_d_EnrolCoursesSeen <- "
+SELECT  STP_Enrolment.PSI_CODE, 
+        STP_Enrolment.PSI_PROGRAM_CODE, 
+        STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+        LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, 
+        STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+        STP_Enrolment.PSI_STUDY_LEVEL, 
+        STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, 
+        COUNT(*) AS Count
+INTO    tmp_tbl_EnrolCoursesSeen
+FROM    STP_Enrolment
+GROUP BY STP_Enrolment.PSI_CODE, 
+        STP_Enrolment.PSI_PROGRAM_CODE, 
+        STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+        LEFT(STP_Enrolment.PSI_CIP_CODE, 2), 
+        STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+        STP_Enrolment.PSI_STUDY_LEVEL, 
+        STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
+
+
+# ---- qry03h_create_table_Suspect_Skills_Based ----
+qry03h_create_table_Suspect_Skills_Based <- "
+SELECT      STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN,   STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment.PSI_SCHOOL_YEAR, STP_Enrolment.PSI_REGISTRATION_TERM, 
+            STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, LEFT(STP_Enrolment.PSI_CIP_CODE,2) AS CIP2, STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+            STP_Enrolment.PSI_STUDY_LEVEL, STP_Enrolment.PSI_ENTRY_STATUS, STP_Enrolment.PSI_BIRTHDATE, STP_Enrolment.PSI_GENDER, STP_Enrolment.PSI_MIN_START_DATE, STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY
+INTO        tmp_tbl_Suspect_Skills_Based
+FROM        STP_Enrolment_Record_Type 
+INNER JOIN  STP_Enrolment 
+  ON        STP_Enrolment_Record_Type.ID = STP_Enrolment.ID
+WHERE    (STP_Enrolment_Record_Type.RecordStatus IS NULL);"
+
+
+# ---- qry03i_Find_Suspect_Skills_Based ----
+qry03i_Find_Suspect_Skills_Based <- "
+SELECT    tmp_tbl_Suspect_Skills_Based.ID, tmp_tbl_Suspect_Skills_Based.ENCRYPTED_TRUE_PEN, tmp_tbl_Suspect_Skills_Based.PSI_STUDENT_NUMBER, 
+          tmp_tbl_Suspect_Skills_Based.PSI_CODE, tmp_tbl_Suspect_Skills_Based.PSI_PROGRAM_CODE, 
+          tmp_tbl_Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, tmp_tbl_Suspect_Skills_Based.CIP2, 
+          tmp_tbl_Suspect_Skills_Based.PSI_CREDENTIAL_CATEGORY, tmp_tbl_Suspect_Skills_Based.PSI_STUDY_LEVEL, 
+          tmp_tbl_Suspect_Skills_Based.PSI_CONTINUING_EDUCATION_COURSE_ONLY, tmp_tbl_SkillsBasedCourses.Keep
+INTO      Suspect_Skills_Based
+FROM      tmp_tbl_Suspect_Skills_Based 
+INNER JOIN  tmp_tbl_SkillsBasedCourses 
+  ON      tmp_tbl_Suspect_Skills_Based.PSI_CODE = tmp_tbl_SkillsBasedCourses.PSI_CODE 
+  AND     tmp_tbl_Suspect_Skills_Based.PSI_PROGRAM_CODE = tmp_tbl_SkillsBasedCourses.PSI_PROGRAM_CODE 
+  AND     tmp_tbl_Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_PROGRAM_DESCRIPTION 
+  AND     tmp_tbl_Suspect_Skills_Based.CIP2 = tmp_tbl_SkillsBasedCourses.CIP2 
+  AND     tmp_tbl_Suspect_Skills_Based.PSI_CREDENTIAL_CATEGORY = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_CATEGORY 
+  AND     tmp_tbl_Suspect_Skills_Based.PSI_STUDY_LEVEL = tmp_tbl_SkillsBasedCourses.PSI_STUDY_LEVEL
+WHERE (tmp_tbl_SkillsBasedCourses.Keep IS NULL);"
+
+
+# ---- qry03i2_Drop_Suspect_Skills_Based ----
+qry03i2_Drop_Suspect_Skills_Based <-
+  "UPDATE  Suspect_Skills_Based
+SET  Keep = 'Y'
+FROM  Suspect_Skills_Based 
+INNER JOIN tmp_tbl_SkillsBasedCourses 
+  ON Suspect_Skills_Based.PSI_CODE = tmp_tbl_SkillsBasedCourses.PSI_CODE 
+  AND Suspect_Skills_Based.PSI_PROGRAM_CODE = tmp_tbl_SkillsBasedCourses.PSI_PROGRAM_CODE 
+  AND Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_PROGRAM_DESCRIPTION 
+  AND Suspect_Skills_Based.CIP2 = tmp_tbl_SkillsBasedCourses.CIP2 
+  AND Suspect_Skills_Based.PSI_CREDENTIAL_CATEGORY = tmp_tbl_SkillsBasedCourses.PSI_CREDENTIAL_CATEGORY 
+  AND Suspect_Skills_Based.PSI_STUDY_LEVEL = tmp_tbl_SkillsBasedCourses.PSI_STUDY_LEVEL
+WHERE (tmp_tbl_SkillsBasedCourses.KEEP = 'Y')"
+
+# ---- qry03j_Update_Suspect_Skills_Based ----
+qry03j_Update_Suspect_Skills_Based <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       RecordStatus = 6
+FROM      Suspect_Skills_Based INNER JOIN STP_Enrolment_Record_Type 
+  ON        Suspect_Skills_Based.ID = STP_Enrolment_Record_Type.ID
+WHERE STP_Enrolment_Record_Type.RecordStatus IS NULL AND Suspect_Skills_Based.Keep IS NULL;"
+
+
+# ---- qry03k_Drop_Developmental_CIPS ----
+qry03k_Drop_Developmental_CIPS <- "SELECT 
+ STP_Enrolment.ID,   STP_Enrolment.ENCRYPTED_TRUE_PEN,   STP_Enrolment.PSI_STUDENT_NUMBER,   STP_Enrolment.PSI_CODE,
+ STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+ LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+ STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY
+INTO  Drop_Developmental_CIPS
+FROM  STP_Enrolment_Record_Type 
+INNER JOIN STP_Enrolment ON STP_Enrolment_Record_Type.ID = STP_Enrolment.ID
+WHERE     (STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY = 'NOT SKILLS CRS ONLY') AND 
+(STP_Enrolment_Record_Type.RecordStatus IS NULL) AND
+(LEFT(STP_Enrolment.PSI_CIP_CODE, 2) IN ('21', '32','33', '34', '35', '36', '37', '53', '89'));"
+
+
+# ---- qry03k_Update_ID_for_Drop_Dev_Credential_CIP ----
+qry03k_Update_ID_for_Drop_Dev_Credential_CIP <- "
+UPDATE  Drop_Developmental_CIPS
+SET     ID = STP_Enrolment.ID
+FROM    Drop_Developmental_CIPS 
+INNER JOIN STP_Enrolment 
+  ON    Drop_Developmental_CIPS.ENCRYPTED_TRUE_PEN = STP_Enrolment.ENCRYPTED_TRUE_PEN;"
+
+
+# ---- qry03l_Update_Developmental_CIPs ----
+qry03l_Update_Developmental_CIPs <- "
+UPDATE  STP_Enrolment_Record_Type
+SET     RecordStatus = 7
+FROM    STP_Enrolment_Record_Type 
+INNER JOIN Drop_Developmental_CIPS 
+  ON    STP_Enrolment_Record_Type.ID = Drop_Developmental_CIPS.ID
+WHERE   STP_Enrolment_Record_Type.RecordStatus IS NULL 
+  AND   Drop_Developmental_CIPS.DO_NOT_EXCLUDE IS Null;"
+
+
+# ---- qry04a_Drop_No_PSI_Transition ----
+qry04a_Drop_No_PSI_Transition <- "
+SELECT  ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_ENTRY_STATUS
+INTO    Drop_No_Transition
+FROM    STP_Enrolment
+WHERE   PSI_ENTRY_STATUS = 'No Transition';"
+
+
+# ---- qry04b_Update_Drop_No_PSI_Transition ----
+qry04b_Update_Drop_No_PSI_Transition <- "
+UPDATE  STP_Enrolment_Record_Type
+SET     RecordStatus = 3
+FROM    STP_Enrolment_Record_Type
+INNER JOIN Drop_No_Transition 
+  ON    STP_Enrolment_Record_Type.ID = Drop_No_Transition.ID
+WHERE   STP_Enrolment_Record_Type.RecordStatus is NULL;"
+
+
+# ---- qry05a_Drop_Credential_Only ----
+qry05a_Drop_Credential_Only <- "
+SELECT ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_ENTRY_STATUS, PSI_MIN_START_DATE, CREDENTIAL_AWARD_DATE
+INTO Drop_Credential_Only
+FROM STP_Enrolment
+WHERE (PSI_MIN_START_DATE IN('',' ','(Unspecified)'))
+  AND (PSI_ENTRY_STATUS IN('',' ','(Unspecified)')) 
+  AND (CREDENTIAL_AWARD_DATE NOT IN('',' ','(Unspecified)'));"
+
+
+# ---- qry05b_Update_Drop_Credential_Only ----
+qry05b_Update_Drop_Credential_Only <- "
+UPDATE  STP_Enrolment_Record_Type
+SET     RecordStatus = 4
+FROM    STP_Enrolment_Record_Type INNER JOIN
+        Drop_Credential_Only ON STP_Enrolment_Record_Type.ID = Drop_Credential_Only.ID
+WHERE   STP_Enrolment_Record_Type.RecordStatus is NULL;"
+
+
+# ---- qry06a_Drop_PSI_Outside_BC ----
+qry06a_Drop_PSI_Outside_BC <- "
+SELECT  ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, ATTENDING_PSI_OUTSIDE_BC
+INTO    Drop_PSI_Outside_BC
+FROM    STP_Enrolment
+WHERE   ATTENDING_PSI_OUTSIDE_BC = 'Y';"
+
+
+# ---- qry06b_Update_Drop_PSI_Outside_BC ----
+qry06b_Update_Drop_PSI_Outside_BC <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       RecordStatus = 5
+FROM      STP_Enrolment_Record_Type INNER JOIN
+          Drop_PSI_Outside_BC ON STP_Enrolment_Record_Type.ID = Drop_PSI_Outside_BC.ID
+WHERE STP_Enrolment_Record_Type.RecordStatus is NULL;"
+
+# ---- qry07_Update_RecordStatus_No_Dropped ----
+qry07_Update_RecordStatus_No_Dropped <- "
+UPDATE  STP_Enrolment_Record_Type 
+SET     STP_Enrolment_Record_Type.RecordStatus = 0
+WHERE   STP_Enrolment_Record_Type.RecordStatus Is Null;"
+
+
+# ---- qry08a_Create_Table_STP_Enrolment_Valid ----
+qry08a_Create_Table_STP_Enrolment_Valid <- "
+SELECT  STP_Enrolment.ID, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_SCHOOL_YEAR, 
+        STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment.PSI_ENROLMENT_SEQUENCE, STP_Enrolment.PSI_CODE, 
+        STP_Enrolment.PSI_MIN_START_DATE
+INTO    STP_Enrolment_Valid
+FROM    STP_Enrolment
+INNER JOIN STP_Enrolment_Record_Type 
+        ON STP_Enrolment.ID = STP_Enrolment_Record_Type.ID
+WHERE     (STP_Enrolment_Record_Type.RecordStatus = 0);"
+
+
+# ---- qry08b_Fix_EPEN_in_STP_Enrolment_Valid ----
+qry08b_Fix_EPEN_in_STP_Enrolment_Valid <- "
+UPDATE    STP_Enrolment_Valid
+SET       ENCRYPTED_TRUE_PEN = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.EPEN_FIXED
+FROM      STP_Enrolment_Valid 
+INNER JOIN pssm2019.dbo.EPEN_ENRO_FIXES_2019_20
+  ON STP_Enrolment_Valid.ID = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.ID
+WHERE     pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.EPEN_FIXED_FLAG = 1;"
+
+
+# ---- qry08c_Fix_Enrol_Sequence_in_STP_Enrolment_Valid ----
+qry08c_Fix_Enrol_Sequence_in_STP_Enrolment_Valid <- "
+UPDATE    STP_Enrolment_Valid
+SET       PSI_ENROLMENT_SEQUENCE = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.PSI_ENROLMENT_SEQUENCE_FIX
+FROM      STP_Enrolment_Valid 
+INNER JOIN pssm2019.dbo.EPEN_ENRO_FIXES_2019_20
+  ON STP_Enrolment_Valid.ID = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.ID
+WHERE     pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.PSI_ENROLMENT_SEQUENCE_FIX <> 'NULL';"
+
+# ---- qry09a_MinEnrolmentPEN ----
+qry09a_MinEnrolmentPEN <- "
+SELECT    ENCRYPTED_TRUE_PEN, PSI_SCHOOL_YEAR, MIN(PSI_ENROLMENT_SEQUENCE) AS MinPSIEnrolmentSequence
+INTO      tmp_tbl_qry09a_MinEnrolmentPEN
+FROM      STP_Enrolment_Valid
+GROUP BY  ENCRYPTED_TRUE_PEN, PSI_SCHOOL_YEAR
+HAVING    ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)');"
+
+# ---- qry09b_MinEnrolmentPEN ----
+qry09b_MinEnrolmentPEN <- "
+SELECT    STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
+          STP_Enrolment_Valid.PSI_SCHOOL_YEAR, 
+          STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE, 
+          MIN(STP_Enrolment_Valid.ID) AS MinID
+INTO      tmp_tbl_qry09b_MinEnrolmentPEN
+FROM      tmp_tbl_qry09a_MinEnrolmentPEN
+INNER JOIN STP_Enrolment_Valid 
+  ON      tmp_tbl_qry09a_MinEnrolmentPEN.ENCRYPTED_TRUE_PEN = STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN 
+  AND     tmp_tbl_qry09a_MinEnrolmentPEN.PSI_SCHOOL_YEAR = STP_Enrolment_Valid.PSI_SCHOOL_YEAR 
+  AND     tmp_tbl_qry09a_MinEnrolmentPEN.MinPSIEnrolmentSequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
+GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
+
+# ---- qry09c_MinEnrolmentPEN ----
+qry09c_MinEnrolmentPEN <- "
+SELECT    MinID AS MinOfID
+INTO      MinEnrolment_ID_PEN
+FROM      tmp_tbl_qry09b_MinEnrolmentPEN;"
+
+# ---- qry10a_MinEnrolmentSTUID ----
+qry10a_MinEnrolmentSTUID <- "
+SELECT    PSI_STUDENT_NUMBER, PSI_CODE, PSI_SCHOOL_YEAR, MIN(PSI_ENROLMENT_SEQUENCE) AS MinPSIEnrolmentSequence, ENCRYPTED_TRUE_PEN
+INTO      tmp_tbl_qry10a_MinEnrolmentSTUID
+FROM      STP_Enrolment_Valid
+GROUP BY  PSI_STUDENT_NUMBER, PSI_CODE, PSI_SCHOOL_YEAR, ENCRYPTED_TRUE_PEN
+HAVING    ENCRYPTED_TRUE_PEN IN('',' ','(Unspecified)');"
+
+# ---- qry10b_MinEnrolmentSTUID ----
+qry10b_MinEnrolmentSTUID <- "
+SELECT    STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE , STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE, MIN(STP_Enrolment_Valid.ID) AS MinID
+INTO      tmp_tbl_qry10b_MinEnrolmentSTUID
+FROM      tmp_tbl_qry10a_MinEnrolmentSTUID 
+INNER JOIN STP_Enrolment_Valid 
+  ON tmp_tbl_qry10a_MinEnrolmentSTUID.PSI_STUDENT_NUMBER = STP_Enrolment_Valid.PSI_STUDENT_NUMBER 
+  AND tmp_tbl_qry10a_MinEnrolmentSTUID.PSI_SCHOOL_YEAR = STP_Enrolment_Valid.PSI_SCHOOL_YEAR 
+  AND tmp_tbl_qry10a_MinEnrolmentSTUID.PSI_CODE = STP_Enrolment_Valid.PSI_CODE 
+  AND tmp_tbl_qry10a_MinEnrolmentSTUID.MinPSIEnrolmentSequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
+GROUP BY STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
+
+# ---- qry10c_MinEnrolmentSTUID ----
+qry10c_MinEnrolmentSTUID <- "
+SELECT    MinID AS MinOfID
+INTO      MinEnrolment_ID_STUID
+FROM      tmp_tbl_qry10b_MinEnrolmentSTUID;"
+
+# ---- qry11a_Update_MinEnrolmentPEN ----
+qry11a_Update_MinEnrolmentPEN <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       MinEnrolment = 1
+FROM      MinEnrolment_ID_PEN 
+INNER JOIN STP_Enrolment_Record_Type 
+  ON MinEnrolment_ID_PEN.MinOfID = STP_Enrolment_Record_Type.ID;"
+
+# ---- qry11b_Update_MinEnrolmentSTUID ----
+qry11b_Update_MinEnrolmentSTUID <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       MinEnrolment = 1
+FROM      MinEnrolment_ID_STUID 
+INNER JOIN STP_Enrolment_Record_Type 
+  ON MinEnrolment_ID_STUID.MinOfID = STP_Enrolment_Record_Type.ID
+WHERE STP_Enrolment_Record_Type.MinEnrolment = 0
+  OR  STP_Enrolment_Record_Type.MinEnrolment IS NULL;"
+
+# ---- qry11c_Update_MinEnrolment_NA ----
+qry11c_Update_MinEnrolment_NA <- "
+UPDATE STP_Enrolment_Record_Type 
+SET STP_Enrolment_Record_Type.MinEnrolment = 0
+WHERE (((STP_Enrolment_Record_Type.MinEnrolment) Is Null));"
+
+# ---- qry12a_FirstEnrolmentPEN ----
+qry12a_FirstEnrolmentPEN <- "
+SELECT    ENCRYPTED_TRUE_PEN, MIN(PSI_MIN_START_DATE) AS MIN_PSI_MIN_START_DATE
+INTO      tmp_tbl_qry12a_FirstEnrolmentPEN
+FROM      STP_Enrolment_Valid
+GROUP BY  ENCRYPTED_TRUE_PEN
+HAVING    ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)');"
+
+# ---- qry12b_FirstEnrolmentPEN ----
+qry12b_FirstEnrolmentPEN <- "
+SELECT    STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE, MIN(STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE) AS MinPSI_Enrolment_Sequence
+INTO      tmp_tbl_qry12b_FirstEnrolmentPEN
+FROM      tmp_tbl_qry12a_FirstEnrolmentPEN 
+INNER JOIN STP_Enrolment_Valid 
+  ON tmp_tbl_qry12a_FirstEnrolmentPEN.ENCRYPTED_TRUE_PEN = STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN 
+  AND tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE = STP_Enrolment_Valid.PSI_MIN_START_DATE
+GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE;"
+
+# ---- qry12c_FirstEnrolmentPEN ----
+qry12c_FirstEnrolmentPEN <- "
+SELECT    MIN(STP_Enrolment_Valid.ID) AS MinID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_MIN_START_DATE,  STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
+INTO      FirstEnrolment_ID_PEN
+FROM      tmp_tbl_qry12b_FirstEnrolmentPEN
+INNER JOIN STP_Enrolment_Valid 
+ON tmp_tbl_qry12b_FirstEnrolmentPEN.ENCRYPTED_TRUE_PEN = STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN 
+AND tmp_tbl_qry12b_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE = STP_Enrolment_Valid.PSI_MIN_START_DATE 
+AND tmp_tbl_qry12b_FirstEnrolmentPEN.MinPSI_Enrolment_Sequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
+GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_MIN_START_DATE, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
+
+
+# ---- qry13a_FirstEnrolmentSTUID ----
+qry13a_FirstEnrolmentSTUID <- "
+SELECT    PSI_STUDENT_NUMBER, PSI_CODE, MIN(PSI_MIN_START_DATE) AS Min_PSI_Min_Start_Date
+INTO      tmp_tbl_qry13a_FirstEnrolment_STUID
+FROM      STP_Enrolment_Valid
+WHERE     ENCRYPTED_TRUE_PEN IN('',' ','(Unspecified)')
+GROUP BY PSI_STUDENT_NUMBER, PSI_CODE;"
+
+# ---- qry13b_FirstEnrolmentSTUID ----
+qry13b_FirstEnrolmentSTUID <- "
+SELECT    STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date, 
+          MIN(STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE) AS Min_PSI_Enrolment_Sequence
+INTO      tmp_tbl_qry13b_FirstEnrolment_STUID
+FROM      tmp_tbl_qry13a_FirstEnrolment_STUID 
+INNER JOIN STP_Enrolment_Valid 
+  ON tmp_tbl_qry13a_FirstEnrolment_STUID.PSI_STUDENT_NUMBER = STP_Enrolment_Valid.PSI_STUDENT_NUMBER 
+  AND tmp_tbl_qry13a_FirstEnrolment_STUID.PSI_CODE = STP_Enrolment_Valid.PSI_CODE 
+  AND tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date = STP_Enrolment_Valid.PSI_MIN_START_DATE
+GROUP BY STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date;"
+
+# ---- qry13c_FirstEnrolmentSTUID ----
+qry13c_FirstEnrolmentSTUID <- "
+SELECT    MIN(STP_Enrolment_Valid.ID) AS MinID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE
+INTO      FirstEnrolment_ID_STUID
+FROM      tmp_tbl_qry13b_FirstEnrolment_STUID 
+INNER JOIN STP_Enrolment_Valid 
+  ON tmp_tbl_qry13b_FirstEnrolment_STUID.PSI_STUDENT_NUMBER = STP_Enrolment_Valid.PSI_STUDENT_NUMBER 
+  AND tmp_tbl_qry13b_FirstEnrolment_STUID.PSI_CODE = STP_Enrolment_Valid.PSI_CODE 
+  AND tmp_tbl_qry13b_FirstEnrolment_STUID.Min_PSI_Enrolment_Sequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE 
+  AND tmp_tbl_qry13b_FirstEnrolment_STUID.Min_PSI_Min_Start_Date = STP_Enrolment_Valid.PSI_MIN_START_DATE
+GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE;"
+
+# ---- qry14a_Update_FirstEnrolmentPEN ----
+qry14a_Update_FirstEnrolmentPEN <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       FirstEnrolment = 1
+FROM      FirstEnrolment_ID_PEN 
+INNER JOIN STP_Enrolment_Record_Type 
+  ON FirstEnrolment_ID_PEN.MinID = STP_Enrolment_Record_Type.ID
+WHERE     STP_Enrolment_Record_Type.FirstEnrolment IS NULL
+    OR    STP_Enrolment_Record_Type.FirstEnrolment = 0;"
+
+# ---- qry14b_Update_FirstEnrolmentSTUID ----
+qry14b_Update_FirstEnrolmentSTUID <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       FirstEnrolment = 1
+FROM      STP_Enrolment_Record_Type 
+INNER JOIN FirstEnrolment_ID_STUID 
+  ON STP_Enrolment_Record_Type.ID = FirstEnrolment_ID_STUID.MinID
+WHERE STP_Enrolment_Record_Type.FirstEnrolment IS NULL;"
+
+# ---- qry14c_Update_FirstEnrolmentNA ----
+qry14c_Update_FirstEnrolmentNA <- "
+UPDATE    STP_Enrolment_Record_Type
+SET       FirstEnrolment = 0
+WHERE     FirstEnrolment IS NULL;"
+
+# ---- RecordTypeSummary ----
+RecordTypeSummary <-
+  "SELECT RecordStatus, COUNT(*) AS Expr1
+FROM  STP_Enrolment_Record_Type
+GROUP BY RecordStatus
+"
+
+# ---- CheckSkillsBased ---
+CheckSkillsBased <-
+  "SELECT PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
+FROM  Drop_Skills_Based
+GROUP BY PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY;"
+
+
+##################################################################################################
+# ---- qrydates_create_tmp_table ----
+qrydates_create_tmp_table <- "
+SELECT ID, 
+       PSI_BIRTHDATE, 
+       LAST_SEEN_BIRTHDATE, 
+       PSI_MIN_START_DATE, 
+       PSI_PROGRAM_EFFECTIVE_DATE
+  INTO tmp_ConvertDateFormat
+  FROM STP_Enrolment;"
+
+# ---- qrydates_add_cols ----
+qrydates_add_cols <- "
+ALTER TABLE tmp_ConvertDateFormat
+  ADD PSI_BIRTHDATE_convert varchar(50), 
+      LAST_SEEN_BIRTHDATE_convert varchar(50),
+      PSI_MIN_START_DATE_convert varchar(50),
+      PSI_PROGRAM_EFFECTIVE_DATE_convert varchar(50);"
+
+# ---- qrydates_convert1 ----
+qrydates_convert1 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_BIRTHDATE_CONVERT = '20'+PSI_BIRTHDATE
+WHERE ((Left(PSI_BIRTHDATE,2)<24));"
+
+# ---- qrydates_convert2 ----
+qrydates_convert2 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_BIRTHDATE_CONVERT = '19'+PSI_BIRTHDATE
+WHERE ((Left(PSI_BIRTHDATE,2)>23));"
+
+# ---- qrydates_convert3 ----
+qrydates_convert3 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_BIRTHDATE_CONVERT = ''
+WHERE ((Left(PSI_BIRTHDATE,2)='  '));"
+
+# ---- qrydates_convert4 ----
+qrydates_convert4 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.LAST_SEEN_BIRTHDATE_CONVERT = '20'+LAST_SEEN_BIRTHDATE
+WHERE ((Left(LAST_SEEN_BIRTHDATE,2)<24));"
+
+# ---- qrydates_convert5 ----
+qrydates_convert5 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.LAST_SEEN_BIRTHDATE_CONVERT = '19'+LAST_SEEN_BIRTHDATE
+WHERE ((Left(LAST_SEEN_BIRTHDATE,2)>23));"
+
+# ---- qrydates_convert6 ----
+qrydates_convert6 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.LAST_SEEN_BIRTHDATE_CONVERT = ''
+WHERE ((Left(LAST_SEEN_BIRTHDATE,2)='  '));"
+
+# ---- qrydates_convert7 ----
+qrydates_convert7 <- "UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_MIN_START_DATE_CONVERT = '20'+PSI_MIN_START_DATE
+WHERE ((Left(PSI_MIN_START_DATE,2)<24));"
+
+# ---- qrydates_convert8 ----
+qrydates_convert8 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_MIN_START_DATE_CONVERT = '19'+PSI_MIN_START_DATE
+WHERE ((Left(PSI_MIN_START_DATE,2)>23));"
+
+# ---- qrydates_convert9 ----
+qrydates_convert9 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_MIN_START_DATE_CONVERT = ''
+WHERE ((Left(PSI_MIN_START_DATE,2)='  '));"
+
+# ---- qrydates_convert10 ----
+qrydates_convert10 <- "UPDATE Tmp_ConvertDateFormat SET Tmp_ConvertDateFormat.PSI_PROGRAM_EFFECTIVE_DATE_CONVERT = '20'+PSI_PROGRAM_EFFECTIVE_DATE
+WHERE ((Left(PSI_PROGRAM_EFFECTIVE_DATE,2)<24));"
+
+# ---- qrydates_convert11 ----
+qrydates_convert11 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_PROGRAM_EFFECTIVE_DATE_CONVERT = '19'+PSI_PROGRAM_EFFECTIVE_DATE
+WHERE ((Left(PSI_PROGRAM_EFFECTIVE_DATE,2)>23));"
+
+# ---- qrydates_convert12 ----
+qrydates_convert12 <- "
+UPDATE Tmp_ConvertDateFormat 
+SET Tmp_ConvertDateFormat.PSI_PROGRAM_EFFECTIVE_DATE_CONVERT = ''
+WHERE ((Left(PSI_PROGRAM_EFFECTIVE_DATE,2)='  '));"
+
+# ---- qrydates_update1 ----
+qrydates_update1 <- "
+UPDATE STP_Enrolment
+SET STP_Enrolment.PSI_BIRTHDATE = tmp_ConvertDateFormat.PSI_BIRTHDATE_CONVERT
+FROM tmp_ConvertDateFormat, STP_Enrolment
+WHERE STP_Enrolment.ID = tmp_ConvertDateFormat.ID;"
+
+# ---- qrydates_update2 ----
+qrydates_update2 <- "
+UPDATE STP_Enrolment
+SET STP_Enrolment.LAST_SEEN_BIRTHDATE = tmp_ConvertDateFormat.LAST_SEEN_BIRTHDATE_CONVERT
+FROM tmp_ConvertDateFormat, STP_Enrolment
+WHERE STP_Enrolment.ID = tmp_ConvertDateFormat.ID;"
+
+# ---- qrydates_update3 ----
+qrydates_update3 <- "
+UPDATE STP_Enrolment
+SET STP_Enrolment.PSI_MIN_START_DATE = tmp_ConvertDateFormat.PSI_MIN_START_DATE_CONVERT
+FROM tmp_ConvertDateFormat, STP_Enrolment
+WHERE STP_Enrolment.ID = tmp_ConvertDateFormat.ID;"
+
+# ---- qrydates_update4 ----
+qrydates_update4 <- "
+UPDATE STP_Enrolment
+SET STP_Enrolment.PSI_PROGRAM_EFFECTIVE_DATE = tmp_ConvertDateFormat.PSI_PROGRAM_EFFECTIVE_DATE_CONVERT
+FROM tmp_ConvertDateFormat, STP_Enrolment
+WHERE STP_Enrolment.ID = tmp_ConvertDateFormat.ID;"
+###################################################################################
+
+# ---- ----
+qry01_BirthdateCleaning <- "
+SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE, count(*) as NumBirthdateRecords
+INTO        tmp_BirthDate
+FROM        STP_Enrolment
+GROUP BY    ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE"
+
+# ---- ----
+qry02_BirthdateCleaning <- "
+SELECT     ENCRYPTED_TRUE_PEN, COUNT(*) AS N_Birthdates
+INTO        tmp_MoreThanOne_Birthdate
+FROM        tmp_BirthDate
+WHERE       PSI_BIRTHDATE NOT IN('',' ', '(Unspecified)') 
+  AND       ENCRYPTED_TRUE_PEN NOT IN('',' ', '(Unspecified)')
+GROUP BY    ENCRYPTED_TRUE_PEN
+HAVING      COUNT(*) > 1"
+
+# ---- ----
+qry03_BirthdateCleaning <-
+  "SELECT     ENCRYPTED_TRUE_PEN, MIN(PSI_BIRTHDATE) AS MinPSIBirthdate
+INTO        tmp_MinPSIBirthdate
+FROM        tmp_BirthDate
+WHERE       PSI_BIRTHDATE NOT IN('',' ', '(Unspecified)')
+GROUP BY    ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry04_BirthdateCleaning <- "
+SELECT     ENCRYPTED_TRUE_PEN, MAX(PSI_BIRTHDATE) AS MaxPSIBirthdate
+INTO        tmp_MaxPSIBirthdate
+FROM        tmp_BirthDate
+WHERE       PSI_BIRTHDATE NOT IN('',' ', '(Unspecified)')
+AND         ENCRYPTED_TRUE_PEN NOT IN('',' ', '(Unspecified)')
+GROUP BY    ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry05_BirthdateCleaning <-
+  "UPDATE       tmp_MinPSIBirthdate
+SET           NumBirthdateRecords = tmp_BirthDate.NumBirthdateRecords
+FROM          tmp_MinPSIBirthdate 
+INNER JOIN    tmp_BirthDate 
+  ON          tmp_MinPSIBirthdate.ENCRYPTED_TRUE_PEN = tmp_BirthDate.ENCRYPTED_TRUE_PEN 
+  AND         tmp_MinPSIBirthdate.MinPSIBirthdate = tmp_BirthDate.PSI_BIRTHDATE"
+
+# ---- ----
+qry06_BirthdateCleaning <- "
+UPDATE        tmp_MaxPSIBirthdate
+SET           NumBirthdateRecords = tmp_BirthDate.NumBirthdateRecords
+FROM          tmp_MaxPSIBirthdate 
+INNER JOIN    tmp_BirthDate 
+  ON          tmp_MaxPSIBirthdate.ENCRYPTED_TRUE_PEN = tmp_BirthDate.ENCRYPTED_TRUE_PEN 
+  AND         tmp_MaxPSIBirthdate.MaxPSIBirthdate = tmp_BirthDate.PSI_BIRTHDATE"
+
+# ---- ----
+qry07a_BirthdateCleaning <- "
+UPDATE        tmp_MoreThanOne_Birthdate
+SET           MinPSIBirthdate = tmp_MinPSIBirthdate.MinPSIBirthdate, 
+              NumMinBirthdateRecords = tmp_MinPSIBirthdate.NumBirthdateRecords
+FROM          tmp_MoreThanOne_Birthdate 
+INNER JOIN    tmp_MinPSIBirthdate 
+  ON          tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN = tmp_MinPSIBirthdate.ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry07b_BirthdateCleaning <- "
+UPDATE        tmp_MoreThanOne_Birthdate
+SET           MaxPSIBirthdate = tmp_MaxPSIBirthdate.MaxPSIBirthdate, 
+              NumMaxBirthdateRecords = tmp_MaxPSIBirthdate.NumBirthdateRecords
+FROM          tmp_MoreThanOne_Birthdate 
+INNER JOIN    tmp_MaxPSIBirthdate 
+  ON          tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN = tmp_MaxPSIBirthdate.ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry08_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
+SET           LastSeenBirthdate = STP_Enrolment.LAST_SEEN_BIRTHDATE
+FROM          tmp_MoreThanOne_Birthdate 
+INNER JOIN    STP_Enrolment 
+ON            tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN = STP_Enrolment.ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry09_BirthdateCleaning <- "
+UPDATE      tmp_MoreThanOne_Birthdate
+SET         UseMaxOrMin_FINAL = CASE 
+              WHEN MaxPSIBirthdate = LastSeenBirthdate THEN 'MAX'
+              WHEN NumMaxBirthdateRecords > NumMinBirthdateRecords THEN 'MAX'
+              WHEN NumMaxBirthdateRecords < NumMinBirthdateRecords THEN 'MIN'
+              ELSE 'MIN' END
+FROM        tmp_MoreThanOne_Birthdate"
+
+# ---- ----
+qry10_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
+SET                psi_birthdate_cleaned = MinPSIBirthdate
+WHERE        (USEMAXORMIN_FINAL = 'MIN')"
+
+# ---- ----
+qry11_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
+SET                psi_birthdate_cleaned = MaxPSIBirthdate
+WHERE        (USEMAXORMIN_FINAL = 'MAX')"
+
+# ---- ----
+qry12_BirthdateCleaning <-
+  "UPDATE    STP_Enrolment
+SET              psi_birthdate_cleaned = tmp_MoreThanOne_Birthdate.psi_birthdate_cleaned
+FROM         STP_Enrolment INNER JOIN
+                      tmp_MoreThanOne_Birthdate ON STP_Enrolment.ENCRYPTED_TRUE_PEN = tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN"
+# ---- ----
+qry13_BirthdateCleaning <-
+  "SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
+ INTO            tmp_NullBirthdate
+ FROM         tmp_BirthDate
+ GROUP BY ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
+HAVING      (ENCRYPTED_TRUE_PEN NOT IN('',' ', '(Unspecified)')) AND (PSI_BIRTHDATE IN('', ' ', '(Unspecified)'))"
+
+# ---- ----
+qry14_BirthdateCleaning <- "
+ SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
+ INTO        tmp_NonNullBirthdate
+ FROM       tmp_BirthDate
+ GROUP BY ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
+HAVING      (ENCRYPTED_TRUE_PEN NOT IN('', ' ', '(Unspecified)')) AND (PSI_BIRTHDATE NOT IN('',' ', '(Unspecified)'))"
+
+# ---- ----
+qry15_BirthdateCleaning <-
+  "SELECT     tmp_NonNullBirthdate.ENCRYPTED_TRUE_PEN, tmp_NonNullBirthdate.PSI_BIRTHDATE
+INTO        tmp_NullBirthdateCleaned
+FROM        tmp_NonNullBirthdate 
+INNER JOIN  tmp_NullBirthdate 
+  ON tmp_NonNullBirthdate.ENCRYPTED_TRUE_PEN = tmp_NullBirthdate.ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry16_BirthdateCleaning <- "
+UPDATE    tmp_NullBirthdateCleaned
+SET       psi_birthdate_cleaned = tmp_MoreThanOne_Birthdate.psi_birthdate_cleaned
+FROM      tmp_NullBirthdateCleaned 
+INNER JOIN tmp_MoreThanOne_Birthdate 
+ON tmp_NullBirthdateCleaned.ENCRYPTED_TRUE_PEN = tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN"
+
+# ---- ----
+qry17_BirthdateCleaning <-
+  "UPDATE    tmp_NullBirthdateCleaned
+SET              psi_birthdate_cleaned = PSI_BIRTHDATE
+WHERE     (psi_birthdate_cleaned IS NULL)"
+
+# ---- ----
+qry18_BirthdateCleaning <- "
+UPDATE    STP_Enrolment
+SET       psi_birthdate_cleaned = tmp_NullBirthdateCleaned.psi_birthdate_cleaned
+FROM      STP_Enrolment 
+INNER JOIN  tmp_NullBirthdateCleaned 
+  ON STP_Enrolment.ENCRYPTED_TRUE_PEN = tmp_NullBirthdateCleaned.ENCRYPTED_TRUE_PEN
+WHERE     (STP_Enrolment.psi_birthdate_cleaned IS NULL) 
+OR        (STP_Enrolment.psi_birthdate_cleaned IN('', ' ', '(Unspecified)'))"
+
+# ---- ----
+qry19_BirthdateCleaning <-
+  "UPDATE    STP_Enrolment
+ SET         psi_birthdate_cleaned = PSI_BIRTHDATE
+WHERE       ((psi_birthdate_cleaned IS NULL) AND (NOT (PSI_BIRTHDATE IS NULL)))
+OR          ((psi_birthdate_cleaned IN( '',' ', '(Unspecified)'))   AND (NOT (PSI_BIRTHDATE IS NULL)))
+OR          ((psi_birthdate_cleaned IS NULL) AND (PSI_BIRTHDATE NOT IN( '',' ', '(Unspecified)'))) 
+OR          ((psi_birthdate_cleaned IN( '',' ', '(Unspecified)'))   AND (PSI_BIRTHDATE NOT IN( '',' ', '(Unspecified)')))"
+
+
+# ---- ----
+qry20_BirthdateCleaning <-
+  "SELECT     PSI_STUDENT_NUMBER, PSI_BIRTHDATE, psi_birthdate_cleaned, PSI_CODE, COUNT(*) AS Expr1
+INTO            tmp_TEST_multi_birthdate
+FROM         STP_Enrolment
+WHERE     (ENCRYPTED_TRUE_PEN IN( ' ', '(Unspecified)'))
+GROUP BY PSI_STUDENT_NUMBER, PSI_BIRTHDATE, psi_birthdate_cleaned, PSI_CODE
+HAVING      (PSI_BIRTHDATE NOT IN( '',' ', '(Unspecified)')) AND (PSI_STUDENT_NUMBER NOT IN( '',' ', '(Unspecified)')) AND (PSI_CODE NOT IN( '',' ', '(Unspecified)'))"
+
+# ---- ----
+qry21_BirthdateCleaning <-
+  "SELECT     PSI_STUDENT_NUMBER, PSI_CODE, COUNT(*) AS Expr1
+FROM         tmp_TEST_multi_birthdate
+GROUP BY    PSI_STUDENT_NUMBER, PSI_CODE
+HAVING      (COUNT(*) > 1)"
+
+
+###################################################################################
+# ---- qry01a_MinEnrolmentSupVar ----
+qry01a_MinEnrolmentSupVar <- "
+SELECT    STP_Enrolment.ID, STP_Enrolment.psi_birthdate_cleaned, STP_Enrolment.PSI_MIN_START_DATE, 
+          STP_Enrolment_Record_Type.MinEnrolment, STP_Enrolment_Record_Type.FirstEnrolment, STP_Enrolment_Record_Type.RecordStatus
+INTO      MinEnrolmentSupVar
+FROM      STP_Enrolment 
+INNER JOIN STP_Enrolment_Record_Type 
+  ON      STP_Enrolment.ID = STP_Enrolment_Record_Type.ID;"
+
+
+# ---- qry01b_MinEnrolmentSupVar ----
+qry01b_MinEnrolmentSupVar <- "ALTER TABLE MinEnrolmentSupVar 
+ADD
+	psi_birthdate_cleaned_D date NULL,
+	PSI_MIN_START_DATE_D date NULL,
+	AGE_AT_ENROL_DATE numeric(18, 0) NULL,
+	AGE_GROUP_ENROL_DATE numeric(18, 0) NULL,
+	AGE_AT_CENSUS_2016 numeric(18, 0) NULL,
+	AGE_GROUP_CENSUS_2016 numeric(18, 0) NULL,
+	IS_FIRST_ENROLMENT varchar(255) NULL,
+	IS_SKILLS_BASED int NULL;"
+
+
+# ---- qry01c_MinEnrolmentSupVar ----
+qry01c_MinEnrolmentSupVar <- "
+UPDATE    MinEnrolmentSupvar
+SET       psi_birthdate_cleaned_D = psi_birthdate_cleaned
+WHERE     psi_birthdate_cleaned is not null;"
+
+
+# ---- qry01d_MinEnrolmentSupVar ---- ---
+qry01d1_MinEnrolmentSupVar <- "
+UPDATE MinEnrolmentSupvar
+SET    PSI_MIN_START_DATE_D = PSI_MIN_START_DATE
+WHERE     (PSI_MIN_START_DATE <> '' AND PSI_MIN_START_DATE <> '(Unspecified)';"
+
+# ---- qry01d_MinEnrolmentSupVar ----
+qry01d2_MinEnrolmentSupVar <- "
+UPDATE      MinEnrolmentSupVar
+SET         psi_birthdate_cleaned_D = NULL
+WHERE       psi_birthdate_cleaned_D = CONVERT(DATETIME, '1900-01-01 00:00:00', 102)
+  AND       (
+              psi_birthdate_cleaned IS NULL 
+              OR psi_birthdate_cleaned = '' 
+              OR psi_birthdate_cleaned = '(Unspecified)'
+);"
+
+
+# ---- qry01e_MinEnrolmentSupVar ----
+qry01e_MinEnrolmentSupVar <- "
+UPDATE    MinEnrolmentSupVar
+SET       IS_FIRST_ENROLMENT = 'Yes'
+WHERE     FirstEnrolment = 1;"
+
+
+# ---- qry02a_UpdateAgeAtEnrol ----
+qry02a_UpdateAgeAtEnrol <- "
+UPDATE    MinEnrolment
+SET       AGE_AT_ENROL_DATE = 
+            CASE WHEN dateadd(year, datediff (year, psi_birthdate_cleaned_D, PSI_MIN_START_DATE_D), psi_birthdate_cleaned_D) > PSI_MIN_START_DATE_D
+		             THEN datediff (year, psi_birthdate_cleaned_D, PSI_MIN_START_DATE_D) - 1
+		             ELSE datediff (year, psi_birthdate_cleaned_D, PSI_MIN_START_DATE_D)
+		        END
+WHERE     psi_birthdate_cleaned_D IS NOT NULL
+;"
+
+
+# ---- qry02b_UpdateAGAtEnrol ----
+qry02b_UpdateAGAtEnrol <- "
+UPDATE    MinEnrolment
+SET       AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+FROM      MinEnrolment 
+CROSS JOIN AgeGroupLookup
+WHERE     AgeGroupLookup.LowerBound <= MinEnrolment.AGE_AT_ENROL_DATE
+  AND     AgeGroupLookup.UpperBound >= MinEnrolment.AGE_AT_ENROL_DATE;"
+
+
+# ---- qry04a*_UpdateMinEnrolment_Gender ----
+qry04a1_UpdateMinEnrolment_Gender <- "
+UPDATE      MinEnrolment
+SET         PSI_GENDER = Credential.PSI_GENDER_CLEANED
+FROM        MinEnrolment 
+INNER JOIN  Credential
+  ON        MinEnrolment.ENCRYPTED_TRUE_PEN = Credential.ENCRYPTED_TRUE_PEN 
+  AND       MinEnrolment.PSI_GENDER <> Credential.PSI_GENDER_CLEANED
+WHERE       MinEnrolment.ENCRYPTED_TRUE_PEN <> ''
+  AND       MinEnrolment.ENCRYPTED_TRUE_PEN IS NOT NULL
+  AND       MinEnrolment.ENCRYPTED_TRUE_PEN <> '(Unspecified)'
+;"
+
+qry04a2_UpdateMinEnrolment_Gender <- "
+UPDATE      MinEnrolment
+SET         PSI_GENDER = Credential.psi_gender_cleaned
+FROM        MinEnrolment 
+INNER JOIN  Credential 
+  ON        MinEnrolment.PSI_STUDENT_NUMBER = Credential.PSI_STUDENT_NUMBER 
+  AND       MinEnrolment.PSI_CODE = Credential.PSI_CODE 
+  AND       MinEnrolment.PSI_GENDER <> Credential.psi_gender_cleaned
+WHERE       MinEnrolment.ENCRYPTED_TRUE_PEN IS NULL
+  OR        MinEnrolment.ENCRYPTED_TRUE_PEN = ''
+  OR        MinEnrolment.ENCRYPTED_TRUE_PEN = '(Unspecified)'
+;"
+
+
+# ---- qry04b*_tmp_MinEnrolment_Gender ----
+qry04b1_tmp_MinEnrolment_Gender <- "
+SELECT    DISTINCT PSI_GENDER, ENCRYPTED_TRUE_PEN
+INTO      tmp_MinEnrolment_EPEN_Gender_step1
+FROM      MinEnrolment
+WHERE     ENCRYPTED_TRUE_PEN <> '' 
+AND       ENCRYPTED_TRUE_PEN IS NOT NULL
+AND       ENCRYPTED_TRUE_PEN <> '(Unspecified)'
+;"
+
+qry04b2_tmp_MinEnrolment_Gender <- "
+SELECT    DISTINCT PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE
+INTO      tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1
+FROM      MinEnrolment
+WHERE     ENCRYPTED_TRUE_PEN = '' 
+OR        ENCRYPTED_TRUE_PEN IS NULL
+OR        ENCRYPTED_TRUE_PEN = '(Unspecified)'
+;"
+
+# Make a new table called tmp_MinEnrolment_EPEN_Gender and append the tmp_MinEnrolment_EPEN_Gender_step1 records to it. */
+qry04b3_tmp_MinEnrolment_Gender <- "
+SELECT  tmp_MinEnrolment_EPEN_Gender_step1.* 
+INTO    tmp_MinEnrolment_EPEN_Gender
+FROM    tmp_MinEnrolment_EPEN_Gender_step1;"
+
+# In the tmp_MinEnrolment_EPEN_Gender add cols for PSI_STUDENT_NUMBER, PSI_CODE and CONCATENATED_ID */
+qry04b4_tmp_MinEnrolment_Gender <- "
+ALTER TABLE tmp_MinEnrolment_EPEN_Gender
+  ADD   PSI_STUDENT_NUMBER varchar(50), 
+        PSI_CODE varchar(50),
+        CONCATENATED_ID varchar(50);"
+
+# Append the tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1 records to the tmp_MinEnrolment_EPEN_Gender */
+qry04b5_tmp_MinEnrolment_Gender <- "
+INSERT INTO tmp_MinEnrolment_EPEN_Gender (PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE)
+SELECT      PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE 
+FROM        tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1;"
+
+qry04b6_tmp_MinEnrolment_Gender <- "
+UPDATE      tmp_MinEnrolment_EPEN_Gender
+SET         CONCATENATED_ID = ENCRYPTED_TRUE_PEN
+WHERE       ENCRYPTED_TRUE_PEN IS NOT NULL
+AND         ENCRYPTED_TRUE_PEN <> ''
+AND         ENCRYPTED_TRUE_PEN <> '(Unspecified)'
+;"
+
+qry04b7_tmp_MinEnrolment_Gender <- "
+UPDATE      tmp_MinEnrolment_EPEN_Gender
+SET         CONCATENATED_ID = PSI_STUDENT_NUMBER + PSI_CODE
+WHERE       (ENCRYPTED_TRUE_PEN IS NULL) 
+OR          (ENCRYPTED_TRUE_PEN = '')
+OR          (ENCRYPTED_TRUE_PEN = '(Unspecified)')
+;"
+
+# ---- qry04c_tmp_MinEnrolment_GenderDups ----
+qry04c_tmp_MinEnrolment_GenderDups <- "
+SELECT     CONCATENATED_ID, COUNT(*) AS Expr1
+INTO       tmp_Dup_MinEnrolment_EPEN_Gender
+FROM       tmp_MinEnrolment_EPEN_Gender
+GROUP BY CONCATENATED_ID
+HAVING      (COUNT(*) > 1);
+
+ALTER TABLE tmp_Dup_MinEnrolment_EPEN_Gender
+ADD PSI_GENDER_FirstEnrolment varchar(50);
+;"
+
+# ---- qry04d*_tmp_MinEnrolment_GenderDups_PickGender ----
+qry04d1_tmp_MinEnrolment_GenderDups_PickGender <- "
+UPDATE    tmp_Dup_MinEnrolment_EPEN_Gender
+SET       PSI_GENDER_FirstEnrolment = MinEnrolment.PSI_GENDER
+FROM      tmp_Dup_MinEnrolment_EPEN_Gender 
+INNER JOIN MinEnrolment 
+ON        tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = MinEnrolment.ENCRYPTED_TRUE_PEN
+WHERE     (MinEnrolment.IS_FIRST_ENROLMENT = 'Yes');"
+
+
+qry04d2_tmp_MinEnrolment_GenderDups_PickGender <- "
+UPDATE    tmp_Dup_MinEnrolment_EPEN_Gender
+SET              PSI_GENDER_FirstEnrolment = MinEnrolment.PSI_GENDER
+FROM         tmp_Dup_MinEnrolment_EPEN_Gender 
+INNER JOIN MinEnrolment 
+ON tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = (MinEnrolment.PSI_STUDENT_NUMBER+MinEnrolment.PSI_CODE)
+WHERE     (MinEnrolment.IS_FIRST_ENROLMENT = 'Yes');"
+
+# Select records with 'U' to tmp table
+qry04d3_tmp_MinEnrolment_GenderDups_PickGender <- "
+SELECT *   
+INTO  tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
+FROM         tmp_Dup_MinEnrolment_EPEN_Gender
+WHERE PSI_GENDER_FirstEnrolment <> 'Male' 
+AND PSI_GENDER_FirstEnrolment <> 'Female'
+AND PSI_GENDER_FirstEnrolment <> 'Gender Diverse'
+"
+
+# Alter table to add other gender variable
+qry04d4_tmp_MinEnrolment_GenderDups_PickGender <- "
+ALTER TABLE tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
+ADD PSI_GENDER_FinalUnknowns VARCHAR(50)"
+
+# Update new gender variable with gender <> 'U'
+qry04d5_tmp_MinEnrolment_GenderDups_PickGender <- "
+UPDATE       tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
+SET                PSI_GENDER_FinalUnknowns = tmp_MinEnrolment_EPEN_Gender.psi_gender
+FROM            tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns 
+INNER JOIN      tmp_MinEnrolment_EPEN_Gender 
+ON tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.CONCATENATED_ID = tmp_MinEnrolment_EPEN_Gender.CONCATENATED_ID
+WHERE        tmp_MinEnrolment_EPEN_Gender.psi_gender <> 'Unknown'"
+
+# Update original table with non-U gender
+qry04d6_tmp_MinEnrolment_GenderDups_PickGender <- "
+UPDATE       tmp_Dup_MinEnrolment_EPEN_Gender
+SET                PSI_GENDER_FirstEnrolment = tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.PSI_GENDER_FinalUnknowns
+FROM            tmp_Dup_MinEnrolment_EPEN_Gender
+INNER JOIN      tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
+ON tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.CONCATENATED_ID"
+
+
+# ---- qry04e_UpdateMinEnrolment_EPEN_GenderDups ----
+qry04e1_UpdateMinEnrolment_EPEN_GenderDups <- "
+UPDATE       MinEnrolment
+SET          PSI_GENDER = tmp_Dup_MinEnrolment_EPEN_Gender.PSI_GENDER_FirstEnrolment
+FROM         MinEnrolment 
+INNER JOIN   tmp_Dup_MinEnrolment_EPEN_Gender 
+ON           tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = MinEnrolment.ENCRYPTED_TRUE_PEN;"
+
+qry04e2_UpdateMinEnrolment_EPEN_GenderDups <- "
+UPDATE       MinEnrolment
+SET          PSI_GENDER = tmp_Dup_MinEnrolment_EPEN_Gender.PSI_GENDER_FirstEnrolment
+FROM         MinEnrolment 
+INNER JOIN   tmp_Dup_MinEnrolment_EPEN_Gender 
+ON           tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = (MinEnrolment.PSI_STUDENT_NUMBER+MinEnrolment.PSI_CODE);"
+
+# ---- qry05a1_Extract_No_Gender ----
+qry05a1_Extract_No_Gender <- "
+SELECT    DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER 
+INTO      Extract_No_Gender
+FROM      MinEnrolment
+WHERE     PSI_GENDER='U' 
+OR        PSI_GENDER = 'Unknown'
+OR        PSI_GENDER = '(Unspecified)'
+OR        PSI_GENDER = '' 
+OR        PSI_GENDER IS NULL;"
+
+# ---- qry05a1_Extract_No_Gender_First_Enrolment ----
+qry05a1_Extract_No_Gender_First_Enrolment <- "
+SELECT    DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER 
+INTO      Extract_No_Gender_First_Enrolment
+FROM      MinEnrolment
+WHERE     (PSI_GENDER ='Unknown' OR PSI_GENDER = '(Unspecified)' OR PSI_GENDER ='' OR PSI_GENDER IS NULL) 
+AND       IS_FIRST_ENROLMENT='Yes';"
+
+# ---- qry05a2_Show_Gender_Distribution ----
+qry05a2_Show_Gender_Distribution <- "
+SELECT     PSI_GENDER, COUNT(*) AS NumEnrolled 
+FROM       MinEnrolment
+WHERE      PSI_GENDER <> 'Unknown' 
+  AND      PSI_GENDER <> '' 
+  AND      PSI_GENDER <> '(Unspecified)'
+  AND      PSI_GENDER IS NOT NULL 
+  AND      IS_FIRST_ENROLMENT='Yes'
+GROUP BY   PSI_GENDER;"
+
+# ---- qry06a1_Assign_TopID_Gender ----
+qry06a1_Assign_TopID_Gender <- "
+UPDATE    TOP (5429) Extract_No_Gender_First_Enrolment
+SET       PSI_GENDER = 'Female';"
+
+# ---- qry06a2_Assign_TopID_Gender2 ----
+qry06a2_Assign_TopID_Gender2 <- "
+UPDATE    TOP (5177) Extract_No_Gender_First_Enrolment
+SET       PSI_GENDER = 'Male'
+WHERE     PSI_GENDER = 'U' 
+    OR    PSI_GENDER = 'Unknown'
+    OR    PSI_GENDER ='(Unspecified)'
+    OR    PSI_GENDER='' 
+    OR    PSI_GENDER IS NULL;"
+
+# ---- qry06a2_Assign_TopID_Gender3 ----
+qry06a2_Assign_TopID_Gender3 <- "
+UPDATE    Extract_No_Gender_First_Enrolment
+SET       PSI_GENDER = 'Gender Diverse'
+WHERE     PSI_GENDER = 'U' 
+    OR    PSI_GENDER = 'Unknown'
+    OR    PSI_GENDER ='(Unspecified)'
+    OR    PSI_GENDER='' 
+    OR    PSI_GENDER IS NULL;"
+
+
+# ---- qry06a3*_CorrectGender1 ----
+qry06a3_CorrectGender1 <- "
+UPDATE    Extract_No_Gender
+SET       PSI_GENDER = Extract_No_Gender_First_Enrolment.PSI_GENDER
+FROM      Extract_No_Gender_First_Enrolment 
+INNER JOIN Extract_No_Gender 
+    ON    Extract_No_Gender_First_Enrolment.PSI_STUDENT_NUMBER = Extract_No_Gender.PSI_STUDENT_NUMBER 
+    AND   Extract_No_Gender_First_Enrolment.PSI_CODE = Extract_No_Gender.PSI_CODE;"
+
+qry06a3_CorrectGender2 <- "
+UPDATE    TOP (40) Extract_No_Gender
+SET       PSI_GENDER ='Female'
+WHERE     PSI_GENDER IS NULL 
+OR        PSI_GENDER = ' ' 
+OR        PSI_GENDER = 'U'
+OR        PSI_GENDER = 'Unknown'
+OR        PSI_GENDER = '(Unspecified)'
+"
+
+qry06a3_CorrectGender3 <- "
+UPDATE    TOP (39) Extract_No_Gender
+SET       PSI_GENDER ='Male'
+WHERE     PSI_GENDER IS NULL 
+OR        PSI_GENDER = ' ' 
+OR        PSI_GENDER = 'U'
+OR        PSI_GENDER = 'Unknown'
+OR        PSI_GENDER = '(Unspecified)'
+"
+
+qry06a3_CorrectGender4 <- "
+UPDATE    Extract_No_Gender
+SET       PSI_GENDER = 'Gender Diverse'
+WHERE     PSI_GENDER IS NULL 
+OR        PSI_GENDER = ' ' 
+OR        PSI_GENDER = 'U'
+OR        PSI_GENDER = 'Unknown'
+OR        PSI_GENDER = '(Unspecified)'
+"
+
+
+# ---- qry06a4a_ExtractNoGender_DupEPENS ----
+qry06a4a_ExtractNoGender_DupEPENS <- "
+SELECT    ENCRYPTED_TRUE_PEN, PSI_GENDER
+INTO      tmp_Extract_No_Gender_EPENS
+FROM      Extract_No_Gender
+WHERE     ENCRYPTED_TRUE_PEN <> '' 
+AND       ENCRYPTED_TRUE_PEN IS NOT NULL
+AND       ENCRYPTED_TRUE_PEN <> '(Unspecified)'
+GROUP BY  ENCRYPTED_TRUE_PEN, PSI_GENDER;"
+
+
+# ---- qry06a4b_ExtractNoGender_DupEPENS ----
+qry06a4b_ExtractNoGender_DupEPENS_1 <- "
+SELECT     ENCRYPTED_TRUE_PEN, COUNT(*) AS Expr1
+INTO       tmp_Extract_No_Gender_DupEPENS
+FROM       tmp_Extract_No_Gender_EPENS
+GROUP BY   ENCRYPTED_TRUE_PEN
+HAVING     COUNT(*) > 1;"
+
+qry06a4b_ExtractNoGender_DupEPENS_2 <-
+  "UPDATE    TOP (10) tmp_Extract_No_Gender_DupEPENS
+SET        PSI_GENDER_to_use ='Female'
+WHERE      PSI_GENDER_to_use IS NULL;
+
+UPDATE     TOP (0) tmp_Extract_No_Gender_DupEPENS
+SET        PSI_GENDER_to_use ='Gender Diverse'
+WHERE      PSI_GENDER_to_use IS NULL;
+
+UPDATE     tmp_Extract_No_Gender_DupEPENS
+SET        PSI_GENDER_to_use ='Male'
+WHERE      PSI_GENDER_to_use IS NULL;
+"
+
+
+# ---- qry06a4c_Update_ExtractNoGender_DupEPENS ----
+qry06a4c_Update_ExtractNoGender_DupEPENS <- "
+UPDATE     Extract_No_Gender
+SET        PSI_GENDER = tmp_Extract_No_Gender_DupEPENS.PSI_GENDER_TO_USE
+FROM       Extract_No_Gender 
+INNER JOIN tmp_Extract_No_Gender_DupEPENS 
+  ON       Extract_No_Gender.ENCRYPTED_TRUE_PEN = tmp_Extract_No_Gender_DupEPENS.ENCRYPTED_TRUE_PEN;"
+
+# ---- qry06a4c_Check_Prop  ----
+qry06a4c_Check_Prop <- "
+SELECT     PSI_GENDER, COUNT(*) AS NumEnrolled
+FROM       MinEnrolment
+WHERE      PSI_GENDER <> 'Unknown' 
+AND        PSI_GENDER <> '' 
+AND        PSI_GENDER <> '(Unspecified)'
+AND        PSI_GENDER IS NOT NULL 
+AND        IS_FIRST_ENROLMENT='Yes'
+GROUP BY   PSI_GENDER
+"
+
+# ---- qry06a5_CorrectGender2 ----
+qry06a5_CorrectGender2 <- "
+UPDATE    MinEnrolment
+SET       PSI_GENDER = Extract_No_Gender.PSI_GENDER
+FROM      Extract_No_Gender 
+INNER JOIN MinEnrolment ON Extract_No_Gender.id = MinEnrolment.id;"
+
+# ---- qry07a_Extract_No_Age ----
+qry07a_Extract_No_Age <- "
+SELECT DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, AGE_AT_ENROL_DATE, 
+PSI_SCHOOL_YEAR, PSI_MIN_START_DATE, PSI_MIN_START_DATE_D
+INTO    Extract_No_Age
+FROM    MinEnrolment
+WHERE   AGE_AT_ENROL_DATE IS NULL;"
+
+
+# ---- qry07b_Extract_No_Age_First_Enrolment ----
+qry07b_Extract_No_Age_First_Enrolment <- "
+SELECT DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_GENDER, PSI_CODE, AGE_AT_ENROL_DATE
+INTO            Extract_No_Age_First_Enrolment
+FROM         MinEnrolment
+WHERE     (AGE_AT_ENROL_DATE IS NULL) AND IS_FIRST_ENROLMENT='Yes';"
+
+
+# ---- qry07b2_update_Extract_No_Age_IsFirstEnrolment ----
+qry07b2_update_Extract_No_Age_IsFirstEnrolment <- "
+UPDATE    Extract_No_Age
+SET       IS_FIRST_ENROLMENT = 'Yes'
+FROM         Extract_No_Age 
+INNER JOIN Extract_No_Age_First_Enrolment 
+ON Extract_No_Age.id = Extract_No_Age_First_Enrolment.id;"
+
+
+# ---- qry07c_Show_Age_Distribution ----
+qry07c_Show_Age_Distribution <- "
+SELECT     AGE_AT_ENROL_DATE, PSI_GENDER, COUNT(id) AS NumEnrolled 
+FROM         MinEnrolment
+WHERE     (AGE_GROUP_ENROL_DATE IS NOT NULL) AND (IS_FIRST_ENROLMENT = 'Yes')
+GROUP BY AGE_AT_ENROL_DATE, PSI_GENDER;"
+
+
+# ---- qry07d1_Update_Extract_No_Age ----
+qry07d1_Update_Extract_No_Age <- "
+UPDATE    Extract_No_Age
+SET              AGE_AT_ENROL_DATE = Extract_No_Age_First_Enrolment.AGE_AT_ENROL_DATE
+FROM         Extract_No_Age_First_Enrolment INNER JOIN
+                      Extract_No_Age ON Extract_No_Age_First_Enrolment.id = Extract_No_Age.id;"
+
+# ---- qry02a_Multiple_Enrol ----
+qry02a_Multiple_Enrol <- "
+SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE
+FROM   Extract_No_Age
+GROUP BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE
+HAVING (((Count(*))>1));"
+
+
+# ---- qry02b_Calc_Ages  ----
+qry02b_Calc_Ages <- "
+SELECT  Extract_No_Age.ID, 
+        Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, 
+        Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE_D, 
+        Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.IS_FIRST_ENROLMENT
+FROM    Extract_No_Age
+ORDER BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, 
+        Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT DESC;"
+
+# ---- qry_Update_Linked_dbo_Extract_No_Age_after_mod2 ----
+qry_Update_Linked_dbo_Extract_No_Age_after_mod2 <- "
+UPDATE Extract_No_Age
+SET   Extract_No_Age.AGE_AT_ENROL_DATE = R_Extract_No_Age.AGE_AT_ENROL_DATE
+FROM  Extract_No_Age
+INNER JOIN R_Extract_No_Age
+  ON  Extract_No_Age.id = R_Extract_No_Age.id 
+WHERE Extract_No_Age.AGE_AT_ENROL_DATE Is Null
+AND   R_Extract_No_Age.AGE_AT_ENROL_DATE Is Not Null;"
+
+
+# ---- qry07d_Create_Age_Manual_Fixes View ----
+qry07d_Create_Age_Manual_Fixes_View <- "CREATE VIEW qry05c_Age_Manual_Fixes_View AS
+SELECT     TOP (100) PERCENT Extract_No_Age.AGE_AT_ENROL_DATE AS Expr1, MinEnrolment.PSI_GENDER, MinEnrolment.PSI_STUDENT_NUMBER, MinEnrolment.PSI_CODE, MinEnrolment.id, 
+                      MinEnrolment.psi_birthdate_cleaned_D, MinEnrolment.PSI_MIN_START_DATE_D, MinEnrolment.AGE_AT_ENROL_DATE, MinEnrolment.IS_FIRST_ENROLMENT
+FROM         Extract_No_Age INNER JOIN
+                      MinEnrolment ON Extract_No_Age.PSI_STUDENT_NUMBER = MinEnrolment.PSI_STUDENT_NUMBER AND 
+                      Extract_No_Age.PSI_CODE = MinEnrolment.PSI_CODE
+WHERE     (Extract_No_Age.AGE_AT_ENROL_DATE IS NULL)
+ORDER BY MinEnrolment.PSI_STUDENT_NUMBER;"
+
+
+# ---- qry07d2_Update_Birthdate ----
+qry07d2_Update_Birthdate <- "
+UPDATE    qry05c_Age_Manual_Fixes_View
+SET              PSI_BIRTHDATE_cleaned_D = qry05c_Age_Manual_Fixes_View_1.PSI_BIRTHDATE_cleaned_D
+FROM         qry05c_Age_Manual_Fixes_View INNER JOIN
+                      qry05c_Age_Manual_Fixes_View AS qry05c_Age_Manual_Fixes_View_1 ON 
+                      qry05c_Age_Manual_Fixes_View.PSI_STUDENT_NUMBER = qry05c_Age_Manual_Fixes_View_1.PSI_STUDENT_NUMBER AND 
+                      qry05c_Age_Manual_Fixes_View.PSI_CODE = qry05c_Age_Manual_Fixes_View_1.PSI_CODE
+WHERE     (qry05c_Age_Manual_Fixes_View.PSI_BIRTHDATE_cleaned_D IS NULL) AND (qry05c_Age_Manual_Fixes_View_1.PSI_BIRTHDATE_cleaned_D IS NOT NULL);"
+
+
+# ---- qry07d3_Update_Age ----
+qry07d3_Update_Age <- "UPDATE    qry05C_Age_Manual_Fixes_View
+SET     AGE_AT_ENROL_DATE = CASE
+		WHEN dateadd(year, datediff (year, PSI_birthdate_cleaned_D, PSI_MIN_START_DATE_D), PSI_birthdate_cleaned_D) > PSI_MIN_START_DATE_D
+		THEN datediff (year, PSI_birthdate_cleaned_D, PSI_MIN_START_DATE_D) - 1
+		ELSE datediff (year, PSI_birthdate_cleaned_D, PSI_MIN_START_DATE_D)
+		END
+WHERE     (PSI_birthdate_cleaned_D IS NOT NULL)"
+
+
+# ---- qry07e_Update_MinEnrolment_With_Age ----
+qry07e_Update_MinEnrolment_With_Age <- "UPDATE    MinEnrolment
+SET              AGE_AT_ENROL_DATE = Extract_No_Age.AGE_AT_ENROL_DATE
+FROM         MinEnrolment INNER JOIN
+                      Extract_No_Age ON MinEnrolment.id = Extract_No_Age.id;"
+
+
+# ---- qry08_UpdateAGAtEnrol ----
+qry08_UpdateAGAtEnrol <- "UPDATE    MinEnrolment
+SET              AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+FROM         MinEnrolment CROSS JOIN
+                      AgeGroupLookup
+WHERE     (AgeGroupLookup.LowerBound <= MinEnrolment.AGE_AT_ENROL_DATE) AND (AgeGroupLookup.UpperBound >= MinEnrolment.AGE_AT_ENROL_DATE);"
+
+
+# ---- qry09c_MinEnrolment by Credential and CIP Code ----
+qry09c_MinEnrolment_by_Credential_and_CIP_Code <- "
+SELECT        PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, COUNT(*) AS Expr1
+INTO  qry09c_MinEnrolment_by_Credential_and_CIP_Code
+FROM            MinEnrolment
+GROUP BY PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE
+--HAVING        (PSI_SCHOOL_YEAR = '2016/2017')
+ORDER BY PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE;"
+
+
+# ---- qry09c_MinEnrolment ----
+qry09c_MinEnrolment <- "
+SELECT     MinEnrolment.PSI_GENDER, MinEnrolment.PSI_GENDER + AgeGroupLookup.AgeGroup As Groups, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
+INTO    qry09c_MinEnrolment
+FROM       MinEnrolment 
+INNER JOIN  AgeGroupLookup 
+ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
+HAVING      (MinEnrolment.PSI_SCHOOL_YEAR <> '2023/2024')
+ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
+;"
+
+
+# ---- qry09c_MinEnrolment_Domestic ----
+qry09c_MinEnrolment_Domestic <- "
+SELECT     MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
+INTO  qry09c_MinEnrolment_Domestic
+FROM         MinEnrolment INNER JOIN
+                      AgeGroupLookup ON MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+WHERE     (MinEnrolment.PSI_VISA_STATUS = 'DOMESTIC')
+GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
+--HAVING      (MinEnrolment.PSI_SCHOOL_YEAR <> '2012/2013')
+ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
+
+
+# ---- qry09c_MinEnrolment_PSI_TYPE ----
+qry09c_MinEnrolment_PSI_TYPE <- "
+SELECT        MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1, PSI_CODE_RECODE.PSI_TYPE_RECODE, PSI_CODE_RECODE.PSI_CODE_RECODE
+INTO qry09c_MinEnrolment_PSI_TYPE
+FROM            MinEnrolment INNER JOIN
+                         AgeGroupLookup ON MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex INNER JOIN
+                         PSI_CODE_RECODE ON MinEnrolment.PSI_CODE = PSI_CODE_RECODE.PSI_CODE
+WHERE        (AgeGroupLookup.AgeIndex <> 1 AND AgeGroupLookup.AgeIndex <> 9)
+GROUP BY MinEnrolment.PSI_SCHOOL_YEAR, PSI_CODE_RECODE.PSI_TYPE_RECODE, PSI_CODE_RECODE.PSI_CODE_RECODE
+--HAVING        (MinEnrolment.PSI_SCHOOL_YEAR <> '2015/2016')
+ORDER BY MinEnrolment.PSI_SCHOOL_YEAR;"
+
+
+# ---- qry_CreateMinEnrolmentView ----
+qry_CreateMinEnrolmentView <- "
+CREATE VIEW MinEnrolment
+AS
+SELECT    STP_Enrolment.ID, 
+          STP_Enrolment.PSI_PEN, 
+          STP_Enrolment.PSI_BIRTHDATE, 
+          STP_Enrolment.psi_birthdate_cleaned, 
+          STP_Enrolment.PSI_GENDER, 
+          STP_Enrolment.PSI_STUDENT_NUMBER, 
+          STP_Enrolment.PSI_STUDENT_POSTAL_CODE_FIRST_CONTACT, 
+          STP_Enrolment.TRUE_PEN, 
+          STP_Enrolment.ENCRYPTED_TRUE_PEN, 
+          STP_Enrolment.PSI_SCHOOL_YEAR, 
+          STP_Enrolment.PSI_REGISTRATION_TERM, 
+          STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+          STP_Enrolment.PSI_INDIGENOUS_STATUS, 
+          STP_Enrolment.PSI_NEW_STUDENT_FLAG, 
+          STP_Enrolment.PSI_ENROLMENT_SEQUENCE, 
+          STP_Enrolment.PSI_CODE, 
+          STP_Enrolment.PSI_TYPE, 
+          STP_Enrolment.PSI_FULL_NAME, 
+          STP_Enrolment.PSI_BASIS_OF_ADMISSION, 
+          STP_Enrolment.PSI_MIN_START_DATE, 
+          STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          STP_Enrolment.PSI_PROGRAM_CODE, 
+          STP_Enrolment.PSI_CIP_CODE, 
+          STP_Enrolment.PSI_PROGRAM_EFFECTIVE_DATE, 
+          STP_Enrolment.PSI_FACULTY, 
+          STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, 
+          STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+          STP_Enrolment.PSI_VISA_STATUS, 
+          STP_Enrolment.PSI_STUDY_LEVEL, 
+          STP_Enrolment.PSI_ENTRY_STATUS,
+          STP_Enrolment.OVERALL_INDIGENOUS_STATUS, 
+          MinEnrolmentSupVar.psi_birthdate_cleaned_D, 
+          MinEnrolmentSupVar.PSI_MIN_START_DATE_D, 
+          MinEnrolmentSupVar.AGE_AT_ENROL_DATE, 
+          MinEnrolmentSupVar.AGE_GROUP_ENROL_DATE, 
+          MinEnrolmentSupVar.AGE_AT_CENSUS_2016, 
+          MinEnrolmentSupVar.AGE_GROUP_CENSUS_2016, 
+          MinEnrolmentSupVar.IS_FIRST_ENROLMENT, 
+          MinEnrolmentSupVar.IS_SKILLS_BASED
+FROM            STP_Enrolment INNER JOIN
+                         STP_Enrolment_Record_Type ON STP_Enrolment.ID = STP_Enrolment_Record_Type.ID INNER JOIN
+                         MinEnrolmentSupVar ON STP_Enrolment.ID = MinEnrolmentSupVar.ID
+WHERE        (STP_Enrolment_Record_Type.RecordStatus = 0) AND (STP_Enrolment_Record_Type.MinEnrolment = 1);"
+
+
+###################################################################################
+
+qry_Update_Linked_dbo_Extract_No_Age_after_mod2 <-
+  "UPDATE dbo_Extract_No_Age INNER JOIN Extract_No_Age ON dbo_Extract_No_Age.id = Extract_No_Age.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Extract_No_Age]![AGE_AT_ENROL_DATE]
+WHERE (((dbo_Extract_No_Age.AGE_AT_ENROL_DATE) Is Null) AND ((Extract_No_Age.AGE_AT_ENROL_DATE) Is Not Null));"
+
+qry02a_Multiple_Enrol <-
+  "SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Count(*) AS Expr1
+FROM Extract_No_Age
+GROUP BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE
+HAVING (((Count(*))>1));"
+
+qry02b_Calc_Ages <-
+  "SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.IS_FIRST_ENROLMENT
+FROM Extract_No_Age
+ORDER BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT DESC;"
+
+qry03a_Manual_Fixes_ePEN <-
+  "SELECT dbo_MinEnrolment.id, Query1.ENCRYPTED_TRUE_PEN, dbo_MinEnrolment.PSI_CODE, dbo_MinEnrolment.PSI_STUDENT_NUMBER, dbo_MinEnrolment.PSI_SCHOOL_YEAR, dbo_MinEnrolment.PSI_MIN_START_DATE_D, dbo_MinEnrolment.PSI_BIRTHDATE_D AS Expr2, dbo_MinEnrolment.AGE_AT_ENROL_DATE, dbo_Extract_No_Age.AGE_AT_ENROL_DATE INTO tmp_tbl_Age_Manual_Fixes
+FROM (dbo_MinEnrolment INNER JOIN Query1 ON dbo_MinEnrolment.ENCRYPTED_TRUE_PEN = Query1.ENCRYPTED_TRUE_PEN) INNER JOIN dbo_Extract_No_Age ON dbo_MinEnrolment.ENCRYPTED_TRUE_PEN = dbo_Extract_No_Age.ENCRYPTED_TRUE_PEN
+ORDER BY Query1.ENCRYPTED_TRUE_PEN, dbo_MinEnrolment.PSI_MIN_START_DATE_D;"
+
+qry03b_Update_BIRTHDATE <-
+  "UPDATE Old_tmp_tbl_Age_Manual_Fixes AS tmp_tbl_Age_Manual_Fixes_1 INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON tmp_tbl_Age_Manual_Fixes_1.ENCRYPTED_TRUE_PEN = Old_tmp_tbl_Age_Manual_Fixes.ENCRYPTED_TRUE_PEN SET tmp_tbl_Age_Manual_Fixes_1.PSI_BIRTHDATE_D = [Old_tmp_tbl_Age_Manual_Fixes].PSI_BIRTHDATE_D
+WHERE (((tmp_tbl_Age_Manual_Fixes_1.PSI_BIRTHDATE_D) Is Null) AND ((Old_tmp_tbl_Age_Manual_Fixes.PSI_BIRTHDATE_D) Is Not Null));"
+
+qry03c_Update_Age <-
+  "UPDATE tmp_tbl_Age_Manual_Fixes SET tmp_tbl_Age_Manual_Fixes.dbo_MinEnrolment_AGE_AT_ENROL_DATE = DateDiff('yyyy',[PSI_BIRTHDATE_D],[PSI_MIN_START_DATE_D])+([PSI_MIN_START_DATE_D]<DateSerial(Year([PSI_MIN_START_DATE_D]),Month([PSI_BIRTHDATE_D]),Day([PSI_BIRTHDATE_D])))
+WHERE (((tmp_tbl_Age_Manual_Fixes.dbo_Extract_No_Age_AGE_AT_ENROL_DATE) Is Null));"
+
+qry04d_Update_dbo_Extract_No_Age <-
+  "UPDATE dbo_Extract_No_Age INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON dbo_Extract_No_Age.id = Old_tmp_tbl_Age_Manual_Fixes.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Old_tmp_tbl_Age_Manual_Fixes].dbo_MinEnrolment_AGE_AT_ENROL_DATE;"
+
+qry05c_Update_Birthdate <-
+  "UPDATE dbo_qry05c_Age_Manual_Fixes_View AS dbo_qry05c_Age_Manual_Fixes_View_1 INNER JOIN dbo_qry05c_Age_Manual_Fixes_View ON (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_STUDENT_NUMBER = dbo_qry05c_Age_Manual_Fixes_View.PSI_STUDENT_NUMBER) AND (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_CODE = dbo_qry05c_Age_Manual_Fixes_View.PSI_CODE) SET dbo_qry05c_Age_Manual_Fixes_View.PSI_BIRTHDATE_D = [dbo_qry05c_Age_Manual_Fixes_View_1].[PSI_BIRTHDATE_D]
+WHERE ((([dbo_qry05c_Age_Manual_Fixes_View].[PSI_BIRTHDATE_D]) Is Null) AND (([dbo_qry05c_Age_Manual_Fixes_View_1].[PSI_BIRTHDATE_D]) Is Not Null));"
+
+Check_AdvancedAge_ForEPENS <-
+  "SELECT Extract_No_Age.id, Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT
+FROM Extract_No_Age
+WHERE (((Extract_No_Age.ENCRYPTED_TRUE_PEN)<>''))
+ORDER BY Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_SCHOOL_YEAR;"
+
+Check_AdvancedAge_ForStudentNumPSICODE <-
+  "SELECT Extract_No_Age.id, Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT
+FROM Extract_No_Age
+WHERE (((Extract_No_Age.ENCRYPTED_TRUE_PEN)=''))
+ORDER BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_SCHOOL_YEAR;"
+
+###################################################################################
+
+###################################################################################
+
+###################################################################################
+# ---- Checks ----
+qry00a_check_null_epens <- "SELECT COUNT (*) AS n_null_epens FROM STP_Credential
+  WHERE STP_Credential.ENCRYPTED_TRUE_PEN IN ('', ' ', '(Unspecified)') 
+OR STP_Credential.ENCRYPTED_TRUE_PEN IS NULL;"
+
+qry00b_check_unique_epens <- "
+  SELECT COUNT (DISTINCT ENCRYPTED_TRUE_PEN) AS n_epens
+  FROM STP_Credential"
+
+qry00c_CreateIDinSTPCredential <- "
+  ALTER TABLE STP_Credential
+  ADD ID INT IDENTITY(1,1) NOT NULL"
+
+qry00d_SetPKeyinSTPCredential <- "
+  ALTER TABLE STP_Credential
+  ADD CONSTRAINT STP_Credential_PK_ID PRIMARY KEY (ID)"
+
+
+# ---- qry01_ExtractAllID_into_STP_Credential_Record_Type ----
+qry01_ExtractAllID_into_STP_Credential_Record_Type <- "
+  CREATE TABLE [STP_Credential_Record_Type] (
+  [ID] int NOT NULL,
+  [ENCRYPTED_TRUE_PEN] varchar(50),
+  [RecordStatus] smallint,
+  [MinEnrolment] smallint,
+  [FirstEnrolment] smallint);
+  
+  INSERT INTO STP_Credential_Record_Type (ID, ENCRYPTED_TRUE_PEN)
+  SELECT STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN
+  FROM STP_Credential;"
+
+
+# ---- qry02a_Record_With_PEN_Or_STUID ----
+qry02a_Record_With_PEN_Or_STUID <- "SELECT      id, PSI_STUDENT_NUMBER, PSI_CODE, ENCRYPTED_TRUE_PEN
+INTO       tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID
+FROM       STP_Credential
+WHERE     (PSI_STUDENT_NUMBER NOT IN ('', ' ', '(Unspecified)') 
+AND        PSI_CODE NOT IN ('', ' ', '(Unspecified)')) 
+OR (ENCRYPTED_TRUE_PEN NOT IN ('', ' ', '(Unspecified)'));"
+
+
+# ---- qry02b_Drop_No_PEN_Or_No_STUID ----
+qry02b_Drop_No_PEN_Or_No_STUID <- "
+SELECT STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_STUDENT_NUMBER
+INTO Drop_Cred_No_PEN_or_No_STUID
+FROM tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID 
+RIGHT JOIN STP_Credential 
+ON tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID.ID = STP_Credential.ID
+WHERE (((tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID.ID) Is Null));"
+
+
+# ---- qry02c_Update_Drop_No_PEN_or_No_STUID.SQL ----
+qry02c_Update_Drop_No_PEN_or_No_STUID <- "
+UPDATE    STP_Credential_Record_Type
+SET       RecordStatus = 1
+FROM      STP_Credential_Record_Type 
+INNER JOIN Drop_Cred_No_PEN_or_No_STUID 
+ON STP_Credential_Record_Type.ID = Drop_Cred_No_PEN_or_No_STUID.ID;"
+
+
+# ---- qry03a_Drop_Record_Developmental ----
+qry03a_Drop_Record_Developmental <- "
+SELECT    ID, ENCRYPTED_TRUE_PEN,  PSI_CODE, PSI_STUDENT_NUMBER, PSI_CREDENTIAL_CATEGORY, LEFT(STP_CREDENTIAL.PSI_CREDENTIAL_CIP, 2) AS CIP2, PSI_CREDENTIAL_LEVEL
+INTO      Drop_Cred_Developmental
+FROM      STP_Credential
+WHERE     PSI_CREDENTIAL_LEVEL = 'DEVELOPMENTAL';"
+
+
+# ---- qry03b_Update_Drop_Record_Developmental ----
+qry03b_Update_Drop_Record_Developmental <- "
+UPDATE    STP_Credential_Record_Type
+SET       RecordStatus = 2
+FROM      STP_Credential_Record_Type 
+INNER JOIN Drop_Cred_Developmental 
+  ON STP_Credential_Record_Type.ID = Drop_Cred_Developmental.ID
+WHERE STP_Credential_Record_Type.RecordStatus is null;"
+
+# ---- qry03c_create_table_EnrolmentSkillsBasedCourse ----
+qry03c_create_table_EnrolmentSkillsBasedCourse <- "
+SELECT    STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
+          STP_Enrolment.PSI_STUDY_LEVEL, STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, COUNT(*) AS Count
+INTO      tmp_tbl_EnrolmentSkillsBasedCourses
+FROM      STP_Enrolment_Record_Type 
+INNER JOIN STP_Enrolment 
+  ON STP_Enrolment_Record_Type.ID = STP_Enrolment.ID
+WHERE     (STP_Enrolment_Record_Type.RecordStatus = 6)
+GROUP BY STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, LEFT(STP_Enrolment.PSI_CIP_CODE, 2), 
+                      STP_Enrolment.PSI_CREDENTIAL_CATEGORY, STP_Enrolment.PSI_STUDY_LEVEL, STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
+
+
+# ---- qry03d_create_table_Suspect_Skills_Based ----
+qry03d_create_table_Suspect_Skills_Based <- "
+SELECT    STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_STUDENT_NUMBER, STP_Credential.PSI_SCHOOL_YEAR,
+          STP_Credential.PSI_CODE, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, LEFT(STP_Credential.PSI_CREDENTIAL_CIP,2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, 
+          STP_Credential.PSI_CREDENTIAL_LEVEL
+INTO      tmp_tbl_Cred_Suspect_Skills_Based
+FROM      STP_Credential_Record_Type 
+INNER JOIN STP_Credential 
+  ON STP_Credential_Record_Type.ID = STP_Credential.ID
+WHERE    (STP_Credential_Record_Type.RecordStatus IS NULL);"
+
+# ---- qry03e_Find_Suspect_Skills_Based ----
+qry03e_Find_Suspect_Skills_Based <- "
+SELECT    tmp_tbl_Cred_Suspect_Skills_Based.ID, tmp_tbl_Cred_Suspect_Skills_Based.ENCRYPTED_TRUE_PEN, tmp_tbl_Cred_Suspect_Skills_Based.PSI_CODE,  tmp_tbl_Cred_Suspect_Skills_Based.PSI_STUDENT_NUMBER,
+          tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, tmp_tbl_Cred_Suspect_Skills_Based.CIP2, 
+          tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_CATEGORY, tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_LEVEL
+INTO      Cred_Suspect_Skills_Based
+FROM      tmp_tbl_Cred_Suspect_Skills_Based 
+INNER JOIN tmp_tbl_EnrolmentSkillsBasedCourses 
+  ON tmp_tbl_Cred_Suspect_Skills_Based.PSI_CODE = tmp_tbl_EnrolmentSkillsBasedCourses.PSI_CODE 
+  AND tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = tmp_tbl_EnrolmentSkillsBasedCourses.PSI_CREDENTIAL_PROGRAM_DESCRIPTION 
+  AND tmp_tbl_Cred_Suspect_Skills_Based.CIP2 = tmp_tbl_EnrolmentSkillsBasedCourses.CIP2 
+  AND tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_CATEGORY = tmp_tbl_EnrolmentSkillsBasedCourses.PSI_CREDENTIAL_CATEGORY 
+  AND tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_LEVEL = tmp_tbl_EnrolmentSkillsBasedCourses.PSI_STUDY_LEVEL;"
+
+
+# ---- qry03f_Update_Suspect_Skills_Based ----
+qry03f_Update_Suspect_Skills_Based <- "
+UPDATE    STP_Credential_Record_Type
+SET       RecordStatus = 6
+FROM      Cred_Suspect_Skills_Based 
+INNER JOIN STP_Credential_Record_Type 
+  ON Cred_Suspect_Skills_Based.ID = STP_Credential_Record_Type.ID
+WHERE STP_Credential_Record_Type.RecordStatus IS NULL;"
+
+# ---- qry03g_Drop_Developmental_Credential_CIPS ----
+qry03g_Drop_Developmental_Credential_CIPS <- "
+SELECT    STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_STUDENT_NUMBER, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, STP_Credential_Record_Type.RecordStatus
+INTO      Drop_Developmental_PSI_CREDENTIAL_CIPS
+FROM      STP_Credential 
+INNER JOIN STP_Credential_Record_Type 
+  ON STP_Credential.ID = STP_Credential_Record_Type.ID
+WHERE     (LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) IN ('21', '32', '33', '34', '35', '36', '37', '53', '89')) 
+  AND (STP_Credential_Record_Type.RecordStatus IS NULL);"
+
+# ---- qry03g2_Drop_Developmental_Credential_CIPS ----
+qry03g2_Drop_Developmental_Credential_CIPS <- "
+UPDATE Drop_Developmental_PSI_CREDENTIAL_CIPS
+   SET Keep = 'Yes'
+ WHERE (PSI_CODE = 'UVIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'PROF SPEC CERTIFICATE IN MIDDLE YEARS LANG AND LITERACY')
+    OR (PSI_CODE = 'NIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'Aquaculture Technician 1')
+    OR (PSI_CODE = 'NIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'Coastal Forest Resource')
+    OR (PSI_CODE = 'NIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'Underground Mining Essentials');"
+
+# ---- qry03h_Update_Developmental_CIPs ----
+qry03h_Update_Developmental_CIPs <- "
+UPDATE    STP_Credential_Record_Type
+SET       RecordStatus = 7
+FROM      STP_Credential_Record_Type 
+INNER JOIN Drop_Developmental_PSI_CREDENTIAL_CIPS 
+  ON STP_Credential_Record_Type.ID = Drop_Developmental_PSI_CREDENTIAL_CIPS.ID
+WHERE STP_Credential_Record_Type.RecordStatus IS NULL and Drop_Developmental_PSI_CREDENTIAL_CIPS.Keep IS Null;"
+
+
+# ---- qry03i_Drop_RecommendationForCert ----
+qry03i_Drop_RecommendationForCert <- "
+SELECT      STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+                         LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, STP_Credential_Record_Type.RecordStatus
+INTO        Drop_Cred_RecommendForCert
+FROM        STP_Credential 
+INNER JOIN STP_Credential_Record_Type 
+  ON STP_Credential.ID = STP_Credential_Record_Type.ID
+WHERE        (PSI_CREDENTIAL_CATEGORY = 'RECOMMENDATION FOR CERTIFICATION') AND (STP_Credential_Record_Type.RecordStatus IS NULL);"
+
+
+# ---- qry03j_Update_RecommendationForCert  ----
+qry03j_Update_RecommendationForCert <- "
+UPDATE    STP_Credential_Record_Type
+SET       RecordStatus = 8
+FROM      STP_Credential_Record_Type 
+INNER JOIN Drop_Cred_RecommendForCert 
+  ON STP_Credential_Record_Type.ID = Drop_Cred_RecommendForCert.ID
+WHERE STP_Credential_Record_Type.RecordStatus IS NULL;"
+
+
+# ---- qry04_Update_RecordStatus_Not_Dropped ----
+qry04_Update_RecordStatus_Not_Dropped <- "
+UPDATE STP_Credential_Record_Type 
+SET STP_Credential_Record_Type.RecordStatus = 0
+WHERE (((STP_Credential_Record_Type.RecordStatus) Is Null));;"
+
+# ---- RecordTypeSummary ----
+RecordTypeSummary <-
+  "SELECT RecordStatus, COUNT(*) AS Expr1
+FROM  STP_Credential_Record_Type
+GROUP BY RecordStatus"
+
+
+###############################################################################################
+# ---- qry_Credential_view_initial ----
+qry_Credential_view_initial <- "
+CREATE VIEW Credential 
+AS
+SELECT        STP_Credential.ID,STP_Credential.ENCRYPTED_TRUE_PEN, 
+              STP_Credential.PSI_SCHOOL_YEAR, 
+              STP_Credential.PSI_STUDENT_NUMBER, 
+              STP_Credential.PSI_CODE, 
+              STP_Credential.CREDENTIAL_AWARD_DATE, 
+              STP_Credential_Record_Type.RecordStatus, 
+              STP_Credential.PSI_PROGRAM_CODE, 
+              STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+              STP_Credential.PSI_CREDENTIAL_CIP, 
+              STP_Credential.PSI_CREDENTIAL_LEVEL, 
+              STP_Credential.PSI_CREDENTIAL_CATEGORY
+FROM          STP_Credential 
+INNER JOIN    STP_Credential_Record_Type 
+  ON          STP_Credential.ID = STP_Credential_Record_Type.ID
+WHERE        (STP_Credential.CREDENTIAL_AWARD_DATE NOT IN ('', ' ', '(Unspecified)')) 
+  AND (STP_Credential_Record_Type.RecordStatus = 0);"
+
+
+# ---- qry01a_CredentialSupVars ----
+qry01a_CredentialSupVars <- "
+SELECT      ID, 
+            ENCRYPTED_TRUE_PEN, 
+            PSI_STUDENT_NUMBER, 
+            PSI_CODE, 
+            PSI_SCHOOL_YEAR, 
+            CREDENTIAL_AWARD_DATE, 
+            RecordStatus AS CredentialRecordStatus, 
+            PSI_PROGRAM_CODE, 
+            PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+            PSI_CREDENTIAL_CIP, 
+            PSI_CREDENTIAL_LEVEL, 
+            PSI_CREDENTIAL_CATEGORY
+INTO        CredentialSupVars
+FROM        Credential;"
+
+
+# ---- qry01b_CredentialSupVars ----
+qry01b_CredentialSupVars <- "
+ALTER TABLE CredentialSupVars 
+ADD         CREDENTIAL_AWARD_DATE_D [date] NULL,
+	          PSI_AWARD_SCHOOL_YEAR [varchar](50) NULL,
+	          RECORD_TO_DELETE [int] NULL,
+	          psi_birthdate_cleaned_D [date] NULL,
+	          psi_birthdate_cleaned [date] NULL,
+	          Last_Date_Highest_Cred [varchar](255) NULL,
+	          Highest_Cred_by_Date [varchar](255) NULL,
+	          Highest_Cred_by_Rank [varchar](255) NULL,
+	          Highest_Cred_by_School_Year [varchar](255) NULL,
+	          OUTCOMES_CRED [varchar](255) NULL,
+	          RESEARCH_UNIVERSITY [int] NULL,
+	          CREDENTIAL_AWARD_DATE_D_DELAYED [date] NULL,
+	          PSI_AWARD_SCHOOL_YEAR_DELAYED [varchar](50) NULL,
+            AGE_AT_GRAD [int] NULL,
+            AGE_GROUP_AT_GRAD [int] NULL, 
+            psi_gender_cleaned NVARCHAR(10) NULL;"
+
+
+# ---- qry01b_CredentialSupVarsFromEnrol ----
+qry01b_CredentialSupVarsFromEnrol_1 <- "
+ALTER TABLE CredentialSupVarsFromEnrolment 
+ADD         PSI_MIN_START_DATE_D [date] NULL,
+	          AGE_AT_GRAD [numeric](18, 0) NULL,
+	          AGE_GROUP_AT_GRAD [numeric](18, 0) NULL,
+	          PSI_BIRTHDATE_D [date] NULL,
+	          RECORD_TO_DELETE [int] NULL,
+	          psi_birthdate_cleaned_D [date] NULL,
+	          PSI_VISA_STATUS [varchar](50) NULL,
+	          PSI_BIRTHDATE  [varchar](50) NULL,
+	          PSI_PROGRAM_CODE [varchar](500) NULL,
+	          PSI_CREDENTIAL_PROGRAM_DESCRIPTION [varchar](500) NULL,
+	          PSI_CIP_CODE [varchar](50) NULL,
+	          PSI_CONTINUING_EDUCATION_COURSE_ONLY [varchar](50) NULL,
+	          PSI_GENDER [varchar](50) NULL,
+	          psi_birthdate_cleaned [date] NULL;"
+
+qry01b_CredentialSupVarsFromEnrol_2 <- "	
+UPDATE      CredentialSupVarsFromEnrolment
+SET         psi_birthdate_cleaned = STP_Enrolment.psi_birthdate_cleaned, 
+            PSI_VISA_STATUS = STP_Enrolment.PSI_VISA_STATUS, 
+            PSI_BIRTHDATE = STP_Enrolment.PSI_BIRTHDATE, 
+            PSI_PROGRAM_CODE = STP_Enrolment.PSI_PROGRAM_CODE, 
+            PSI_CREDENTIAL_PROGRAM_DESCRIPTION = STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+            PSI_CIP_CODE = STP_Enrolment.PSI_CIP_CODE, 
+            PSI_CONTINUING_EDUCATION_COURSE_ONLY = STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, 
+            PSI_GENDER = STP_Enrolment.PSI_GENDER
+FROM        CredentialSupVarsFromEnrolment 
+INNER JOIN  STP_Enrolment 
+  ON        CredentialSupVarsFromEnrolment.EnrolmentID = STP_Enrolment.ID;"
+
+qry01b_CredentialSupVarsFromEnrol_3 <- "
+UPDATE      CredentialSupVarsFromEnrolment
+SET         psi_birthdate_cleaned = NULL
+WHERE       psi_birthdate_cleaned = '1900-01-01';"
+
+
+# ---- qry02a_DropCredCategory ----
+qry02a_DropCredCategory <- "
+SELECT     id, PSI_CODE, PSI_CREDENTIAL_CATEGORY, ENCRYPTED_TRUE_PEN, PSI_SCHOOL_YEAR, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION
+INTO       Drop_Credential_Category
+FROM       Credential
+WHERE      PSI_CREDENTIAL_CATEGORY = 'DEVELOPMENTAL CREDENTIAL'
+  OR       PSI_CREDENTIAL_CATEGORY = 'OTHER'
+  OR       PSI_CREDENTIAL_CATEGORY = 'NONE'
+  OR       PSI_CREDENTIAL_CATEGORY = 'SHORT CERTIFICATE';"
+
+# ---- qry02b_DeleteCredCategory ----
+qry02b_DeleteCredCategory <- "
+UPDATE    STP_Credential_Record_Type
+SET       DropCredCategory = 'Yes'
+FROM      Drop_Credential_Category 
+INNER JOIN STP_Credential_Record_Type 
+ON  Drop_Credential_Category.id =  STP_Credential_Record_Type.id;"
+
+# ---- qry03a1_ConvertAwardDate ----
+qry03a1_ConvertAwardDate <- "
+UPDATE CredentialSupVars
+SET    CREDENTIAL_AWARD_DATE_D = CREDENTIAL_AWARD_DATE;"
+
+# ---- qry03b_DropPartialYear ----
+qry03b_DropPartialYear <- "
+SELECT     id, CREDENTIAL_AWARD_DATE_D
+INTO            Drop_Partial_Year
+FROM         CredentialSupVars
+WHERE     (CREDENTIAL_AWARD_DATE_D >= '2023-09-01');"
+
+# ---- qry03c_DeletePartialYear ----
+qry03c_DeletePartialYear <- "
+UPDATE    STP_Credential_Record_Type 
+SET       DropPartialYear = 'Yes'
+FROM      STP_Credential_Record_Type  
+INNER JOIN Drop_Partial_Year 
+ON        STP_Credential_Record_Type.id = Drop_Partial_Year.id;"
+
+# ---- qry03d_CredentialSupVarsBirthdate ----
+qry03d_CredentialSupVarsBirthdate <- "
+SELECT        ENCRYPTED_TRUE_PEN, psi_birthdate_cleaned, psi_birthdate_cleaned_D, PSI_STUDENT_NUMBER, PSI_CODE
+INTO          CredentialSupVars_BirthdateClean
+FROM          CredentialSupVarsFromEnrolment
+GROUP BY      ENCRYPTED_TRUE_PEN, psi_birthdate_cleaned, psi_birthdate_cleaned_D, PSI_STUDENT_NUMBER, PSI_CODE"
+
+
+# ---- qry03e_CredentialSupVarsGender ----
+qry03e_CredentialSupVarsGender <- "
+SELECT        ENCRYPTED_TRUE_PEN, PSI_GENDER
+INTO          CredentialSupVars_Gender
+FROM          CredentialSupVarsFromEnrolment
+GROUP BY      ENCRYPTED_TRUE_PEN, PSI_GENDER;"
+
+
+# ---- qry04a_UpdateCredentialSupVarsBirthdate ----
+qry04a_UpdateCredentialSupVarsBirthdate <- "
+UPDATE        CredentialSupVars
+SET           psi_birthdate_cleaned = CredentialSupVars_BirthdateClean.psi_birthdate_cleaned, 
+              psi_birthdate_cleaned_D = CredentialSupVars_BirthdateClean.psi_birthdate_cleaned_D
+FROM          CredentialSupVars 
+INNER JOIN    CredentialSupVars_BirthdateClean 
+  ON          CredentialSupVars.ENCRYPTED_TRUE_PEN = CredentialSupVars_BirthdateClean.ENCRYPTED_TRUE_PEN
+WHERE        (CredentialSupVars.ENCRYPTED_TRUE_PEN IS NOT NULL AND CredentialSupVars.ENCRYPTED_TRUE_PEN NOT IN ('', ' ', '(Unspecified)'))"
+
+qry04a_UpdateCredentialSupVarsBirthdate2 <- "
+UPDATE      CredentialSupVars
+SET         psi_birthdate_cleaned = CredentialSupVars_BirthdateClean.psi_birthdate_cleaned, 
+            psi_birthdate_cleaned_D = CredentialSupVars_BirthdateClean.psi_birthdate_cleaned_D
+FROM        CredentialSupVars_BirthdateClean 
+INNER JOIN  CredentialSupVars 
+  ON        CredentialSupVars_BirthdateClean.PSI_STUDENT_NUMBER = CredentialSupVars.PSI_STUDENT_NUMBER 
+  AND       CredentialSupVars_BirthdateClean.PSI_CODE = CredentialSupVars.PSI_CODE
+WHERE       (CredentialSupVars.ENCRYPTED_TRUE_PEN IS NULL OR CredentialSupVars.ENCRYPTED_TRUE_PEN IN ('', ' ', '(Unspecified)'))
+AND         (CredentialSupVars.PSI_CODE IS NOT NULL AND CredentialSupVars.PSI_CODE NOT IN ('', ' ', '(Unspecified)')) 
+AND         (CredentialSupVars.PSI_STUDENT_NUMBER IS NOT NULL AND CredentialSupVars.PSI_STUDENT_NUMBER NOT IN ('', ' ', '(Unspecified)'));"
+
+
+qry04a1_UpdateCredentialSupVarsBirthdate <- "
+UPDATE        CredentialSupVarsFromEnrolment
+SET           LAST_SEEN_BIRTHDATE = STP_Enrolment.LAST_SEEN_BIRTHDATE
+FROM          CredentialSupVarsFromEnrolment 
+INNER JOIN    STP_Enrolment 
+ON CredentialSupVarsFromEnrolment.EnrolmentID = STP_Enrolment.ID"
+
+qry04a2_UpdateCredentialSupVarsBirthdate <- "
+UPDATE        CredentialSupVars
+SET           LAST_SEEN_BIRTHDATE = CredentialSupVarsFromEnrolment.LAST_SEEN_BIRTHDATE
+FROM          CredentialSupVarsFromEnrolment 
+INNER JOIN    CredentialSupVars 
+ON CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN = CredentialSupVars.ENCRYPTED_TRUE_PEN"
+
+qry04a3_UpdateCredentialSupVarsBirthdate <- "
+UPDATE       CredentialSupVars
+SET          CredentialSupVars.psi_birthdate_cleaned = LAST_SEEN_BIRTHDATE
+WHERE        ((LAST_SEEN_BIRTHDATE IS NOT NULL AND LAST_SEEN_BIRTHDATE NOT IN ('', ' ')) 
+AND           (psi_birthdate_cleaned IS NULL))
+OR           ((LAST_SEEN_BIRTHDATE IS NOT NULL AND LAST_SEEN_BIRTHDATE NOT IN ('', ' ')) 
+AND           (psi_birthdate_cleaned IN ('', ' ')))"
+
+# ---- qry04b_UpdateCredentiaSupVarsGender  ----
+qry04b_UpdateCredentiaSupVarsGender <- "
+UPDATE       CredentialSupVars
+SET          psi_gender_cleaned = CredentialSupVars_Gender.psi_gender_cleaned
+FROM         CredentialSupVars 
+INNER JOIN   CredentialSupVars_Gender 
+  ON         CredentialSupVars.ENCRYPTED_TRUE_PEN = CredentialSupVars_Gender.ENCRYPTED_TRUE_PEN;"
+
+
+# ---- qry04c_RecreateCredentialViewWithSupVars  ----
+qry04c_RecreateCredentialViewWithSupVars <- "
+CREATE VIEW Credential AS
+SELECT        STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN,  STP_Credential.PSI_STUDENT_NUMBER,
+              STP_Credential.PSI_CODE, STP_Credential.PSI_FULL_NAME, STP_Credential.PSI_SCHOOL_YEAR, 
+              STP_Credential.PSI_PROGRAM_CODE, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+              STP_Credential.PSI_CREDENTIAL_CATEGORY, STP_Credential.PSI_CREDENTIAL_LEVEL, 
+              STP_Credential.PSI_CREDENTIAL_CIP, STP_Credential.CREDENTIAL_AWARD_DATE, 
+              CredentialSupVars.CREDENTIAL_AWARD_DATE_D, CredentialSupVars.AGE_AT_GRAD, CredentialSupVars.AGE_GROUP_AT_GRAD, 
+              CredentialSupVars.PSI_AWARD_SCHOOL_YEAR, CredentialSupVars.RECORD_TO_DELETE, CredentialSupVars.Last_Date_Highest_Cred, 
+              CredentialSupVars.Highest_Cred_by_Date, CredentialSupVars.Highest_Cred_by_Rank, CredentialSupVars.Highest_Cred_by_School_Year, 
+              CredentialSupVars.OUTCOMES_CRED, CredentialSupVars.RESEARCH_UNIVERSITY, CredentialSupVars.CREDENTIAL_AWARD_DATE_D_DELAYED, 
+              CredentialSupVars.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+						  CredentialSupVars.psi_birthdate_cleaned,
+						  CredentialSupVars.psi_birthdate_cleaned_D, 
+						  CredentialSupVars.psi_gender_cleaned,
+						  STP_Credential_Record_Type.RecordStatus, STP_Credential_Record_Type.DropCredCategory, 
+              STP_Credential_Record_Type.DropPartialYear
+FROM          STP_Credential 
+INNER JOIN    CredentialSupVars 
+  ON          STP_Credential.ID = CredentialSupVars.ID 
+  INNER JOIN  STP_Credential_Record_Type ON STP_Credential.ID = STP_Credential_Record_Type.ID
+WHERE        (STP_Credential_Record_Type.RecordStatus = 0) 
+AND           (STP_Credential_Record_Type.DropCredCategory IS NULL)
+AND           (STP_Credential_Record_Type.DropPartialYear IS NULL);"
+
+
+# ---- qry05a_FindDistinctCredentials_CreateViewCredentialRemoveDup ----
+qry05a_FindDistinctCredentials_CreateViewCredentialRemoveDup <- "
+CREATE VIEW     Credential_Remove_Dup AS
+SELECT DISTINCT ENCRYPTED_TRUE_PEN, PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CREDENTIAL_CIP, PSI_CREDENTIAL_LEVEL, 
+                PSI_CREDENTIAL_CATEGORY, CREDENTIAL_AWARD_DATE_D, MAX(DISTINCT id) AS ID
+FROM            Credential
+GROUP BY        ENCRYPTED_TRUE_PEN, PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CREDENTIAL_CIP, PSI_CREDENTIAL_LEVEL, 
+                PSI_CREDENTIAL_CATEGORY, CREDENTIAL_AWARD_DATE_D;"
+
+
+# ---- qry05b_Lookingatdups ----
+qry05b_Lookingatdups <- "
+SELECT        Credential.ENCRYPTED_TRUE_PEN AS Expr1, Credential.PSI_STUDENT_NUMBER, Credential.PSI_CODE AS Expr2, Credential.PSI_PROGRAM_CODE, Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+              Credential.PSI_CREDENTIAL_CIP, Credential.PSI_CREDENTIAL_LEVEL, Credential.PSI_CREDENTIAL_CATEGORY, Credential.CREDENTIAL_AWARD_DATE_D, 
+              STP_Credential_Record_Type.ID AS Expr8, STP_Credential_Record_Type.ID, STP_Credential_Record_Type.ENCRYPTED_TRUE_PEN, 
+              STP_Credential_Record_Type.RecordStatus, STP_Credential_Record_Type.MinEnrolment, STP_Credential_Record_Type.FirstEnrolment, 
+              STP_Credential_Record_Type.DropCredCategory, STP_Credential_Record_Type.DropPartialYear
+FROM          Credential INNER JOIN
+                         STP_Credential_Record_Type ON Credential.ID = STP_Credential_Record_Type.ID
+WHERE        (STP_Credential_Record_Type.DropPartialYear IS NULL) AND (STP_Credential_Record_Type.DropCredCategory IS NULL) AND 
+                         (STP_Credential_Record_Type.RecordStatus = 0)
+ORDER BY Expr1;"
+
+
+# ---- qry05c_UpdateAgeAtGrad ----
+qry05c_UpdateAgeAtGrad <- "
+UPDATE    Credential
+SET       AGE_AT_GRAD = 
+              CASE WHEN dateadd(year, datediff(year, psi_birthdate_cleaned_d, CREDENTIAL_AWARD_DATE_D), psi_birthdate_cleaned_d) > CREDENTIAL_AWARD_DATE_D 
+              THEN datediff(year, psi_birthdate_cleaned_d, CREDENTIAL_AWARD_DATE_D) - 1 
+              ELSE datediff(year, psi_birthdate_cleaned_d,  CREDENTIAL_AWARD_DATE_D) 
+              END
+WHERE     (psi_birthdate_cleaned IS NOT NULL) AND (psi_birthdate_cleaned NOT IN ('', ' '));"
+
+
+# ---- qry05d_UpdateAGAtGrad ----
+qry05d_UpdateAgeGroupAtGrad <- "
+UPDATE    Credential
+SET       AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex
+FROM      Credential CROSS JOIN AgeGroupLookup
+WHERE     (AgeGroupLookup.LowerBound <= Credential.AGE_AT_GRAD) AND (AgeGroupLookup.UpperBound >= Credential.AGE_AT_GRAD);"
+
+
+# ---- qry06e_UpdateAwardSchoolYear ----
+qry06e_UpdateAwardSchoolYear <- "
+UPDATE Credential
+SET    PSI_AWARD_SCHOOL_YEAR = CASE
+	WHEN (Month(Credential.CREDENTIAL_AWARD_DATE_D) >= 9) THEN LTrim(Str(Year(Credential.CREDENTIAL_AWARD_DATE_D))) + '/' + LTrim(Str(Year(Credential.CREDENTIAL_AWARD_DATE_D)+1))
+	ELSE LTrim(Str(Year(Credential.CREDENTIAL_AWARD_DATE_D)-1)) + '/' + LTrim(Str(Year(Credential.CREDENTIAL_AWARD_DATE_D)))
+	END
+WHERE (((Credential.PSI_AWARD_SCHOOL_YEAR) Is Null));"
+
+
+# ---- qry07a1a_UpdateGender ----
+qry07a1a_UpdateGender <- "
+UPDATE    Credential
+SET       Credential.PSI_GENDER_cleaned = STP_Enrolment.PSI_GENDER
+FROM      STP_Enrolment 
+INNER JOIN Credential ON STP_Enrolment.ENCRYPTED_TRUE_PEN = Credential.ENCRYPTED_TRUE_PEN
+ AND STP_Enrolment.PSI_STUDENT_NUMBER = Credential.PSI_STUDENT_NUMBER
+ AND STP_Enrolment.PSI_code = Credential.PSI_code
+WHERE     (Credential.PSI_GENDER_cleaned IN ('', ' ', '(Unspecified)') 
+OR         Credential.PSI_GENDER_cleaned IS NULL) 
+AND       (STP_Enrolment.PSI_GENDER IN ('Female', 'Male', 'Gender Diverse'));"
+
+
+# ---- qry07a1b_Create_Credential_Non_Dup ----
+qry07a1b_Create_Credential_Non_Dup <- "
+SELECT credential.id,
+       credential.psi_student_number,
+       credential.psi_birthdate_cleaned,
+       credential.psi_gender_cleaned,
+       credential.encrypted_true_pen,
+       credential.psi_school_year,
+       credential.psi_code,
+       credential.credential_award_date,
+       credential.recordstatus,
+       credential.psi_program_code,
+       credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+       credential.psi_credential_cip,
+       credential.psi_credential_level,
+       credential.psi_credential_category,
+       credential.credential_award_date_d,
+       credential.age_at_grad,
+       credential.age_group_at_grad,
+       credential.psi_birthdate_cleaned_d,
+       credential.psi_award_school_year,
+       credential.record_to_delete,
+       credential.last_date_highest_cred,
+       credential.highest_cred_by_date,
+       credential.highest_cred_by_rank,
+       credential.outcomes_cred,
+       credential.highest_cred_by_school_year,
+       credential.research_university
+INTO   credential_non_dup
+FROM   credential
+INNER JOIN credential_remove_dup
+ON credential.id = credential_remove_dup.id; "
+
+# ---- qry07a1c_tmp_Credential_Gender ----
+qry07a1c_tmp_Credential_Gender <- "
+SELECT DISTINCT encrypted_true_pen,
+                psi_student_number,
+                psi_code,
+                psi_gender_cleaned
+INTO   tmp_credential_epen_gender
+FROM   credential;"
+
+# ---- qry07a1d_tmp_Credential_GenderDups ----
+qry07a1d_tmp_Credential_GenderDups <- "
+SELECT encrypted_true_pen,
+       psi_student_number,
+       psi_code,
+       Count(*) AS Expr1
+INTO   tmp_dup_credential_epen_gender
+FROM   tmp_credential_epen_gender
+GROUP  BY encrypted_true_pen,
+          psi_student_number,
+          psi_code
+HAVING ( Count(*) > 1 );"
+
+
+# ---- qry07a1e_tmp_Credential_GenderDups_FindMaxCredDate ----
+qry07a1e_tmp_Credential_GenderDups_FindMaxCredDate <- "
+SELECT tmp_dup_credential_epen_gender.encrypted_true_pen,
+       tmp_dup_credential_epen_gender.psi_student_number,
+       tmp_dup_credential_epen_gender.psi_code,
+       Max(credential_non_dup.credential_award_date_d) AS
+       Max_Credential_Award_Date
+INTO   tmp_dup_credential_epen_gender_maxcreddate
+FROM   credential_non_dup
+       INNER JOIN tmp_dup_credential_epen_gender
+               ON credential_non_dup.encrypted_true_pen =
+                             tmp_dup_credential_epen_gender.encrypted_true_pen
+                  AND credential_non_dup.psi_student_number =
+                      tmp_dup_credential_epen_gender.psi_student_number
+                  AND credential_non_dup.psi_code =
+                      tmp_dup_credential_epen_gender.psi_code
+GROUP  BY tmp_dup_credential_epen_gender.encrypted_true_pen,
+          tmp_dup_credential_epen_gender.psi_student_number,
+          tmp_dup_credential_epen_gender.psi_code;"
+
+
+# ---- qry07a1f_tmp_Credential_GenderDups_PickGender ----
+qry07a1f_tmp_Credential_GenderDups_PickGender <- "
+UPDATE      tmp_Dup_Credential_EPEN_Gender_MaxCredDate
+SET         PSI_GENDER = Credential_Non_Dup.PSI_GENDER_cleaned
+FROM        tmp_Dup_Credential_EPEN_Gender_MaxCredDate 
+INNER JOIN  Credential_Non_Dup 
+ON          tmp_Dup_Credential_EPEN_Gender_MaxCredDate.ENCRYPTED_TRUE_PEN = Credential_Non_Dup.ENCRYPTED_TRUE_PEN 
+AND         tmp_Dup_Credential_EPEN_Gender_MaxCredDate.Max_Credential_Award_Date = Credential_Non_Dup.CREDENTIAL_AWARD_DATE_D"
+
+
+# ---- qry07a1g_Update_Credential_Non_Dup_GenderDups ----
+qry07a1g_Update_Credential_Non_Dup_GenderDups <- "
+UPDATE    Credential_Non_Dup
+SET       PSI_GENDER_CLEANED = tmp_Dup_Credential_EPEN_Gender_MaxCredDate.PSI_GENDER
+FROM      tmp_Dup_Credential_EPEN_Gender_MaxCredDate 
+INNER JOIN  Credential_Non_Dup 
+ON        tmp_Dup_Credential_EPEN_Gender_MaxCredDate.ENCRYPTED_TRUE_PEN = Credential_Non_Dup.ENCRYPTED_TRUE_PEN 
+AND       Credential_Non_Dup.PSI_GENDER_CLEANED <> tmp_Dup_Credential_EPEN_Gender_MaxCredDate.PSI_GENDER;"
+
+
+# ---- qry07a1h_Update_Credential_GenderDups ----
+qry07a1h_Update_Credential_GenderDups <- "
+UPDATE    Credential
+SET       PSI_GENDER_CLEANED = tmp_Dup_Credential_EPEN_Gender_MaxCredDate.PSI_GENDER
+FROM      Credential 
+INNER JOIN tmp_Dup_Credential_EPEN_Gender_MaxCredDate 
+ON        Credential.ENCRYPTED_TRUE_PEN = tmp_Dup_Credential_EPEN_Gender_MaxCredDate.ENCRYPTED_TRUE_PEN 
+AND       Credential.PSI_GENDER_CLEANED <> tmp_Dup_Credential_EPEN_Gender_MaxCredDate.PSI_GENDER;"
+
+
+# ---- qry07a2a_ExtractNoGender ----
+qry07a2a_ExtractNoGender <- "
+SELECT    id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, psi_gender_cleaned, PSI_CREDENTIAL_CATEGORY 
+INTO      CRED_Extract_No_Gender
+FROM      Credential_Non_Dup
+WHERE     psi_gender_cleaned IN ('', ' ', '(Unspecified)') OR psi_gender_cleaned IS NULL;"
+
+
+# ---- qry07a2b_ExtractNoGenderUnique ----
+qry07a2b_ExtractNoGenderUnique <- "
+SELECT    DISTINCT ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, psi_gender_cleaned, PSI_CREDENTIAL_CATEGORY
+INTO      CRED_Extract_No_Gender_Unique
+FROM      CRED_Extract_No_Gender;"
+
+# ---- qry07a2c_Create_CRED_Extract_No_Gender_EPEN_with_MultiCred ----
+qry07a2c_Create_CRED_Extract_No_Gender_EPEN_with_MultiCred <- "
+SELECT    ENCRYPTED_TRUE_PEN, psi_gender_cleaned, COUNT(*) AS Expr1
+INTO      CRED_Extract_No_Gender_EPEN_with_MultiCred
+FROM      CRED_Extract_No_Gender_Unique
+GROUP BY  ENCRYPTED_TRUE_PEN, psi_gender_cleaned
+HAVING    COUNT(*) > 1;"
+
+# ---- qry07a2d_Update_MultiCredFlag ----
+qry07a2d_Update_MultiCredFlag <- "
+UPDATE    CRED_Extract_No_Gender_Unique
+SET       MultiCredFlag = 'Y'
+FROM      CRED_Extract_No_Gender_Unique
+INNER JOIN CRED_Extract_No_Gender_EPEN_with_MultiCred 
+ON        CRED_Extract_No_Gender_Unique.ENCRYPTED_TRUE_PEN = CRED_Extract_No_Gender_EPEN_with_MultiCred.ENCRYPTED_TRUE_PEN;"
+
+# ---- qry07b_GenderDistribution ----
+qry07b_GenderDistribution <- "
+SELECT psi_gender_cleaned AS PSI_GENDER, PSI_CREDENTIAL_CATEGORY, COUNT(*) AS Expr1
+FROM Credential_Non_Dup
+GROUP BY psi_gender_cleaned, PSI_CREDENTIAL_CATEGORY;"
+
+# ---- qry07c1_Assign_TopID_GenderF_AdvancedCert ----
+qry07c1_Assign_TopID_GenderF_AdvancedCert <- "
+UPDATE TOP (26) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'ADVANCED CERTIFICATE';"
+
+# ---- qry07c2_Assign_TopID_GenderF_AdvancedDip ----
+qry07c2_Assign_TopID_GenderF_AdvancedDip <- "
+UPDATE TOP (18) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'ADVANCED DIPLOMA';
+"
+
+# ---- qry07c3_Assign_TopID_GenderF_Apprenticeship ----
+qry07c3_Assign_TopID_GenderF_Apprenticeship <- "
+UPDATE TOP (1) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'APPRENTICESHIP';
+"
+
+# ---- qry07c4_Assign_TopID_GenderF_AssocDegree ----
+qry07c4_Assign_TopID_GenderF_AssocDegree <- "
+UPDATE TOP (30) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'ASSOCIATE DEGREE';
+"
+
+# ---- qry07c5_Assign_TopID_GenderF_Bachelor ----
+qry07c5_Assign_TopID_GenderF_Bachelor <- "
+UPDATE TOP (1643) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'BACHELORS DEGREE';
+"
+
+# ---- qry07c6_Assign_TopID_GenderF_Certificate ----
+qry07c6_Assign_TopID_GenderF_Certificate <- "
+UPDATE TOP (795) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'CERTIFICATE';
+"
+
+# ---- qry07c7_Assign_TopID_GenderF_Diploma ----
+qry07c7_Assign_TopID_GenderF_Diploma <- "
+UPDATE TOP (465) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'DIPLOMA';
+"
+
+# ---- qry07c8_Assign_TopID_GenderF_Doctorate ----
+qry07c8_Assign_TopID_GenderF_Doctorate <- "
+UPDATE TOP (63) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'DOCTORATE';
+"
+
+# ---- qry07c9_Assign_TopID_GenderF_FirstProfDeg ----
+qry07c9_Assign_TopID_GenderF_FirstProfDeg <- "
+UPDATE TOP (26) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'FIRST PROFESSIONAL DEGREE';"
+
+# ---- qry07c10_Assign_TopID_GenderF_GradCert ----
+qry07c10_Assign_TopID_GenderF_GradCert <- "
+UPDATE TOP (1) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'GRADUATE CERTIFICATE';
+"
+
+# ---- qry07c11_Assign_TopID_GenderF_GradDipl ----
+qry07c11_Assign_TopID_GenderF_GradDipl <- "
+UPDATE TOP (101) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'GRADUATE DIPLOMA';
+"
+
+# ---- qry07c12_Assign_TopID_GenderF_Masters ----
+qry07c12_Assign_TopID_GenderF_Masters <- "
+UPDATE TOP (457) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'MASTERS DEGREE';
+"
+
+# ---- qry07c13_Assign_TopID_GenderF_PostDegCert ----
+qry07c13_Assign_TopID_GenderF_PostDegCert <- "
+UPDATE TOP (40) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'POST-DEGREE CERTIFICATE';
+"
+
+# ---- qry07c14_Assign_TopID_GenderF_PostDegDipl ----
+qry07c14_Assign_TopID_GenderF_PostDegDipl <- "
+UPDATE TOP (248) CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Female'
+WHERE PSI_CREDENTIAL_CATEGORY = 'POST-DEGREE DIPLOMA';
+"
+
+
+# ---- qry07c_Assign_TopID_GenderM ----
+qry07c_Assign_TopID_GenderM <- "
+UPDATE CRED_Extract_No_Gender_Unique
+SET PSI_GENDER_CLEANED = 'Gender Diverse'
+WHERE PSI_GENDER_CLEANED NOT IN('Female','Male') OR PSI_GENDER_CLEANED IS NULL;
+"
+
+
+# ---- qry07d_CorrectGender1 ----
+qry07d_CorrectGender1 <- "
+UPDATE CRED_Extract_No_Gender
+SET PSI_GENDER_CLEANED = CRED_Extract_No_Gender_Unique.PSI_GENDER_CLEANED
+FROM CRED_Extract_No_Gender_Unique
+INNER JOIN CRED_Extract_No_Gender ON CRED_Extract_No_Gender_Unique.ENCRYPTED_TRUE_PEN = CRED_Extract_No_Gender.ENCRYPTED_TRUE_PEN;"
+
+
+# ---- qry07d_CorrectGender2 ----
+qry07d_CorrectGender2 <- "
+UPDATE    Credential_Non_Dup
+SET       PSI_GENDER_CLEANED = CRED_Extract_No_Gender.PSI_GENDER_CLEANED
+FROM      CRED_Extract_No_Gender 
+INNER JOIN Credential_Non_Dup ON CRED_Extract_No_Gender.id = Credential_Non_Dup.id;"
+
+
+# ---- qry08_Create_Credential_Ranking_View a ----
+qry08_Create_Credential_Ranking_View_a <-
+  "SELECT        a.id, a.ENCRYPTED_TRUE_PEN, 
+a.CREDENTIAL_AWARD_DATE_D, 
+CredentialRank.RANK, 
+a.Highest_Cred_by_Date, 
+a.Highest_Cred_by_Rank, 
+a.Highest_Cred_by_School_Year
+INTO              tmp_Credential_Ranking_step1
+FROM            Credential_Non_Dup AS a INNER JOIN
+                         CredentialRank ON a.PSI_CREDENTIAL_CATEGORY = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE        (a.ENCRYPTED_TRUE_PEN IN
+                             (SELECT        ENCRYPTED_TRUE_PEN
+                               FROM            Credential_Non_Dup AS b
+                               GROUP BY ENCRYPTED_TRUE_PEN
+                               HAVING         (COUNT(ENCRYPTED_TRUE_PEN) > 1) 
+                               AND (ENCRYPTED_TRUE_PEN IS NOT NULL) 
+AND (ENCRYPTED_TRUE_PEN NOT IN ('', ' ', '(Unspecified)'))))"
+
+# ---- qry08_Create_Credential_Ranking_View b ----
+qry08_Create_Credential_Ranking_View_b <-
+  "SELECT        a.id, a.ENCRYPTED_TRUE_PEN, a.PSI_STUDENT_NUMBER, a.psi_code, a.CREDENTIAL_AWARD_DATE_D, CredentialRank.RANK, a.Highest_Cred_by_Date, a.Highest_Cred_by_Rank, 
+                         a.Highest_Cred_by_School_Year
+INTO              tmp_CredentialNonDup_STUD_NUM_PSI_CODE_MoreThanOne
+FROM            Credential_Non_Dup AS a INNER JOIN
+                         CredentialRank ON a.PSI_CREDENTIAL_CATEGORY = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE        (a.PSI_STUDENT_NUMBER IN
+                             (SELECT        PSI_STUDENT_NUMBER
+                               FROM            Credential_Non_Dup AS b
+                               GROUP BY ENCRYPTED_TRUE_PEN,PSI_STUDENT_NUMBER
+                               HAVING         (COUNT(PSI_STUDENT_NUMBER) > 1) AND ((ENCRYPTED_TRUE_PEN IS NULL) OR (ENCRYPTED_TRUE_PEN IN ('', ' ', '(Unspecified)')))))"
+
+
+# ---- qry08_Create_Credential_Ranking_View c ----
+qry08_Create_Credential_Ranking_View_c <-
+  "SELECT        a.id, a.ENCRYPTED_TRUE_PEN, a.PSI_STUDENT_NUMBER, a.PSI_CODE, a.CREDENTIAL_AWARD_DATE_D, CredentialRank.RANK, a.Highest_Cred_by_Date, 
+                         a.Highest_Cred_by_Rank, a.Highest_Cred_by_School_Year
+INTO              tmp_Credential_Ranking_step2
+FROM            Credential_Non_Dup AS a INNER JOIN
+                         CredentialRank ON a.PSI_CREDENTIAL_CATEGORY = CredentialRank.PSI_CREDENTIAL_CATEGORY INNER JOIN
+                         tmp_CredentialNonDup_STUD_NUM_PSI_CODE_MoreThanOne ON 
+                         a.PSI_STUDENT_NUMBER = tmp_CredentialNonDup_STUD_NUM_PSI_CODE_MoreThanOne.PSI_STUDENT_NUMBER AND 
+                         a.PSI_CODE = tmp_CredentialNonDup_STUD_NUM_PSI_CODE_MoreThanOne.PSI_CODE AND 
+                         a.ENCRYPTED_TRUE_PEN = tmp_CredentialNonDup_STUD_NUM_PSI_CODE_MoreThanOne.ENCRYPTED_TRUE_PEN"
+
+# ---- qry08_Create_Credential_Ranking_View d ----
+qry08_Create_Credential_Ranking_View_d <-
+  "SELECT        id, ENCRYPTED_TRUE_PEN, CREDENTIAL_AWARD_DATE_D, RANK, Highest_Cred_by_Date, Highest_Cred_by_Rank, Highest_Cred_by_School_Year
+INTO              tmp_Credential_Ranking_step3
+FROM            tmp_Credential_Ranking_step1"
+
+# ---- qry08_Create_Credential_Ranking_View e ----
+qry08_Create_Credential_Ranking_View_e <-
+  "INSERT INTO tmp_Credential_Ranking_step3
+                         (id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, CREDENTIAL_AWARD_DATE_D, RANK, Highest_Cred_by_Date, Highest_Cred_by_Rank, 
+                         Highest_Cred_by_School_Year)
+SELECT        id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, CREDENTIAL_AWARD_DATE_D, RANK, Highest_Cred_by_Date, Highest_Cred_by_Rank, 
+                         Highest_Cred_by_School_Year
+FROM            tmp_Credential_Ranking_step2"
+
+# ---- qry08_Create_Credential_Ranking_View f ----
+qry08_Create_Credential_Ranking_View_f <-
+  "SELECT        id, ENCRYPTED_TRUE_PEN, CREDENTIAL_AWARD_DATE_D, RANK, Highest_Cred_by_Date, Highest_Cred_by_Rank, Highest_Cred_by_School_Year, 
+                         PSI_STUDENT_NUMBER, PSI_CODE
+FROM            tmp_Credential_Ranking_step3;"
+
+# ---- qry08_Create_Credential_Ranking_View_g----
+qry08_Create_Credential_Ranking_View_g <- "
+CREATE VIEW Credential_Ranking 
+AS
+SELECT  id, 
+        ENCRYPTED_TRUE_PEN, 
+        PSI_STUDENT_NUMBER, 
+        PSI_CODE,
+        CREDENTIAL_AWARD_DATE_D, 
+        RANK, 
+        Highest_Cred_by_Date, 
+        Highest_Cred_by_Rank, 
+        Highest_Cred_by_School_Year
+FROM    tmp_Credential_Ranking_step3;"
+
+
+# ---- qry08a1_Update_CredentialNonDup_with_highestDate_Rank ----
+qry08a1_Update_CredentialNonDup_with_highestDate_Rank <- "
+UPDATE  Credential_Non_Dup
+SET     Highest_Cred_by_Date = tmp_Credential_Ranking.Highest_Cred_by_Date, 
+        Highest_Cred_by_Rank = tmp_Credential_Ranking.Highest_Cred_by_Rank
+FROM    Credential_Non_Dup
+INNER JOIN tmp_Credential_Ranking ON Credential_Non_Dup.id = tmp_Credential_Ranking.id;
+"
+
+# ---- qry08a_Run_after_Credential_Ranking ----
+qry08a_Run_after_Credential_Ranking <- "
+UPDATE  Credential_Ranking
+SET     Highest_Cred_by_Date = tmp_Credential_Ranking.Highest_Cred_by_Date, 
+        Highest_Cred_by_Rank = tmp_Credential_Ranking.Highest_Cred_by_Rank
+FROM    tmp_Credential_Ranking
+INNER JOIN Credential_Ranking ON tmp_Credential_Ranking.id = Credential_Ranking.id;
+"
+
+# ---- qry08b_Rank_non_multi_cred ----
+qry08b_Rank_non_multi_cred <- "
+UPDATE Credential_Non_Dup
+SET Credential_Non_Dup.Highest_Cred_by_Date = 'Yes', 
+    Credential_Non_Dup.Highest_Cred_by_Rank = 'Yes'
+WHERE NOT EXISTS (
+SELECT * FROM tmp_Credential_Ranking
+WHERE tmp_Credential_Ranking.ID = Credential_Non_Dup.ID)"
+
+
+# ---- qry09a_ExtractNoAge ----
+qry09a_ExtractNoAge <- "
+SELECT  id, ENCRYPTED_TRUE_PEN, AGE_AT_GRAD, psi_gender_cleaned, PSI_AWARD_SCHOOL_YEAR, 
+PSI_CREDENTIAL_CATEGORY, CREDENTIAL_AWARD_DATE_D, 0 AS LASTCRED, HIGHEST_CRED_BY_DATE
+INTO    CRED_Extract_No_Age
+FROM    Credential_Non_Dup
+WHERE   (AGE_AT_GRAD IS NULL);
+"
+
+# ---- qry09b_ExtractNoAgeUnique ----
+qry09b_ExtractNoAgeUnique <- "
+SELECT  id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, AGE_AT_GRAD, PSI_GENDER_CLEANED, 
+PSI_CREDENTIAL_CATEGORY, CREDENTIAL_AWARD_DATE_D, PSI_AWARD_SCHOOL_YEAR
+INTO    CRED_Extract_No_Age_Unique
+FROM    Credential_Non_Dup
+WHERE   (AGE_AT_GRAD IS NULL) AND (Highest_Cred_by_Date = 'Yes');
+"
+
+
+# ---- qry09c_Create_CREDAgeDistributionGender ----
+qry09c_Create_CREDAgeDistributionGender <- "CREATE TABLE CREDAgeDistributionbyGender(
+	[PSI_GENDER_CLEANED] [varchar](10) NULL,
+	[AGE_AT_GRAD] [numeric](18, 0) NULL,
+	[PSI_CREDENTIAL_CATEGORY] [varchar](50) NULL,
+	[NumGrads] [int] NULL,
+	[PropGrads] [decimal](18, 5) NULL,
+	[NumDistribution] [int] NULL
+) ON [PRIMARY]
+;"
+
+# ---- qry09d_ShowAgeGenderDistribution ----
+qry09d_ShowAgeGenderDistribution <- "
+SELECT     PSI_GENDER_CLEANED, AGE_AT_GRAD, PSI_CREDENTIAL_CATEGORY, COUNT(*) AS NumGrads
+FROM         Credential_Non_Dup
+WHERE     (AGE_GROUP_AT_GRAD IS NOT NULL) AND (Highest_Cred_by_Date = 'Yes')
+GROUP BY   PSI_GENDER_CLEANED, AGE_AT_GRAD, PSI_CREDENTIAL_CATEGORY;"
+
+
+# ---- qry10_Update_Extract_No_Age ----
+qry10_Update_Extract_No_Age <- "
+UPDATE    CRED_Extract_No_Age
+SET       AGE_AT_GRAD = CRED_Extract_No_Age_Unique.AGE_AT_GRAD
+FROM      CRED_Extract_No_Age_Unique
+INNER JOIN CRED_Extract_No_Age 
+ON CRED_Extract_No_Age_Unique.id = CRED_Extract_No_Age.id;"
+
+# ---- qry11a_UpdateAgeAtGrad ----
+qry11a_UpdateAgeAtGrad <- "
+UPDATE    Credential_Non_Dup
+SET       AGE_AT_GRAD = CRED_Extract_No_Age.AGE_AT_GRAD
+FROM      CRED_Extract_No_Age INNER JOIN
+          Credential_Non_Dup ON CRED_Extract_No_Age.id = Credential_Non_Dup.id;"
+
+# ---- qry11b_UpdateAGAtGrad ----
+qry11b_UpdateAGAtGrad <- "
+UPDATE    Credential_Non_Dup
+SET       AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex
+FROM      Credential_Non_Dup 
+INNER JOIN AgeGroupLookup 
+ON Credential_Non_Dup.AGE_AT_GRAD >= AgeGroupLookup.LowerBound AND Credential_Non_Dup.AGE_AT_GRAD <= AgeGroupLookup.UpperBound;"
+
+# ---- qry12_Create_View_tblCredentialHighestRank ----
+qry12_Create_View_tblCredentialHighestRank <- "
+CREATE VIEW tblCredential_HighestRank AS
+SELECT    Credential_Non_Dup.id, 
+          -- Credential_Non_Dup.PSI_PEN,
+          Credential_Non_Dup.psi_birthdate_cleaned, 
+          Credential_Non_Dup.psi_gender_cleaned, 
+          Credential_Non_Dup.ENCRYPTED_TRUE_PEN, 
+          Credential_Non_Dup.PSI_STUDENT_NUMBER,
+          Credential_Non_Dup.PSI_SCHOOL_YEAR,
+          Credential_Non_Dup.PSI_CODE, 
+          Credential_Non_Dup.CREDENTIAL_AWARD_DATE, 
+          Credential_Non_Dup.RecordStatus, 
+          Credential_Non_Dup.PSI_PROGRAM_CODE, 
+          Credential_Non_Dup.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
+          Credential_Non_Dup.PSI_CREDENTIAL_CIP, 
+          Credential_Non_Dup.PSI_CREDENTIAL_LEVEL, 
+          Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, 
+          Credential_Non_Dup.CREDENTIAL_AWARD_DATE_D, 
+          Credential_Non_Dup.AGE_AT_GRAD, Credential_Non_Dup.AGE_GROUP_AT_GRAD, 
+          Credential_Non_Dup.psi_birthdate_cleaned_D,
+		      Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR, 
+          Credential_Non_Dup.RECORD_TO_DELETE, 
+          Credential_Non_Dup.Last_Date_Highest_Cred, 
+          Credential_Non_Dup.Highest_Cred_by_Date, 
+          Credential_Non_Dup.Highest_Cred_by_Rank, 
+          Credential_Non_Dup.OUTCOMES_CRED, 
+          Credential_Non_Dup.Highest_Cred_by_School_Year, 
+          Credential_Non_Dup.RESEARCH_UNIVERSITY, 
+          Credential_Non_Dup.CONCATENATED_ID,
+          CredentialSupVars.CREDENTIAL_AWARD_DATE_D_DELAYED, 
+          CredentialSupVars.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+          CredentialSupVars.PSI_VISA_STATUS
+FROM      Credential_Non_Dup INNER JOIN CredentialSupVars 
+  ON      Credential_Non_Dup.id = CredentialSupVars.ID
+WHERE     Credential_Non_Dup.Highest_Cred_by_Rank = 'Yes'"
+
+# ---- qry13_UpdateDelayedCredDate ----
+qry13_UpdateDelayedCredDate <- "
+UPDATE  tblCredential_HighestRank
+SET     CREDENTIAL_AWARD_DATE_D_DELAYED = CREDENTIAL_AWARD_DATE_D, 
+        PSI_AWARD_SCHOOL_YEAR_DELAYED = PSI_AWARD_SCHOOL_YEAR
+WHERE     (CREDENTIAL_AWARD_DATE_D_DELAYED IS NULL);"
+
+
+# ---- qry13a_UpdateDelayedCredDate ----
+qry13a_UpdateDelayedCredDate <- "
+UPDATE    Credential_Non_Dup
+SET              CREDENTIAL_AWARD_DATE_D_DELAYED = tblCredential_HighestRank.CREDENTIAL_AWARD_DATE_D_DELAYED, 
+                      PSI_AWARD_SCHOOL_YEAR_DELAYED = tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+FROM         tblCredential_HighestRank INNER JOIN
+                      Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE     (tblCredential_HighestRank.CREDENTIAL_AWARD_DATE_D_DELAYED IS NOT NULL) AND 
+                      (tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED IS NOT NULL);"
+
+# ---- qry13b_UpdateDelayedCredDate ----
+qry13b_UpdateDelayedCredDate <- "
+UPDATE    Credential_Non_Dup
+SET       CREDENTIAL_AWARD_DATE_D_DELAYED = CREDENTIAL_AWARD_DATE_D, 
+          PSI_AWARD_SCHOOL_YEAR_DELAYED = PSI_AWARD_SCHOOL_YEAR
+WHERE     (CREDENTIAL_AWARD_DATE_D_DELAYED IS NULL);"
+
+
+# ---- qry14_ResearchUniversity ----
+qry14_ResearchUniversity <- "UPDATE    Credential_Non_Dup
+SET              RESEARCH_UNIVERSITY = 1
+WHERE     (PSI_CODE = 'SFU') OR
+                      (PSI_CODE = 'UBC') OR
+					  (PSI_CODE = 'UBCV') OR
+                      (PSI_CODE = 'UBCO') OR
+                      (PSI_CODE = 'UNBC') OR
+                      (PSI_CODE = 'UVIC') OR
+                      (PSI_CODE = 'RRU');"
+
+
+# ---- qry14_ResearchUniversity_Exclude_LatestYr ----
+qry14_ResearchUniversity_Exclude_LatestYr <- "
+UPDATE    Credential_Non_Dup_Exclude_LatestYr
+SET              RESEARCH_UNIVERSITY = 1
+WHERE     (PSI_CODE = 'SFU') OR
+                      (PSI_CODE = 'UBC') OR
+                      (PSI_CODE = 'UBCO') OR
+                      (PSI_CODE = 'UNBC') OR
+                      (PSI_CODE = 'UVIC') OR
+                      (PSI_CODE = 'RRU');"
+
+
+# ---- qry15_OutcomeCredential ----
+qry15_OutcomeCredential <- "UPDATE    Credential_Non_Dup
+SET              OUTCOMES_CRED = OutcomeCredential.Outcomes_CRED
+FROM         Credential_Non_Dup INNER JOIN
+                      OutcomeCredential ON Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY = OutcomeCredential.PSI_CREDENTIAL_CATEGORY;"
+
+
+# ---- qry15_OutcomeCredential_Exclude_LatestYr ----
+qry15_OutcomeCredential_Exclude_LatestYr <- "UPDATE    Credential_Non_Dup_Exclude_LatestYr
+SET              OUTCOMES_CRED = OutcomeCredential.Outcomes_CRED
+FROM         Credential_Non_Dup_Exclude_LatestYr INNER JOIN
+                      OutcomeCredential ON Credential_Non_Dup_Exclude_LatestYr.PSI_CREDENTIAL_CATEGORY = OutcomeCredential.PSI_CREDENTIAL_CATEGORY;"
+
+
+# ---- qry20a_1Credential_By_Year_AgeGroup ----
+qry20a_1Credential_By_Year_AgeGroup <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_AgeGroup
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_1Credential_By_Year_AgeGroup_Exclude_CIPs ----
+qry20a_1Credential_By_Year_AgeGroup_Exclude_CIPs <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_AgeGroup_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09' AND Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10')
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_2Credential_By_Year_AgeGroup_Domestic ----
+qry20a_2Credential_By_Year_AgeGroup_Domestic <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_AgeGroup_Domestic
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL)
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_2Credential_By_Year_AgeGroup_Domestic_Exclude_CIPs ----
+qry20a_2Credential_By_Year_AgeGroup_Domestic_Exclude_CIPs <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_AgeGroup_Domestic_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09' AND 
+                         Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09' AND 
+                         Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10')
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_3Credential_By_Year_AgeGroup_Domestic_Exclude_RU_DACSO ----
+qry20a_3Credential_By_Year_AgeGroup_Domestic_Exclude_RU_DACSO <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_AgeGroup_Domestic_Exclude_RU_DACSO
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL)
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_4Credential_By_Year_CIP4_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
+qry20a_4Credential_By_Year_CIP4_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "
+SELECT        AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup AS Expr1, Credential_Non_Dup.FINAL_CIP_CODE_4, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_CIP4_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10')
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         Credential_Non_Dup.FINAL_CIP_CODE_4
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, Credential_Non_Dup.FINAL_CIP_CODE_4, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_4Credential_By_Year_CIP4_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
+qry20a_4Credential_By_Year_CIP4_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "SELECT        tblCredential_HighestRank.psi_gender_cleaned, AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup + tblCredential_HighestRank.psi_gender_cleaned AS Expr1, 
+                         Credential_Non_Dup.FINAL_CIP_CODE_4, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_CIP4_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10')
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         tblCredential_HighestRank.psi_gender_cleaned, Credential_Non_Dup.FINAL_CIP_CODE_4
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         tblCredential_HighestRank.psi_gender_cleaned DESC;"
+
+
+# ---- qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_CIPs ----
+qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_CIPs <- "SELECT        tblCredential_HighestRank.psi_gender_cleaned, AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup + tblCredential_HighestRank.psi_gender_cleaned AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10')
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         tblCredential_HighestRank.psi_gender_cleaned
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         tblCredential_HighestRank.psi_gender_cleaned DESC;"
+
+
+# ---- qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
+qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "SELECT        tblCredential_HighestRank.psi_gender_cleaned, AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup + tblCredential_HighestRank.psi_gender_cleaned AS Expr1, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) 
+                         AS Count
+INTO Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL)
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, tblCredential_HighestRank.psi_gender_cleaned
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, tblCredential_HighestRank.psi_gender_cleaned DESC;"
+
+
+# ---- qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
+qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "
+SELECT        PSI_CODE_RECODE.PSI_TYPE_RECODE, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY AS Expr1, 
+                         tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id INNER JOIN
+                         PSI_CODE_RECODE ON tblCredential_HighestRank.PSI_CODE = PSI_CODE_RECODE.PSI_CODE
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) AND (AgeGroupLookup.AgeIndex <> 9) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) AND 
+                         (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) AND (AgeGroupLookup.AgeIndex <> 9) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) AND 
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9)
+GROUP BY tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+                         PSI_CODE_RECODE.PSI_TYPE_RECODE
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs_Not_Highest ----
+qry20a_4Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs_Not_Highest <- "
+SELECT        PSI_CODE_RECODE.PSI_TYPE_RECODE, Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY AS Expr1, 
+                         Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Count
+INTO Credential_By_Year_PSI_TYPE_Domestic_Exclude_RU_DACSO_Exclude_CIPs_Not_Highest
+FROM            AgeGroupLookup INNER JOIN
+                         Credential_Non_Dup ON AgeGroupLookup.AgeIndex = Credential_Non_Dup.AGE_GROUP_AT_GRAD INNER JOIN
+                         PSI_CODE_RECODE ON Credential_Non_Dup.PSI_CODE = PSI_CODE_RECODE.PSI_CODE INNER JOIN
+                         CredentialSupVars ON Credential_Non_Dup.id = CredentialSupVars.ID
+WHERE        (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9) AND (CredentialSupVars.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND 
+                         (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9) AND (CredentialSupVars.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND 
+                         (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9) AND (CredentialSupVars.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL) OR
+                         (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND (AgeGroupLookup.AgeIndex <> 1) 
+                         AND (AgeGroupLookup.AgeIndex <> 9) AND (CredentialSupVars.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL)
+GROUP BY Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR_DELAYED, PSI_CODE_RECODE.PSI_TYPE_RECODE
+HAVING        (Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR_DELAYED;"
+
+
+# ---- qry20a_99_Checking_Excluding_RU_DACSO_Variables ----
+qry20a_99_Checking_Excluding_RU_DACSO_Variables <- "
+SELECT        RESEARCH_UNIVERSITY, OUTCOMES_CRED, PSI_CODE, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) AS Expr1
+INTO Checking_Excluding_RU_DACSO_Variables
+FROM            Credential_Non_Dup
+GROUP BY RESEARCH_UNIVERSITY, PSI_CODE, OUTCOMES_CRED, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED
+HAVING        (RESEARCH_UNIVERSITY = 1) AND (OUTCOMES_CRED = 'DACSO') AND (PSI_AWARD_SCHOOL_YEAR_DELAYED = '2018/2019')
+ORDER BY OUTCOMES_CRED, RESEARCH_UNIVERSITY;"
+
+
+# ---- qry_Update_Cdtl_Sup_Vars_InternationalFlag ----
+qry_Update_Cdtl_Sup_Vars_InternationalFlag <- "UPDATE    CredentialSupVars SET  International_Include_Flag = 
+tbl_CredentialHighestRank_International.International_Include_Flag 
+FROM         CredentialSupVars INNER JOIN 
+tbl_CredentialHighestRank_International ON 
+CredentialSupVars.ID = tbl_CredentialHighestRank_International.id;"
+
+
+# ---- NOT USED ------
+
+#  ---- qry04a_UpdateCredentialSupVarsRecordStatus  ----
+qry04a_UpdateCredentialSupVarsRecordStatus <- "
+UPDATE    CredentialSupVars
+SET       CredentialRecordStatus = 0
+WHERE     (CredentialRecordStatus = 4);"
+
+
+# ---- qry08_Create_Credential_Ranking_View_Exclude_LatestYr ----
+qry08_Create_Credential_Ranking_View_Exclude_LatestYr <- "
+SELECT  a.id, 
+        a.ENCRYPTED_TRUE_PEN, 
+        a.CREDENTIAL_AWARD_DATE_D, 
+        CredentialRank.RANK, 
+        a.Highest_Cred_by_Date, 
+        a.Highest_Cred_by_Rank, 
+        a.Highest_Cred_by_School_Year, 
+        a.PSI_AWARD_SCHOOL_YEAR
+FROM    Credential_Non_Dup AS a 
+INNER JOIN CredentialRank ON a.PSI_CREDENTIAL_CATEGORY = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE   (a.ENCRYPTED_TRUE_PEN IN (
+            SELECT  ENCRYPTED_TRUE_PEN
+            FROM    Credential_Non_Dup AS b
+            GROUP BY ENCRYPTED_TRUE_PEN
+            HAVING  (COUNT(ENCRYPTED_TRUE_PEN) > 1)
+        )) 
+        AND (a.PSI_AWARD_SCHOOL_YEAR <> '2011/2012');"
+
+
+# ---- qry08a_Run_after_Credential_Ranking_Exclude_LatestYr ----
+qry08a_Run_after_Credential_Ranking_Exclude_LatestYr <- "
+UPDATE  Credential_Ranking_Exclude_LatestYr
+SET     Highest_Cred_by_Date = tmp_Credential_Ranking_Exclude_LatestYr.Highest_Cred_by_Date, 
+        Highest_Cred_by_Rank = tmp_Credential_Ranking_Exclude_LatestYr.Highest_Cred_by_Rank
+        --Highest_Cred_by_School_Year = tmp_Credential_Ranking_Exclude_LatestYr.Highest_Cred_by_School_Year
+FROM    tmp_Credential_Ranking_Exclude_LatestYr
+INNER JOIN Credential_Ranking_Exclude_LatestYr ON tmp_Credential_Ranking_Exclude_LatestYr.id = Credential_Ranking_Exclude_LatestYr.id;
+"
+
+# ---- qry12_Create_View_tblCredentialHighestRank_Exclude_LatestYr ----
+qry12_Create_View_tblCredentialHighestRank_Exclude_LatestYr <-
+  "SELECT     Credential_Non_Dup_Exclude_LatestYr.id, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_PEN, Credential_Non_Dup_Exclude_LatestYr.PSI_BIRTHDATE, 
+            Credential_Non_Dup_Exclude_LatestYr.psi_birthdate_cleaned, Credential_Non_Dup_Exclude_LatestYr.PSI_GENDER, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_STUDENT_NUMBER, Credential_Non_Dup_Exclude_LatestYr.ENCRYPTED_TRUE_PEN, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_SCHOOL_YEAR, Credential_Non_Dup_Exclude_LatestYr.PSI_STUD_POSTAL_CD_CURR, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_ENROLMENT_SEQUENCE, Credential_Non_Dup_Exclude_LatestYr.PSI_CODE, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_MIN_START_DATE, Credential_Non_Dup_Exclude_LatestYr.CREDENTIAL_AWARD_DATE, 
+            Credential_Non_Dup_Exclude_LatestYr.RecordStatus, Credential_Non_Dup_Exclude_LatestYr.PSI_PROGRAM_CODE, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, Credential_Non_Dup_Exclude_LatestYr.PSI_CIP_CODE, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_CREDENTIAL_CIP, Credential_Non_Dup_Exclude_LatestYr.PSI_CONTINUING_EDUCATION_COURSE_ONLY, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_CREDENTIAL_LEVEL, Credential_Non_Dup_Exclude_LatestYr.PSI_CREDENTIAL_CATEGORY, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_MIN_START_DATE_D, Credential_Non_Dup_Exclude_LatestYr.CREDENTIAL_AWARD_DATE_D, 
+            Credential_Non_Dup_Exclude_LatestYr.AGE_AT_GRAD, Credential_Non_Dup_Exclude_LatestYr.AGE_GROUP_AT_GRAD, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_BIRTHDATE_D, Credential_Non_Dup_Exclude_LatestYr.psi_birthdate_cleaned_D, 
+            Credential_Non_Dup_Exclude_LatestYr.PSI_AWARD_SCHOOL_YEAR, Credential_Non_Dup_Exclude_LatestYr.RECORD_TO_DELETE, 
+            Credential_Non_Dup_Exclude_LatestYr.Last_Date_Highest_Cred, Credential_Non_Dup_Exclude_LatestYr.Highest_Cred_by_Date, 
+            Credential_Non_Dup_Exclude_LatestYr.Highest_Cred_by_Rank, Credential_Non_Dup_Exclude_LatestYr.OUTCOMES_CRED, 
+            Credential_Non_Dup_Exclude_LatestYr.Highest_Cred_by_School_Year, Credential_Non_Dup_Exclude_LatestYr.RESEARCH_UNIVERSITY, 
+            Credential_Non_Dup_Exclude_LatestYr.CredentialRecordStatus, CredentialSupVars.CREDENTIAL_AWARD_DATE_D_DELAYED, 
+            CredentialSupVars.PSI_AWARD_SCHOOL_YEAR_DELAYED, CredentialSupVars.PSI_VISA_STATUS
+FROM        Credential_Non_Dup_Exclude_LatestYr INNER JOIN
+CredentialSupVars ON Credential_Non_Dup_Exclude_LatestYr.id = CredentialSupVars.ID
+WHERE     (Credential_Non_Dup_Exclude_LatestYr.Highest_Cred_by_Rank = 'Yes')"
+
+###############################################################################################
+# ---- qry01_CredentialSupVars_From_Enrolment ----
+qry01_CredentialSupVars_From_Enrolment <- "
+SELECT     ENCRYPTED_TRUE_PEN, MAX(PSI_SCHOOL_YEAR) AS MaxSchoolYear
+INTO       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1
+FROM       STP_Enrolment_Valid
+GROUP BY   ENCRYPTED_TRUE_PEN
+HAVING     (ENCRYPTED_TRUE_PEN IS NOT NULL) AND (ENCRYPTED_TRUE_PEN NOT IN ('', ' ', '(Unspecified)'))"
+
+# ---- qry02_CredentialSupVars_From_Enrolment ----
+qry02_CredentialSupVars_From_Enrolment <- "
+SELECT      STP_Enrolment_Valid.ID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER,
+            STP_Enrolment_Valid.PSI_CODE, tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1.MaxSchoolYear
+INTO        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2
+FROM        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1 
+INNER JOIN  STP_Enrolment_Valid 
+  ON        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1.ENCRYPTED_TRUE_PEN = STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN 
+  AND       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1.MaxSchoolYear = STP_Enrolment_Valid.PSI_SCHOOL_YEAR
+GROUP BY    STP_Enrolment_Valid.ID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, 
+            STP_Enrolment_Valid.PSI_CODE, tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step1.MaxSchoolYear"
+
+# ---- qry03_CredentialSupVars_From_Enrolment ----
+qry03_CredentialSupVars_From_Enrolment <- "
+ALTER TABLE tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2
+ADD CONSTRAINT tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2_PK_ID
+PRIMARY KEY (ID);"
+
+# ---- qry04_CredentialSupVars_From_Enrolment ----
+qry04_CredentialSupVars_From_Enrolment <- "
+SELECT  STP_Enrolment_Valid.ID, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
+        STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE, 
+        STP_Enrolment_Valid.PSI_CODE, STP_Enrolment_Valid.PSI_MIN_START_DATE
+INTO    tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
+FROM    tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2 
+INNER JOIN STP_Enrolment_Valid 
+  ON tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2.ID = STP_Enrolment_Valid.ID"
+
+# ---- qry05_CredentialSupVars_From_Enrolment ----
+qry05_CredentialSupVars_From_Enrolment <- "                         
+ALTER TABLE tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
+ADD CONSTRAINT tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3_PK_ID
+PRIMARY KEY (ID);"
+
+# ---- qry06_CredentialSupVars_From_Enrolment ----
+qry06_CredentialSupVars_From_Enrolment <- "
+SELECT        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID AS EnrolmentID, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ENCRYPTED_TRUE_PEN, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_MIN_START_DATE, 
+              Credential.RecordStatus AS CredentialRecordStatus, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_SCHOOL_YEAR, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_ENROLMENT_SEQUENCE
+INTO          CredentialSupVarsFromEnrolment
+FROM          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3 
+INNER JOIN    Credential 
+  ON          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ENCRYPTED_TRUE_PEN = Credential.ENCRYPTED_TRUE_PEN
+GROUP BY      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ENCRYPTED_TRUE_PEN, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_MIN_START_DATE,
+              Credential.RecordStatus, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_SCHOOL_YEAR, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_ENROLMENT_SEQUENCE"
+
+
+# ---- qry07_CredentialSupVars_From_Enrolment ----
+qry07_CredentialSupVars_From_Enrolment <- "    
+SELECT          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ENCRYPTED_TRUE_PEN, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_SCHOOL_YEAR, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_ENROLMENT_SEQUENCE, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE, 
+                tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_MIN_START_DATE
+INTO            tmp_tbl_Enrol_ID_EPEN_for_Cred_Join_step4
+FROM            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3 
+INNER JOIN      RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE 
+  ON            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER = RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE.PSI_STUDENT_NUMBER 
+  AND           tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE = RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE.PSI_CODE"
+
+
+# ---- qry08_CredentialSupVars_From_Enrolment ----
+qry08_CredentialSupVars_From_Enrolment <- "
+SELECT        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID AS EnrolmentID, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ENCRYPTED_TRUE_PEN AS EnrolEPEN, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_SCHOOL_YEAR, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_ENROLMENT_SEQUENCE, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_MIN_START_DATE, 
+              RW_TEST_CRED_NULLEPENS_TO_MATCH.ID AS CredentialID
+INTO          RW_TEST_CRED_NULLEPENS_MATCHED
+FROM          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3 
+INNER JOIN    RW_TEST_CRED_NULLEPENS_TO_MATCH 
+  ON          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER = RW_TEST_CRED_NULLEPENS_TO_MATCH.PSI_STUDENT_NUMBER 
+  AND         tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE = RW_TEST_CRED_NULLEPENS_TO_MATCH.PSI_CODE"
+
+# ---- qry09_CredentialSupVars_From_Enrolment ----
+qry09_CredentialSupVars_From_Enrolment <- "
+SELECT     ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, MAX(PSI_SCHOOL_YEAR) AS MaxSchoolYear
+INTO       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4
+FROM       STP_Enrolment_Valid
+GROUP BY   ENCRYPTED_TRUE_PEN, PSI_CODE, PSI_STUDENT_NUMBER
+HAVING     (ENCRYPTED_TRUE_PEN IS NULL) OR (ENCRYPTED_TRUE_PEN IN ('', ' ', '(Unspecified)'));"
+
+# ---- qry10_CredentialSupVars_From_Enrolment ----
+qry10_CredentialSupVars_From_Enrolment <- "
+SELECT      STP_Enrolment_Valid.ID, 
+            STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
+            STP_Enrolment_Valid.PSI_STUDENT_NUMBER,
+            STP_Enrolment_Valid.PSI_CODE,
+            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4.MaxSchoolYear
+INTO        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step5
+FROM        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4 
+INNER JOIN  STP_Enrolment_Valid 
+  ON        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4.PSI_CODE = STP_Enrolment_Valid.PSI_CODE 
+	AND       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4.MaxSchoolYear = STP_Enrolment_Valid.PSI_SCHOOL_YEAR
+	AND       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4.PSI_STUDENT_NUMBER = STP_Enrolment_Valid.PSI_STUDENT_NUMBER
+GROUP BY    STP_Enrolment_Valid.ID, 
+            STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
+            STP_Enrolment_Valid.PSI_STUDENT_NUMBER, 
+            STP_Enrolment_Valid.PSI_CODE, 
+            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4.MaxSchoolYear;"
+
+# ---- qry11_CredentialSupVars_From_Enrolment ----
+qry11_CredentialSupVars_From_Enrolment <- "
+ALTER TABLE [tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step5] 
+ADD CONSTRAINT tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step5_PK_ID
+PRIMARY KEY (ID);"
+
+# ---- qry12_CredentialSupVars_From_Enrolment ----
+qry12_CredentialSupVars_From_Enrolment <- "
+SELECT        STP_Enrolment_Valid.ID, 
+              STP_Enrolment_Valid.PSI_STUDENT_NUMBER, 
+              STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
+              STP_Enrolment_Valid.PSI_SCHOOL_YEAR, 
+              STP_Enrolment_Valid.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+              STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE, 
+              STP_Enrolment_Valid.PSI_CODE, 
+              STP_Enrolment_Valid.PSI_MIN_START_DATE
+INTO          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6
+FROM          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step5 
+INNER JOIN    STP_Enrolment_Valid 
+  ON          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step5.ID = STP_Enrolment_Valid.ID;"
+
+# ---- qry12b_CredentialSupVars_From_Enrolment ----
+qry12b_CredentialSupVars_From_Enrolment <- "                        
+ALTER TABLE [tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6] 
+ADD CONSTRAINT tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6_PK_ID
+PRIMARY KEY (ID);"
+
+# ---- qry13_CredentialSupVars_From_Enrolment ----
+qry13_CredentialSupVars_From_Enrolment <- "
+INSERT INTO CredentialSupVarsFromEnrolment
+SELECT        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.ID AS EnrolmentID, 
+				      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.ENCRYPTED_TRUE_PEN, 
+				      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_MIN_START_DATE, 
+              Credential.RecordStatus AS CredentialRecordStatus, 
+				      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+				      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_SCHOOL_YEAR, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_CODE,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_NUMBER,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_ENROLMENT_SEQUENCE
+FROM          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6 
+INNER JOIN    Credential 
+  ON          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_CODE = Credential.PSI_CODE 
+	AND         tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_NUMBER = Credential.PSI_STUDENT_NUMBER
+GROUP BY      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.ID, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.ENCRYPTED_TRUE_PEN, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_MIN_START_DATE, Credential.RecordStatus, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_POSTAL_CODE_CURRENT, 
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_SCHOOL_YEAR, 
+						  tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_CODE,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_NUMBER,
+              tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_ENROLMENT_SEQUENCE"
+
+###############################################################################################
+# ---- qry03e_CredentialSupVarsGender ----
+qry03e_CredentialSupVarsGender <- "
+SELECT        ENCRYPTED_TRUE_PEN, PSI_GENDER
+INTO          CredentialSupVars_Gender
+FROM          CredentialSupVarsFromEnrolment
+GROUP BY      ENCRYPTED_TRUE_PEN, PSI_GENDER;"
+
+# ---- qry03fCredential_SupVarsGenderCleaning1 ----
+qry03fCredential_SupVarsGenderCleaning1 <-
+  "SELECT [ENCRYPTED_TRUE_PEN], COUNT(*) AS GenderCount
+INTO CredentialSupVars_MultiGenderCounter
+FROM [CredentialSupVars_Gender]
+GROUP BY [ENCRYPTED_TRUE_PEN];"
+
+# ---- qry03fCredential_SupVarsGenderCleaning2 ----
+qry03fCredential_SupVarsGenderCleaning2 <-
+  "SELECT [ENCRYPTED_TRUE_PEN]
+INTO CredentialSupVars_MultiGender
+FROM [CredentialSupVars_MultiGenderCounter]
+WHERE [GenderCount]>1
+GROUP BY [ENCRYPTED_TRUE_PEN];"
+
+
+# ---- qry03fCredential_SupVarsGenderCleaning3 ----
+qry03fCredential_SupVarsGenderCleaning3 <-
+  "SELECT CredentialSupVars_MultiGender.ENCRYPTED_TRUE_PEN, CredentialSupVarsFromEnrolment.PSI_GENDER,
+       MAX(CredentialSupVarsFromEnrolment.PSI_SCHOOL_YEAR) AS MAX_PSI_SCHOOL_YEAR,
+       MAX(CredentialSupVarsFromEnrolment.PSI_ENROLMENT_SEQUENCE) AS MAX_PSI_ENROLMENT_SEQUENCE
+INTO tmp_CredentialGenderCleaning_Step1
+FROM CredentialSupVars_MultiGender 
+INNER JOIN CredentialSupVarsFromEnrolment
+ON CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN = CredentialSupVars_MultiGender.ENCRYPTED_TRUE_PEN
+GROUP BY CredentialSupVars_MultiGender.ENCRYPTED_TRUE_PEN, CredentialSupVarsFromEnrolment.PSI_GENDER;"
+
+# ---- qry03fCredential_SupVarsGenderCleaning4 ----
+qry03fCredential_SupVarsGenderCleaning4 <-
+  "SELECT ENCRYPTED_TRUE_PEN, MAX(MAX_PSI_SCHOOL_YEAR) AS MAX_MAX_PSI_SCHOOL_YEAR, 
+       MAX(MAX_PSI_ENROLMENT_SEQUENCE) AS MAX_MAX_PSI_ENROLMENT_SEQUENCE
+INTO tmp_CredentialGenderCleaning_Step2
+FROM tmp_CredentialGenderCleaning_Step1
+GROUP BY ENCRYPTED_TRUE_PEN;"
+
+# ---- qry03fCredential_SupVarsGenderCleaning5 ----
+qry03fCredential_SupVarsGenderCleaning5 <-
+  "SELECT tmp_CredentialGenderCleaning_Step2.ENCRYPTED_TRUE_PEN, 
+   tmp_CredentialGenderCleaning_Step1.PSI_GENDER AS PSI_GENDER_To_Use
+INTO tmp_CredentialGenderCleaning_Step3
+FROM tmp_CredentialGenderCleaning_Step2
+INNER JOIN tmp_CredentialGenderCleaning_Step1 ON 
+   tmp_CredentialGenderCleaning_Step2.ENCRYPTED_TRUE_PEN = tmp_CredentialGenderCleaning_Step1.ENCRYPTED_TRUE_PEN AND 
+   tmp_CredentialGenderCleaning_Step2.MAX_MAX_PSI_SCHOOL_YEAR = tmp_CredentialGenderCleaning_Step1.MAX_PSI_SCHOOL_YEAR AND
+   tmp_CredentialGenderCleaning_Step2.MAX_MAX_PSI_ENROLMENT_SEQUENCE = tmp_CredentialGenderCleaning_Step1.MAX_PSI_ENROLMENT_SEQUENCE
+WHERE tmp_CredentialGenderCleaning_Step2.ENCRYPTED_TRUE_PEN NOT IN ('',' ','(Unspecified)') AND tmp_CredentialGenderCleaning_Step2.ENCRYPTED_TRUE_PEN IS NOT NULL
+GROUP BY tmp_CredentialGenderCleaning_Step2.ENCRYPTED_TRUE_PEN, tmp_CredentialGenderCleaning_Step1.PSI_GENDER;"
+
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning6 ----
+#  Find all the enrolment IDs for EPENS in credential and enrolment that match and have more than one gender in enrolment data:
+qry03fCredential_SupVars_Enrol_GenderCleaning6 <-
+  "SELECT T.ENCRYPTED_TRUE_PEN, COUNT(*) AS CountOfGender
+INTO RW_TEST_ENROL_GENDER_morethanone_list_stepa
+FROM (
+    SELECT ENCRYPTED_TRUE_PEN, PSI_GENDER
+    FROM CredentialSupVarsFromEnrolment
+    GROUP BY ENCRYPTED_TRUE_PEN, PSI_GENDER
+) T
+GROUP BY T.ENCRYPTED_TRUE_PEN
+HAVING COUNT(*) > 1;"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning7 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning7 <-
+  "SELECT R.*, IN_CREDENTIALSUPVARS = 'T'
+INTO RW_TEST_ENROL_GENDER_morethanone_list
+FROM RW_TEST_ENROL_GENDER_morethanone_list_stepa R
+INNER JOIN (
+    SELECT DISTINCT ENCRYPTED_TRUE_PEN
+    FROM CredentialSupVars
+) C
+ON C.ENCRYPTED_TRUE_PEN = R.ENCRYPTED_TRUE_PEN;"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning8 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning8 <- "
+SELECT RW_TEST_ENROL_GENDER_morethanone_list.ENCRYPTED_TRUE_PEN, RW_TEST_ENROL_GENDER_morethanone_list.CountOfGender, 
+  RW_TEST_ENROL_GENDER_morethanone_list.IN_CREDENTIALSUPVARS, STP_Enrolment_Valid.ID AS EnrolmentID
+INTO RW_TEST_ENROL_GENDER_morethanone_listIDS
+FROM RW_TEST_ENROL_GENDER_morethanone_list
+INNER JOIN STP_Enrolment_Valid 
+  ON RW_TEST_ENROL_GENDER_morethanone_list.ENCRYPTED_TRUE_PEN = STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN
+WHERE RW_TEST_ENROL_GENDER_morethanone_list.ENCRYPTED_TRUE_PEN IS NOT NULL AND
+  RW_TEST_ENROL_GENDER_morethanone_list.ENCRYPTED_TRUE_PEN NOT IN ('',' ','(Unspecified)')
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning9 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning9 <- "
+SELECT  STP_Enrolment.ID AS EnrolmentID, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_BIRTHDATE, STP_Enrolment.PSI_MIN_START_DATE, 
+        STP_Enrolment.psi_birthdate_cleaned, STP_Enrolment.PSI_VISA_STATUS, STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment.PSI_SCHOOL_YEAR, 
+        STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, STP_Enrolment.PSI_ENROLMENT_SEQUENCE, 
+        STP_Enrolment.PSI_CIP_CODE, STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, STP_Enrolment.PSI_GENDER
+INTO    CredentialSupVarsFromEnrolment_MultiGender
+FROM    RW_TEST_ENROL_GENDER_morethanone_listIDS 
+INNER JOIN STP_Enrolment 
+  ON    RW_TEST_ENROL_GENDER_morethanone_listIDS.EnrolmentID = STP_Enrolment.ID
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning10 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning10 <- "
+ALTER TABLE CredentialSupVarsFromEnrolment_MultiGender
+ADD psi_gender_cleaned NVARCHAR(50)"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning11 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning11 <- "
+UPDATE      CredentialSupVarsFromEnrolment_MultiGender
+SET                psi_gender_cleaned = tmp_CredentialGenderCleaning_Step3.PSI_GENDER_To_Use
+FROM            CredentialSupVarsFromEnrolment_MultiGender INNER JOIN
+tmp_CredentialGenderCleaning_Step3 ON 
+CredentialSupVarsFromEnrolment_MultiGender.ENCRYPTED_TRUE_PEN = tmp_CredentialGenderCleaning_Step3.ENCRYPTED_TRUE_PEN"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning12 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning12 <- "
+ALTER TABLE CredentialSupVars_Gender
+ADD psi_gender_cleaned NVARCHAR(50), 
+psi_gender_cleaned_flag NVARCHAR(50)"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning13 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning13 <- "
+UPDATE       CredentialSupVars_Gender
+SET                psi_gender_cleaned = CredentialSupVarsFromEnrolment_MultiGender.psi_gender_cleaned, psi_gender_cleaned_flag=  'Yes'
+FROM            CredentialSupVars_Gender INNER JOIN
+                         CredentialSupVarsFromEnrolment_MultiGender ON 
+                         CredentialSupVars_Gender.ENCRYPTED_TRUE_PEN = CredentialSupVarsFromEnrolment_MultiGender.ENCRYPTED_TRUE_PEN"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning14 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning14 <- "
+UPDATE       CredentialSupVars_Gender
+SET                psi_gender_cleaned = PSI_GENDER
+WHERE        (psi_gender_cleaned IS NULL)
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning15 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning15 <- "
+SELECT  ENCRYPTED_TRUE_PEN, psi_gender_cleaned, psi_gender_cleaned_flag, PSI_GENDER
+INTO    tmp_CredentialSupVars_Gender_CleanUnknowns
+FROM    CredentialSupVars_Gender
+WHERE   (psi_gender_cleaned = 'U')
+OR (psi_gender_cleaned = 'Unknown')
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning16 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning16 <- "
+ALTER TABLE tmp_CredentialSupVars_Gender_CleanUnknowns
+ADD psi_gender_cleaned_NEW NVARCHAR(50)
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning17 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning17 <- "
+SELECT  tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN, tmp_CredentialSupVars_Gender_CleanUnknowns.psi_gender_cleaned, 
+        tmp_CredentialSupVars_Gender_CleanUnknowns.psi_gender_cleaned_flag, tmp_CredentialSupVars_Gender_CleanUnknowns.PSI_GENDER, 
+        tmp_CredentialSupVars_Gender_CleanUnknowns.psi_gender_cleaned_NEW, CredentialSupVarsFromEnrolment.PSI_GENDER AS Expr1
+INTO    tmp_CredentialSupVars_Gender_CleanUnknowns_Step2
+FROM    tmp_CredentialSupVars_Gender_CleanUnknowns 
+INNER JOIN CredentialSupVarsFromEnrolment ON 
+        tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN = CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN
+WHERE   tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN IS NOT NULL 
+        AND tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN NOT IN ('',' ','(Unspecified)')
+ORDER BY tmp_CredentialSupVars_Gender_CleanUnknowns.PSI_GENDER DESC
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning18 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning18 <- "
+SELECT  ENCRYPTED_TRUE_PEN, PSI_GENDER AS GenderToUse
+INTO    tmp_CredentialSupVars_Gender_CleanUnknowns_Step3
+FROM    tmp_CredentialSupVars_Gender_CleanUnknowns_Step2
+GROUP BY ENCRYPTED_TRUE_PEN, PSI_GENDER
+HAVING  ((PSI_GENDER <> 'U') AND (PSI_GENDER <> 'Unknown'))
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning19 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning19 <- "
+UPDATE       tmp_CredentialSupVars_Gender_CleanUnknowns
+SET          psi_gender_cleaned_NEW = tmp_CredentialSupVars_Gender_CleanUnknowns_Step3.GenderToUse
+FROM         tmp_CredentialSupVars_Gender_CleanUnknowns_Step3
+INNER JOIN   tmp_CredentialSupVars_Gender_CleanUnknowns ON 
+             tmp_CredentialSupVars_Gender_CleanUnknowns_Step3.ENCRYPTED_TRUE_PEN = tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning20 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning20 <- "
+UPDATE       CredentialSupVarsFromEnrolment_MultiGender
+SET          psi_gender_cleaned = tmp_CredentialSupVars_Gender_CleanUnknowns.psi_gender_cleaned_NEW
+FROM         CredentialSupVarsFromEnrolment_MultiGender
+INNER JOIN   tmp_CredentialSupVars_Gender_CleanUnknowns ON 
+             CredentialSupVarsFromEnrolment_MultiGender.ENCRYPTED_TRUE_PEN = tmp_CredentialSupVars_Gender_CleanUnknowns.ENCRYPTED_TRUE_PEN
+"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning21 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning21 <- "
+UPDATE credentialsupvars_gender
+SET    psi_gender_cleaned =
+       tmp_credentialsupvars_gender_cleanunknowns.psi_gender_cleaned_new
+FROM   credentialsupvars_gender
+       INNER JOIN tmp_credentialsupvars_gender_cleanunknowns
+               ON credentialsupvars_gender.encrypted_true_pen =
+                  tmp_credentialsupvars_gender_cleanunknowns.encrypted_true_pen"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning22 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning22 <-
+  "UPDATE credentialsupvars
+SET    psi_gender_cleaned = credentialsupvars_gender.psi_gender_cleaned
+FROM   credentialsupvars
+       INNER JOIN credentialsupvars_gender
+               ON credentialsupvars.encrypted_true_pen =
+                  credentialsupvars_gender.encrypted_true_pen
+WHERE  credentialsupvars_gender.encrypted_true_pen IS NOT NULL
+       AND credentialsupvars_gender.encrypted_true_pen NOT IN ('',' ','(Unspecified)')"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning23 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning23 <- "
+SELECT *
+FROM   credentialsupvars
+WHERE  psi_gender_cleaned IS NULL"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning24 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning24 <- "
+SELECT encrypted_true_pen,
+       psi_student_number,
+       psi_code,
+       psi_gender_cleaned
+INTO   tmp_credentialgendercleaning_step5
+FROM   credentialsupvars
+WHERE  psi_gender_cleaned IS NULL;"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning25 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning25 <- "
+SELECT DISTINCT tmp_credentialgendercleaning_step5.encrypted_true_pen,
+                stp_enrolment.psi_student_number,
+                stp_enrolment.psi_code,
+                psi_gender_cleaned,
+                stp_enrolment.psi_gender
+INTO   tmp_credentialgendercleaning_step6
+FROM   tmp_credentialgendercleaning_step5
+       INNER JOIN stp_enrolment
+               ON tmp_credentialgendercleaning_step5.psi_student_number =
+                             stp_enrolment.psi_student_number
+                  AND tmp_credentialgendercleaning_step5.psi_code =
+                      stp_enrolment.psi_code;"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning26a ----
+qry03fCredential_SupVars_Enrol_GenderCleaning26a <- "
+SELECT ENCRYPTED_TRUE_PEN,
+       PSI_STUDENT_NUMBER,
+       psi_code, 
+       COUNT(*) AS GenderCount
+INTO CredentialSupVars_MultiGenderCounterForNULLS
+FROM tmp_CredentialGenderCleaning_Step6
+GROUP BY ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, psi_code"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning26b ----
+qry03fCredential_SupVars_Enrol_GenderCleaning26b <- "
+SELECT encrypted_true_pen,
+       psi_student_number,
+       psi_code,
+       Count(*) AS GenderCount
+INTO   credentialsupvars_multigenderfornulls
+FROM   credentialsupvars_multigendercounterfornulls
+GROUP  BY encrypted_true_pen,
+          psi_student_number,
+          psi_code
+HAVING Count(*) > 1"
+
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning27 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning27 <- "
+SELECT      CredentialSupVars_MultiGenderForNULLS.ENCRYPTED_TRUE_PEN, CredentialSupVars_MultiGenderForNULLS.PSI_STUDENT_NUMBER, 
+            CredentialSupVars_MultiGenderForNULLS.psi_code, 
+            CredentialSupVarsFromEnrolment.PSI_GENDER, MAX(CredentialSupVarsFromEnrolment.PSI_SCHOOL_YEAR) AS MAX_PSI_SCHOOL_YEAR, 
+            MAX(CredentialSupVarsFromEnrolment.PSI_ENROLMENT_SEQUENCE) AS MAX_PSI_ENROLMENT_SEQUENCE
+INTO        tmp_CredentialGenderCleaning_Step7
+FROM        CredentialSupVars_MultiGenderForNULLS
+INNER JOIN  CredentialSupVarsFromEnrolment
+  ON        CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN = CredentialSupVars_MultiGenderForNULLS.ENCRYPTED_TRUE_PEN
+GROUP BY    CredentialSupVars_MultiGenderForNULLS.ENCRYPTED_TRUE_PEN, CredentialSupVars_MultiGenderForNULLS.PSI_STUDENT_NUMBER, 
+            CredentialSupVars_MultiGenderForNULLS.psi_code, CredentialSupVarsFromEnrolment.PSI_GENDER"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning28 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning28 <- "
+UPDATE tmp_credentialgendercleaning_step6
+SET    tmp_credentialgendercleaning_step6.psi_gender_cleaned = tmp_credentialgendercleaning_step7.psi_gender_cleaned,
+       tmp_credentialgendercleaning_step6.psi_gender_cleaned_flag = 'Yes'
+FROM   tmp_credentialgendercleaning_step6
+       INNER JOIN tmp_credentialgendercleaning_step7
+               ON tmp_credentialgendercleaning_step6.psi_student_number = tmp_credentialgendercleaning_step7.psi_student_number
+              AND tmp_credentialgendercleaning_step6.psi_code = tmp_credentialgendercleaning_step7.psi_code"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning29  ----
+qry03fCredential_SupVars_Enrol_GenderCleaning29 <- "
+SELECT encrypted_true_pen,
+       psi_student_number,
+       psi_code,
+       psi_gender_cleaned,
+       psi_gender_cleaned_flag,
+       psi_gender
+INTO   tmp_credentialsupvars_gender_cleanunknownsfornulls_step1
+FROM   tmp_credentialgendercleaning_step6
+WHERE  ( psi_gender = 'U' OR psi_gender = 'Unknown' OR psi_gender = '(Unspecified)')
+       AND psi_gender_cleaned_flag IS NULL"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning30 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning30 <- "
+SELECT
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.encrypted_true_pen,
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_student_number,
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_code,
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_gender_cleaned,
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_gender_cleaned_flag,
+       tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_gender,
+       credentialsupvarsfromenrolment.psi_gender AS Expr1
+INTO   tmp_credentialsupvars_gender_cleanunknownsfornulls_step2
+FROM   tmp_credentialsupvars_gender_cleanunknownsfornulls_step1
+       INNER JOIN credentialsupvarsfromenrolment
+               ON tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.encrypted_true_pen = credentialsupvarsfromenrolment.encrypted_true_pen
+              AND tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_student_number = credentialsupvarsfromenrolment.psi_student_number
+              AND tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_code = credentialsupvarsfromenrolment.psi_code
+ORDER  BY tmp_credentialsupvars_gender_cleanunknownsfornulls_step1.psi_student_number DESC"
+
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning31  ----
+qry03fCredential_SupVars_Enrol_GenderCleaning31 <- "
+SELECT encrypted_true_pen,
+       psi_student_number,
+       psi_code,
+       psi_gender AS GenderToUse
+INTO   tmp_credentialsupvars_gender_cleanunknownsfornulls_step3
+FROM   tmp_credentialsupvars_gender_cleanunknownsfornulls_step2
+GROUP  BY encrypted_true_pen,
+          psi_student_number,
+          psi_code,
+          psi_gender
+HAVING ( psi_gender <> 'U' AND psi_gender <> 'Unknown' AND psi_gender <> '(Unspecified)')"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning32 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning32 <- "
+UPDATE       tmp_CredentialGenderCleaning_Step6
+SET                psi_gender_cleaned_flag = 'Yes'
+WHERE (PSI_GENDER = 'U' OR PSI_GENDER = 'Unknown' OR psi_gender = '(Unspecified)')"
+
+qry03fCredential_SupVars_Enrol_GenderCleaning33 <- "
+UPDATE       tmp_CredentialGenderCleaning_Step6
+SET                psi_gender_cleaned = tmp_CredentialGenderCleaning_Step7.psi_gender_cleaned, psi_gender_cleaned_flag=  'Yes'
+FROM            tmp_CredentialGenderCleaning_Step6 INNER JOIN
+                         tmp_CredentialGenderCleaning_Step7 ON 
+                         tmp_CredentialGenderCleaning_Step6.PSI_STUDENT_NUMBER = tmp_CredentialGenderCleaning_Step7.PSI_STUDENT_NUMBER
+						 AND tmp_CredentialGenderCleaning_Step6.psi_code = tmp_CredentialGenderCleaning_Step7.psi_code"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning34 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning34 <- "
+UPDATE       tmp_CredentialGenderCleaning_Step6
+SET                psi_gender_cleaned_flag = 'Yes', psi_gender_cleaned = PSI_GENDER
+WHERE psi_gender_cleaned_flag IS NULL"
+
+# ---- qry03fCredential_SupVars_Enrol_GenderCleaning35 ----
+qry03fCredential_SupVars_Enrol_GenderCleaning35 <- "
+UPDATE       CredentialSupVars
+SET          psi_gender_cleaned = tmp_CredentialGenderCleaning_Step6.psi_gender_cleaned 
+FROM         tmp_CredentialGenderCleaning_Step6 INNER JOIN
+                         CredentialSupVars ON 
+                         tmp_CredentialGenderCleaning_Step6.PSI_STUDENT_NUMBER = CredentialSupVars.PSI_STUDENT_NUMBER
+						 AND tmp_CredentialGenderCleaning_Step6.psi_code = CredentialSupVars.psi_code
+WHERE tmp_CredentialGenderCleaning_Step6.psi_gender_cleaned_flag='Yes' AND CredentialSupVars.psi_gender_cleaned IS NULL"
+
+
+# --------------------------------------------------------------------------------------------------------------------------
+
+"SELECT   CredentialSupVarsFromEnrolment_MultiGender.ENCRYPTED_TRUE_PEN, CredentialSupVarsFromEnrolment_MultiGender.PSI_GENDER, 
+          MAX(CredentialSupVarsFromEnrolment_MultiGender.PSI_SCHOOL_YEAR) AS MAX_PSI_SCHOOL_YEAR
+INTO      tmp_CredentialGenderCleaning_Step1
+FROM      CredentialSupVarsFromEnrolment_MultiGender 
+GROUP BY  CredentialSupVarsFromEnrolment_MultiGender.ENCRYPTED_TRUE_PEN, CredentialSupVarsFromEnrolment_MultiGender.PSI_GENDER
+HAVING    (CredentialSupVarsFromEnrolment_MultiGender.PSI_GENDER IS NOT NULL AND CredentialSupVarsFromEnrolment_MultiGender.PSI_GENDER <> ' ')"
+
+
+#For updating psi_gender_cleaned_for_records_with_nullEPEN or unmatched EPEN, but matched on PSI_STUDENT_NUMBER/PSI_CODE
+"UPDATE       CredentialSupVars
+SET                psi_gender_cleaned = tmp_CredentialGenderCleaning_Step10.psi_gender_cleaned
+FROM            CredentialSupVars INNER JOIN
+                         tmp_CredentialGenderCleaning_Step10 ON CredentialSupVars.ENCRYPTED_TRUE_PEN = tmp_CredentialGenderCleaning_Step10.ENCRYPTED_TRUE_PEN
+WHERE        (CredentialSupVars.psi_gender_cleaned IS NULL) AND (CredentialSupVars.ENCRYPTED_TRUE_PEN IS NOT NULL AND 
+                         CredentialSupVars.ENCRYPTED_TRUE_PEN NOT IN ('',' ','(Unspecified)'))"
+
+
+"UPDATE       CredentialSupVars
+SET                psi_gender_cleaned = tmp_CredentialGenderCleaning_Step10.psi_gender_cleaned
+FROM            CredentialSupVars INNER JOIN
+                         tmp_CredentialGenderCleaning_Step10 ON CredentialSupVars.PSI_STUDENT_NUMBER = tmp_CredentialGenderCleaning_Step10.PSI_STUDENT_NUMBER AND 
+                         CredentialSupVars.PSI_CODE = tmp_CredentialGenderCleaning_Step10.PSI_CODE
+WHERE        (CredentialSupVars.psi_gender_cleaned IS NULL) OR
+                         (CredentialSupVars.psi_gender_cleaned = '')"
+
+###############################################################################################
+
+# ---- CredentialSupVars_VisaStatus_Cleaning_check ----
+CredentialSupVars_VisaStatus_Cleaning_check <- "
+SELECT PSI_VISA_STATUS, count(*) FROM CredentialSupVars GROUP BY PSI_VISA_STATUS"
+
+# ---- CredentialSupVars_VisaStatus_1 ----
+CredentialSupVars_VisaStatus_Cleaning_1 <-
+  "SELECT credential_non_dup.id,
+       credential_non_dup.encrypted_true_pen,
+       credential_non_dup.psi_student_number,
+       credential_non_dup.psi_school_year,
+       credential_non_dup.psi_code,
+       credential_non_dup.credential_award_date,
+       credential_non_dup.psi_program_code,
+       credential_non_dup.psi_credential_program_description,
+       credential_non_dup.psi_credential_category,
+       credential_non_dup.psi_credential_level,
+       credential_non_dup.psi_credential_cip,
+       credential_non_dup.psi_award_school_year,
+       credentialsupvars.psi_visa_status
+INTO   credential_non_dup_visastatus_cleaning_step1
+FROM   credentialsupvars
+       INNER JOIN credential_non_dup
+               ON credentialsupvars.id = credential_non_dup.id "
+
+# ---- CredentialSupVars_VisaStatus_2 ----
+CredentialSupVars_VisaStatus_Cleaning_2 <- "
+UPDATE  Credential_Non_Dup_VisaStatus_Cleaning_Step1
+SET     PSI_VISA_STATUS = CredentialSupVarsFromEnrolment.PSI_VISA_STATUS
+FROM    Credential_Non_Dup_VisaStatus_Cleaning_Step1 
+INNER JOIN CredentialSupVarsFromEnrolment 
+		ON  Credential_Non_Dup_VisaStatus_Cleaning_Step1.ENCRYPTED_TRUE_PEN = CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN
+AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_CODE = CredentialSupVarsFromEnrolment.PSI_CODE 
+AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_STUDENT_NUMBER = CredentialSupVarsFromEnrolment.PSI_STUDENT_NUMBER 
+AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_PROGRAM_CODE = CredentialSupVarsFromEnrolment.PSI_PROGRAM_CODE 
+AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = CredentialSupVarsFromEnrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION
+AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_SCHOOL_YEAR = CredentialSupVarsFromEnrolment.PSI_SCHOOL_YEAR"
+
+# ---- CredentialSupVars_VisaStatus_3 ----
+CredentialSupVars_VisaStatus_Cleaning_3 <- "
+UPDATE  credential_non_dup_visastatus_cleaning_step1
+SET     psi_visa_status = credentialsupvarsfromenrolment.psi_visa_status
+FROM    credential_non_dup_visastatus_cleaning_step1
+INNER JOIN credentialsupvarsfromenrolment
+ON      credential_non_dup_visastatus_cleaning_step1.encrypted_true_pen = credentialsupvarsfromenrolment.encrypted_true_pen
+AND     credential_non_dup_visastatus_cleaning_step1.psi_code = credentialsupvarsfromenrolment.psi_code
+AND     credential_non_dup_visastatus_cleaning_step1.psi_student_number = credentialsupvarsfromenrolment.psi_student_number
+AND     credential_non_dup_visastatus_cleaning_step1.psi_program_code = credentialsupvarsfromenrolment.psi_program_code
+AND     credential_non_dup_visastatus_cleaning_step1.psi_credential_program_description = credentialsupvarsfromenrolment.psi_credential_program_description
+AND     credential_non_dup_visastatus_cleaning_step1.psi_school_year = credentialsupvarsfromenrolment.psi_school_year "
+
+
+# ---- CredentialSupVars_VisaStatus_4 ----
+CredentialSupVars_VisaStatus_Cleaning_4 <- "
+UPDATE    Credential_Non_Dup_VisaStatus_Cleaning_Step1
+SET       PSI_VISA_STATUS = CredentialSupVarsFromEnrolment.PSI_VISA_STATUS
+FROM      Credential_Non_Dup_VisaStatus_Cleaning_Step1 
+INNER JOIN CredentialSupVarsFromEnrolment 
+ON        Credential_Non_Dup_VisaStatus_Cleaning_Step1.ENCRYPTED_TRUE_PEN = CredentialSupVarsFromEnrolment.ENCRYPTED_TRUE_PEN AND 
+          Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_CODE = CredentialSupVarsFromEnrolment.PSI_CODE AND 
+          Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_STUDENT_NUMBER= CredentialSupVarsFromEnrolment.PSI_STUDENT_NUMBER AND 
+          Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_SCHOOL_YEAR = CredentialSupVarsFromEnrolment.PSI_SCHOOL_YEAR
+WHERE     (Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_VISA_STATUS IS NULL)"
+
+# ---- CredentialSupVars_VisaStatus_5 ----
+CredentialSupVars_VisaStatus_Cleaning_5 <- "
+UPDATE    CredentialSupVars
+SET       PSI_VISA_STATUS = Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_VISA_STATUS
+FROM      CredentialSupVars 
+INNER JOIN Credential_Non_Dup_VisaStatus_Cleaning_Step1 ON CredentialSupVars.ID = Credential_Non_Dup_VisaStatus_Cleaning_Step1.id
+WHERE     (CredentialSupVars.PSI_VISA_STATUS IS NULL) 
+OR        (CredentialSupVars.PSI_VISA_STATUS IN ('', ' ', '(Unspecified)'))"
+
+
+# ---- CredentialSupVars_VisaStatus_6 ----
+CredentialSupVars_VisaStatus_Cleaning_6 <- "
+UPDATE      Credential_Non_Dup
+SET         PSI_VISA_STATUS = CredentialSupVars.PSI_VISA_STATUS
+FROM        Credential_Non_Dup 
+INNER JOIN  CredentialSupVars ON Credential_Non_Dup.id = CredentialSupVars.ID"
+
+###############################################################################################
+# ---- qry11a_RankByDateRank ----
+qry11a_RankByDateRank <-
+  "SELECT id,
+credential_ranking.encrypted_true_pen,
+credential_ranking.psi_student_number,
+credential_ranking.psi_code,
+--credential_ranking.concatenated_id,
+credential_ranking.credential_award_date_d,
+credential_ranking.rank,
+credential_ranking.highest_cred_by_date
+FROM   credential_ranking
+ORDER  BY credential_ranking.encrypted_true_pen,
+credential_ranking.psi_student_number,
+credential_ranking.psi_code,
+credential_ranking.credential_award_date_d DESC,
+credential_ranking.rank;"
+
+
+# ---- qry11b_RankByRankDate ----
+qry11b_RankByRankDate <-
+  "SELECT 
+ id, credential_ranking.encrypted_true_pen,
+       credential_ranking.psi_student_number,
+       credential_ranking.psi_code,
+       --credential_ranking.concatenated_id,
+       credential_ranking.rank,
+       credential_ranking.credential_award_date_d,
+       credential_ranking.highest_cred_by_rank
+FROM   credential_ranking
+ORDER  BY credential_ranking.encrypted_true_pen,
+          credential_ranking.psi_student_number,
+          credential_ranking.psi_code,
+          credential_ranking.rank,
+          credential_ranking.credential_award_date_d DESC;"
+
+
+# ---- qry18a_ExtrLaterAwarded ----
+qry18a_ExtrLaterAwarded <-
+  "SELECT DISTINCT credential_non_dup.id  AS LID,
+                tblcredential_highestrank.id AS HID,
+                credential_non_dup.concatenated_id,
+                credential_non_dup.credential_award_date_d AS LATER_AWARD_DATE,
+                credential_non_dup.highest_cred_by_date,
+                credential_non_dup.psi_award_school_year,
+                tblcredential_highestrank.credential_award_date_d AS HIGHEST_AWARD_DATE,
+                credential_non_dup.psi_credential_category,
+                credentialrank.rank
+INTO   tblcredential_laterawarded
+FROM   (credential_non_dup
+        INNER JOIN credentialrank
+                ON credential_non_dup.psi_credential_category =
+                   credentialrank.psi_credential_category)
+       INNER JOIN tblcredential_highestrank
+               ON credential_non_dup.concatenated_id = tblcredential_highestrank.concatenated_id
+WHERE  (( ( credential_non_dup.credential_award_date_d ) >
+                  [tblcredential_highestrank].[credential_award_date_d]))"
+
+# ---- qry18b_ExtrLaterAwarded ----
+qry18b_ExtrLaterAwarded <-
+  "SELECT tblCredential_LaterAwarded.LID, 
+        tblCredential_LaterAwarded.HID, 
+        tblCredential_LaterAwarded.concatenated_id, 
+        tblCredential_LaterAwarded.LATER_AWARD_DATE, 
+        tblCredential_LaterAwarded.PSI_AWARD_SCHOOL_YEAR
+INTO tmp_qry18b_ExtrLaterAwarded
+FROM tblCredential_HighestRank 
+INNER JOIN tblCredential_LaterAwarded 
+ON tblCredential_HighestRank.concatenated_id = tblCredential_LaterAwarded.concatenated_id
+WHERE (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='APPRENTICESHIP' 
+     Or (tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='BACHELORS DEGREE' 
+     Or (tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='FIRST PROFESSIONAL DEGREE')) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='ADVANCED DIPLOMA' 
+  Or (tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='ADVANCED CERTIFICATE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=36)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='ASSOCIATE DEGREE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=18)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='CERTIFICATE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=18)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='DIPLOMA') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=30)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='MASTERS DEGREE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=30)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='GRADUATE CERTIFICATE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=18)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='GRADUATE DIPLOMA') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=30)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='POST-DEGREE CERTIFICATE') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=18)) 
+OR (((tblCredential_LaterAwarded.PSI_CREDENTIAL_CATEGORY)='POST-DEGREE DIPLOMA') 
+AND ((DateDiff(month,[tblCredential_HighestRank].[CREDENTIAL_AWARD_DATE_D],[tblCredential_LaterAwarded].[LATER_AWARD_DATE]))<=30));"
+
+# ---- qry18c_ExtrLaterAwarded ----
+qry18c_ExtrLaterAwarded <-
+  "SELECT tmp_qry18b_ExtrLaterAwarded.concatenated_id, 
+Max(tmp_qry18b_ExtrLaterAwarded.LATER_AWARD_DATE) AS MaxOfLATER_AWARD_DATE
+INTO tmp_qry18c_ExtrLaterAwarded
+FROM tmp_qry18b_ExtrLaterAwarded
+GROUP BY tmp_qry18b_ExtrLaterAwarded.concatenated_id;"
+
+# ---- qry18d_ExtrLaterAwarded ----
+qry18d_ExtrLaterAwarded <-
+  "SELECT DISTINCT Min(tmp_qry18b_ExtrLaterAwarded.LID) AS LID, 
+        tmp_qry18b_ExtrLaterAwarded.HID, 
+        tmp_qry18b_ExtrLaterAwarded.concatenated_id, 
+        tmp_qry18b_ExtrLaterAwarded.LATER_AWARD_DATE, 
+        tmp_qry18b_ExtrLaterAwarded.PSI_AWARD_SCHOOL_YEAR 
+INTO    tblCredential_DelayEffect
+FROM    tmp_qry18b_ExtrLaterAwarded 
+INNER JOIN tmp_qry18c_ExtrLaterAwarded 
+  ON    tmp_qry18b_ExtrLaterAwarded.LATER_AWARD_DATE = tmp_qry18c_ExtrLaterAwarded.MaxOfLATER_AWARD_DATE
+  AND   tmp_qry18b_ExtrLaterAwarded.concatenated_id = tmp_qry18c_ExtrLaterAwarded.concatenated_id
+GROUP BY 
+        tmp_qry18b_ExtrLaterAwarded.HID, 
+        tmp_qry18b_ExtrLaterAwarded.concatenated_id, 
+        tmp_qry18b_ExtrLaterAwarded.LATER_AWARD_DATE, 
+        tmp_qry18b_ExtrLaterAwarded.PSI_AWARD_SCHOOL_YEAR;"
+
+# ---- qry19_UpdateDelayDate ----
+qry19_UpdateDelayDate <- "
+UPDATE  tblCredential_HighestRank 
+SET     tblCredential_HighestRank.CREDENTIAL_AWARD_DATE_D_DELAYED = tblCredential_DelayEffect.LATER_AWARD_DATE, 
+        tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED = tblCredential_DelayEffect.PSI_AWARD_SCHOOL_YEAR
+FROM    tblCredential_HighestRank 
+INNER JOIN tblCredential_DelayEffect 
+ON tblCredential_HighestRank.ID = tblCredential_DelayEffect.HID;"
+
+###############################################################################################
+# APPSO IDS ----
+##
+## qry_APPSO_STP_CIP_Cleaning ----
+## collect STP APPSO data
+## New (from documentation): create table Credential_Non_Dup_STP_APPSO_Cleaning for cleaning STP CIP codes
+qry_APPSO_STP_CIP_Cleaning <- "
+SELECT PSI_CREDENTIAL_CIP, 
+       OUTCOMES_CRED,
+       COUNT(*) AS Expr1
+INTO   Credential_Non_Dup_STP_APPSO_Cleaning
+FROM   Credential_Non_Dup
+GROUP BY 
+       PSI_CREDENTIAL_CIP, 
+       OUTCOMES_CRED
+HAVING OUTCOMES_CRED = 'APPSO'"
+
+# add columns
+qry_APPSO_STP_CIP_add_columns <- "
+ALTER TABLE Credential_Non_Dup_STP_APPSO_Cleaning
+ADD STP_CIP_CODE_4 varchar (255),
+STP_CIP_CODE_4_NAME varchar (255),
+STP_CIP_CODE_2 varchar (255),
+STP_CIP_CODE_2_NAME varchar (255),
+PSI_CREDENTIAL_CIP_orig varchar (255)
+"
+
+qry_APPSO_STP_CIP_update_original <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET PSI_CREDENTIAL_CIP_orig = PSI_CREDENTIAL_CIP"
+
+# clean CIPs that are wrong length
+qry_APPSO_STP_CIP_clean_cip_1 <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    PSI_CREDENTIAL_CIP = CONCAT(PSI_CREDENTIAL_CIP, '0')
+WHERE  LEN(PSI_CREDENTIAL_CIP) = 6 AND
+substring(PSI_CREDENTIAL_CIP,1,2) NOT LIKE '%.'"
+
+qry_APPSO_STP_CIP_clean_cip_2 <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    PSI_CREDENTIAL_CIP = CONCAT('0', PSI_CREDENTIAL_CIP)
+WHERE LEN(PSI_CREDENTIAL_CIP) = 6"
+
+## qry_Clean_APPSO_STP_CIP_Step1_a ----
+## Add 4 and 2D CIP codes from INFOWARE matching on PSI_CREDENTIAL_CIP
+qry_Clean_APPSO_STP_CIP_Step1_a <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD],
+       Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_APPSO_Cleaning INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP = INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD"
+
+## qry_Clean_APPSO_STP_CIP_Step1_b ----
+## New: Add 4 and 2D CIP codes from INFOWARE matching on first 4 digits of PSI_CREDENTIAL_CIP
+qry_Clean_APPSO_STP_CIP_Step1_b <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD],
+       Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_APPSO_Cleaning 
+INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = substring(INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD,1,5)
+WHERE  STP_CIP_CODE_4 is NULL"
+
+## qry_Clean_APPSO_STP_CIP_Step2_c ----
+## New: Add 4D CIP codes for general programs (if 00 change to 01)
+## Check which CIPs have general programs here: https://www.statcan.gc.ca/en/subjects/standard/cip/2021/index
+qry_Clean_APPSO_STP_CIP_Step1_c <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET STP_CIP_CODE_4 = CONCAT(substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,2), '01')
+WHERE (substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 11.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 13.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 14.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 19.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 23.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 24.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 26.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 40.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 42.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 45.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 50.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 52.00 OR
+      substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 55.00) AND
+      STP_CIP_CODE_4 is NULL"
+
+## qry_Clean_APPSO_STP_CIP_Step1_d ----
+## New: Add 2D CIP codes from INFOWARE matching on first 2 digits of PSI_CREDENTIAL_CIP
+qry_Clean_APPSO_STP_CIP_Step1_d <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_APPSO_Cleaning INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     substring(Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP,1,2) = substring(INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD,1,2)
+WHERE  STP_CIP_CODE_2 is NULL"
+
+## qry_Clean_APPSO_STP_CIP_Step2 ----
+# Add 4D names
+qry_Clean_APPSO_STP_CIP_Step2 <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning 
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4_NAME = [INFOWARE_L_CIP_4DIGITS_CIP2016].[LCP4_CIP_4DIGITS_NAME]
+FROM   Credential_Non_Dup_STP_APPSO_Cleaning INNER JOIN INFOWARE_L_CIP_4DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4 = INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD"
+
+## qry_Clean_APPSO_STP_CIP_Step3 ----
+# Add 2D names
+qry_Clean_APPSO_STP_CIP_Step3 <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2_NAME = [INFOWARE_L_CIP_2DIGITS_CIP2016].[LCP2_DIGITS_NAME]
+FROM   Credential_Non_Dup_STP_APPSO_Cleaning 
+INNER JOIN INFOWARE_L_CIP_2DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2 = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_CD"
+
+## qry_Clean_APPSO_STP_CIP_step4 ----
+## New: Set blank 4D names to Invalid 4-digit CIP
+qry_Clean_APPSO_STP_CIP_step4 <- "
+UPDATE Credential_Non_Dup_STP_APPSO_Cleaning
+SET    Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4_NAME = 'Invalid 4-digit CIP'
+WHERE Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4_NAME is NULL"
+
+## qry_Update_Credential_with_STP_CIP_APPSO ----
+## Update STP columns in Credential_Non_Dup and filter on APPSO credentials
+qry_Update_Credential_with_STP_CIP_APPSO <- "
+Select Credential_Non_Dup.ID,
+       Credential_Non_Dup.PSI_CODE,
+       Credential_Non_Dup.PSI_PROGRAM_CODE,
+       Credential_Non_Dup.PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+       Credential_Non_Dup.PSI_CREDENTIAL_CIP,
+       Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR,
+       Credential_Non_Dup.OUTCOMES_CRED,
+       FINAL_CIP_CODE_4 = Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4_NAME,
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2, 
+       FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_2_NAME
+INTO   Credential_Non_Dup_APPSO_IDs
+FROM   Credential_Non_Dup INNER JOIN Credential_Non_Dup_STP_APPSO_Cleaning 
+ON     Credential_Non_Dup.PSI_CREDENTIAL_CIP = Credential_Non_Dup_STP_APPSO_Cleaning.PSI_CREDENTIAL_CIP_orig AND 
+       Credential_Non_Dup.OUTCOMES_CRED = Credential_Non_Dup_STP_APPSO_Cleaning.OUTCOMES_CRED
+WHERE  Credential_Non_Dup.OUTCOMES_CRED = 'APPSO'"
+
+## replace unspecified with NULL
+qry_Update_Credential_with_STP_CIP_APPSO_nulls <- "
+Update Credential_Non_Dup_APPSO_IDs
+SET PSI_PROGRAM_CODE = NULL
+WHERE PSI_PROGRAM_CODE = '(Unspecified)'
+"
+
+###############################################################################################
+
+BGS_Q001b_INST_Recode <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.inst = t_bgs_inst_recode.inst_recode
+FROM    t_bgs_data_final
+INNER JOIN t_bgs_inst_recode
+  ON t_bgs_data_final.inst = t_bgs_inst_recode.inst;"
+
+BGS_Q001c_Update_CIPs_After_Program_Matching <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.cip_code_4 = t_bgs_data_final_for_outcomesmatching.final_cip_code_4,
+       t_bgs_data_final.cip_code_2 = t_bgs_data_final_for_outcomesmatching.final_cip_code_2,
+       t_bgs_data_final.lcip_lcippc_cd = t_bgs_data_final_for_outcomesmatching.final_cip_cluster_code
+FROM   t_bgs_data_final
+INNER JOIN t_bgs_data_final_for_outcomesmatching
+    ON t_bgs_data_final.stqu_id = t_bgs_data_final_for_outcomesmatching.stqu_id;"
+
+BGS_Q002_LCP4_CRED <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.lcip4_cred = cip_code_4 + ' - ' + 'BACH',
+       t_bgs_data_final.pssm_credential = 'BACH';"
+
+BGS_Q003b_Add_CURRENT_REGION_PSSM <- "
+ALTER TABLE T_BGS_DATA_Final
+ADD CURRENT_REGION_PSSM_CODE INT NULL;"
+
+BGS_Q003b_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE      t_bgs_data_final
+SET         t_bgs_data_final.current_region_pssm_code =  bgs_current_region_data.current_region_pssm_code
+FROM        t_bgs_data_final
+INNER JOIN  bgs_current_region_data
+    ON      t_bgs_data_final.stqu_id = bgs_current_region_data.stqu_id;"
+
+BGS_Q003c_Derived_And_Weights <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.BGS_New_Labour_Supply =  
+        CASE
+	        	WHEN CURRENT_ACTIVITY = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 0 THEN 2
+	        	WHEN CURRENT_ACTIVITY = 3 And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL  And  FULL_TM_WRK IS NULL And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL And IN_LBR_FRC = 1 THEN 1
+	        	WHEN srv_y_n = 0 THEN 0
+	        	ELSE 0 
+	      END,
+       t_bgs_data_final.weight = t_weights.weight,
+       t_bgs_data_final.age_group = tbl_age.age_group,
+       t_bgs_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_bgs_data_final
+INNER JOIN t_weights
+  ON t_bgs_data_final.survey_year = t_weights.survey_year)
+LEFT JOIN tbl_age
+  ON t_bgs_data_final.age = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'BGS';"
+
+BGS_Q003c_Derived_And_Weights_QI <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.BGS_New_Labour_Supply =  
+        CASE
+	        	WHEN CURRENT_ACTIVITY = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 0 THEN 2
+	        	WHEN CURRENT_ACTIVITY = 3 And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL  And  FULL_TM_WRK IS NULL And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL And IN_LBR_FRC = 1 THEN 1
+	        	WHEN srv_y_n = 0 THEN 0
+	        	ELSE 0 
+	      END,
+       t_bgs_data_final.weight = t_weights.weight_QI,
+       t_bgs_data_final.age_group = tbl_age.age_group,
+       t_bgs_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_bgs_data_final
+INNER JOIN t_weights
+  ON t_bgs_data_final.survey_year = t_weights.survey_year)
+LEFT JOIN tbl_age
+  ON t_bgs_data_final.age = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'BGS';"
+
+
+BGS_Q005_1b1_Delete_Cohort <- "
+DELETE T_Cohorts_Recoded
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.Survey)='BGS'));"
+
+BGS_Q005_1b2_Cohort_Recoded <- "INSERT INTO t_cohorts_recoded
+            (pen,
+             stqu_id,
+             survey,
+             survey_year,
+             inst_cd,
+             lcp4_cd,
+             noc_cd,
+             age_at_survey,
+             age_group,
+             age_group_rollup,
+             grad_status,
+             respondent,
+             new_labour_supply,
+             old_labour_supply,
+             weight,
+             pssm_credential,
+             pssm_cred,
+             lcip4_cred,
+             lcip2_cred,
+             current_region_pssm_code)
+SELECT t_bgs_data_final.pen,
+       'BGS - ' + cast(cast(stqu_id as integer) as nvarchar(20)) AS stqu_id,
+       'BGS' AS survey,
+       t_bgs_data_final.survey_year,
+       t_bgs_data_final.inst,
+       t_bgs_data_final.cip_code_4,
+       CASE 
+          WHEN t_bgs_data_final.noc = 'XXXXX' THEN '99999' 
+			    ELSE t_bgs_data_final.noc
+	     END AS NOC_CD,
+       t_bgs_data_final.age,
+       t_bgs_data_final.age_group,
+       t_bgs_data_final.age_group_rollup,
+       '1' AS grad_status,
+       t_bgs_data_final.srv_y_n,
+       t_bgs_data_final.bgs_new_labour_supply,
+       t_bgs_data_final.old_labour_supply,
+       t_bgs_data_final.weight,
+       t_bgs_data_final.pssm_credential,
+       t_bgs_data_final.pssm_credential,
+       t_bgs_data_final.lcip4_cred,
+       LEFT(cip_code_4, 2) + ' - ' + 'BACH' AS lcip2_cred,
+       t_bgs_data_final.current_region_pssm_code
+FROM   t_bgs_data_final; "
+
+
+BGS_Q99A_ENDDT_IMPUTED <- "
+UPDATE t_cohorts_recoded
+SET    t_cohorts_recoded.enddt = ( [survey_year] - 2 ) & '-06'
+WHERE  ( ( ( t_cohorts_recoded.enddt ) IS NULL )
+         AND ( ( t_cohorts_recoded.survey ) = 'BGS' ) ); "
+
+BGS_Q00_Checking_Age <- "
+SELECT infoware_bgs_cohort_info.brthmnth,
+infoware_bgs_cohort_info.brthyear,
+infoware_bgs_cohort_info.subm_cd,
+Datevalue([brthdate_string])                       AS Birth_Date,
+[infoware_bgs_cohort_info].[brthyear] & '-' &
+  [infoware_bgs_cohort_info].[brthmnth] & '-' & '15' AS BRTHDATE_STRING,
+'20' & RIGHT([subm_cd], 2) & '-12-01'              AS Survey_Date,
+infoware_bgs_cohort_info.subm_cd, Datediff('yyyy', [Birth_Date],
+                                           [Survey_Date])+([Survey_Date]<Dateserial(Year([Survey_Date]), Month([Birth_Date]
+                                           ), Day([Birth_Date]))) AS expr1, infoware_bgs_dist.age
+FROM   infoware_bgs_cohort_info
+INNER JOIN infoware_bgs_dist
+ON infoware_bgs_cohort_info.stqu_id = infoware_bgs_dist.stqu_id
+WHERE  (((infoware_bgs_cohort_info.subm_cd)='C_Outc16' OR (
+  infoware_bgs_cohort_info.subm_cd)='C_Outc17'));"
+
+###############################################################################################
+# ---- Q003 - Q005 Pull DACSO Records ----
+DACSO_Q003_DACSO_Data_Part_1_stepB <-
+  "SELECT t_dacso_data_part_1_stepa.coci_pen,
+       t_dacso_data_part_1_stepa.coci_stqu_id,
+       t_dacso_data_part_1_stepa.coci_subm_cd,
+       t_dacso_data_part_1_stepa.coci_lrst_cd,
+       t_dacso_data_part_1_stepa.coci_inst_cd,
+       t_dacso_data_part_1_stepa.pfst_current_activity,
+       t_dacso_data_part_1_stepa.lcip_lcippc_name,
+       t_dacso_data_part_1_stepa.lcip_cd,
+       t_dacso_data_part_1_stepa.lcp4_cd,
+       t_dacso_data_part_1_stepa.current_region_pssm_code, 
+       t_dacso_data_part_1_stepa.lcp4_cip_4digits_name,
+       t_dacso_data_part_1_stepa.ttrain,
+       t_dacso_data_part_1_stepa.tpid_lgnd_cd,
+       t_dacso_data_part_1_stepa.labr_in_labour_market,
+       t_dacso_data_part_1_stepa.labr_employed,
+       t_dacso_data_part_1_stepa.labr_unemployed,
+       t_dacso_data_part_1_stepa.labr_employed_full_part_time,
+       t_dacso_data_part_1_stepa.labr_job_search_time_gp,
+       t_dacso_data_part_1_stepa.labr_job_training_related,
+       t_dacso_data_part_1_stepa.labr_occupation_lnoc_cd,
+       t_dacso_data_part_1_stepa.coci_age_at_survey,
+       tbl_age.age_group,
+       tbl_age_groups.age_group_rollup,
+       t_dacso_data_part_1_stepa.cosc_grad_status_lgds_cd_group,
+       t_dacso_data_part_1_stepa.respondent,
+       t_dacso_data_part_1_stepa.new_labour_supply,
+       t_dacso_data_part_1_stepa.old_labour_supply,
+       t_dacso_data_part_1_stepa.weight,
+       t_dacso_data_part_1_stepa.had_previous_credential,
+       t_dacso_data_part_1_stepa.pfst_in_post_sec_before,
+       t_dacso_data_part_1_stepa.pfst_had_previous_cdtl,
+       t_dacso_data_part_1_stepa.pfst_furstdy_incl_still_attd,
+       t_pssm_credential_grouping.prgm_credential_awarded,
+       t_pssm_credential_grouping.prgm_credential_awarded_name,
+       t_pssm_credential_grouping.pssm_credential,
+       t_pssm_credential_grouping.pssm_credential_name,
+       cast(cosc_grad_status_lgds_cd_group as varchar(20)) + ' - ' + lcp4_cd + ' - ' +  
+        CASE WHEN cast(ttrain as varchar(10)) = '2' THEN '1' ELSE cast(ttrain as varchar(10)) END + ' - ' + pssm_credential 
+        AS LCIP4_CRED
+INTO   t_dacso_data_part_1
+FROM   ((t_dacso_data_part_1_stepa
+         INNER JOIN t_pssm_credential_grouping
+                 ON t_dacso_data_part_1_stepa.prgm_credential = t_pssm_credential_grouping.prgm_credential_awarded)
+        LEFT JOIN tbl_age
+               ON t_dacso_data_part_1_stepa.coci_age_at_survey = tbl_age.age)
+       LEFT JOIN tbl_age_groups
+              ON tbl_age.age_group = tbl_age_groups.age_group;"
+
+# in 2023 I removed the inner join on c_out_c_clean2 as it seemed to do nothing.
+DACSO_Q003b_DACSO_DATA_Part_1_Further_Ed <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.had_previous_credential =
+          CASE WHEN infoware_c_outc_clean_short_resp.q08 = '1' 
+          THEN infoware_c_outc_clean_short_resp.pfst_had_previous_cdtl 
+          ELSE infoware_c_outc_clean_short_resp.q08 END,
+       t_dacso_data_part_1.pfst_in_post_sec_before = infoware_c_outc_clean_short_resp.q08,
+       t_dacso_data_part_1.pfst_had_previous_cdtl = infoware_c_outc_clean_short_resp.pfst_had_previous_cdtl,
+       t_dacso_data_part_1.pfst_furstdy_incl_still_attd = infoware_c_outc_clean_short_resp.pfst_furstdy_incl_still_attd
+FROM   t_dacso_data_part_1
+INNER JOIN infoware_c_outc_clean_short_resp  
+  ON  infoware_c_outc_clean_short_resp.stqu_id = t_dacso_data_part_1.coci_stqu_id;"
+
+DACSO_Q004_DACSO_DATA_Part_1_Delete_Credentials <- "
+DELETE t_dacso_data_part_1
+FROM       t_dacso_data_part_1
+INNER JOIN t_pssm_credential_grouping
+ON         t_dacso_data_part_1.prgm_credential_awarded = t_pssm_credential_grouping.prgm_credential_awarded
+WHERE      t_pssm_credential_grouping.dacso_include_in_model IS NULL;"
+
+DACSO_Q004b_DACSO_DATA_Part_1_Add_CURRENT_REGION_PSSM <- "
+ALTER TABLE T_DACSO_DATA_Part_1
+ADD CURRENT_REGION_PSSM_CODE INT NULL;"
+
+DACSO_Q004b_DACSO_DATA_Part_1_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.current_region_pssm_code = dacso_current_region_data.current_region_pssm_code
+FROM t_dacso_data_part_1
+INNER JOIN dacso_current_region_data
+  ON t_dacso_data_part_1.coci_stqu_id = dacso_current_region_data.coci_stqu_id;"
+
+DACSO_Q005_DACSO_DATA_Part_1a_Derived <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.new_labour_supply = 
+       CASE 
+	     		WHEN PFST_CURRENT_ACTIVITY = 3 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 1 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 0 THEN 2
+	     		WHEN PFST_CURRENT_ACTIVITY = 4 And LABR_IN_LABOUR_MARKET = 1 THEN 1
+	     		WHEN RESPONDENT = '1' THEN 0
+	        ELSE 0 
+	     END,
+       t_dacso_data_part_1.weight = t_weights.weight
+FROM t_dacso_data_part_1
+INNER JOIN t_weights
+  ON t_dacso_data_part_1.coci_subm_cd = t_weights.subm_cd
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'DACSO';"
+
+DACSO_Q005_DACSO_DATA_Part_1a_Derived_QI <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.new_labour_supply = 
+       CASE 
+	     		WHEN PFST_CURRENT_ACTIVITY = 3 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 1 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 0 THEN 2
+	     		WHEN PFST_CURRENT_ACTIVITY = 4 And LABR_IN_LABOUR_MARKET = 1 THEN 1
+	     		WHEN RESPONDENT = '1' THEN 0
+	        ELSE 0 
+	     END,
+       t_dacso_data_part_1.weight = t_weights.weight_QI
+FROM t_dacso_data_part_1
+INNER JOIN t_weights
+  ON t_dacso_data_part_1.coci_subm_cd = t_weights.subm_cd
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'DACSO';"
+
+
+DACSO_Q005_DACSO_DATA_Part_1b1_Delete_Cohort <- "
+DELETE t_cohorts_recoded
+FROM   t_cohorts_recoded
+WHERE  t_cohorts_recoded.survey = 'DACSO'; "
+
+DACSO_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <- "
+INSERT 
+INTO t_cohorts_recoded
+    (pen,stqu_id,survey,survey_year,inst_cd,lcp4_cd,ttrain,noc_cd,age_at_survey,age_group,age_group_rollup,grad_status,respondent,new_labour_supply,
+     old_labour_supply,weight,pssm_credential,pssm_cred,lcip4_cred,lcip2_cred,current_region_pssm_code)
+SELECT t_dacso_data_part_1.coci_pen AS pen,
+       'DACSO - ' + CAST(coci_stqu_id AS NVARCHAR(100)) AS stqu_id,
+       t_year_survey_year.survey,
+       t_year_survey_year.survey_year,
+       t_dacso_data_part_1.coci_inst_cd,
+       t_dacso_data_part_1.lcp4_cd,
+       CASE WHEN ttrain = 2 THEN 1 ELSE ttrain END AS TTRAIN,
+       CASE WHEN t_dacso_data_part_1.labr_occupation_lnoc_cd = 'XXXXX' THEN '99999' 
+			ELSE t_dacso_data_part_1.labr_occupation_lnoc_cd END AS NOC_CD,
+       t_dacso_data_part_1.coci_age_at_survey,
+       t_dacso_data_part_1.age_group,
+       t_dacso_data_part_1.age_group_rollup,
+       t_dacso_data_part_1.cosc_grad_status_lgds_cd_group as grad_status,
+       t_dacso_data_part_1.respondent,
+       t_dacso_data_part_1.new_labour_supply,
+       t_dacso_data_part_1.old_labour_supply,
+       t_dacso_data_part_1.weight,
+       t_dacso_data_part_1.pssm_credential,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + pssm_credential AS PSSM_CRED,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + lcp4_cd + ' - ' + 
+			CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS LCIP4_CRED,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + LEFT(lcp4_cd, 2) + ' - ' + 
+            CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS LCIP2_CRED,
+       t_dacso_data_part_1.current_region_pssm_code
+FROM   t_year_survey_year
+INNER JOIN t_dacso_data_part_1
+  ON t_year_survey_year.subm_cd = t_dacso_data_part_1.coci_subm_cd
+WHERE  t_year_survey_year.survey = 'DACSO';"
+
+
+DACSO_Q005_DACSO_DATA_Part_1b3_Check_Weights <- "
+SELECT t_cohorts_recoded.survey,
+       t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.weight
+FROM   t_cohorts_recoded
+GROUP  BY t_cohorts_recoded.survey,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.weight;"
+###############################################################################################
+## update columns of credential non dup
+qry_Credential_Non_Dup_Add_Columns <- "
+ALTER TABLE Credential_Non_Dup
+ADD         OUTCOMES_CIP_CODE_4 varchar(4),
+            OUTCOMES_CIP_CODE_4_NAME varchar(255),
+            FINAL_CIP_CODE_4 varchar(4),
+            FINAL_CIP_CODE_4_NAME varchar(255),
+            FINAL_CIP_CODE_2 varchar(2),
+            FINAL_CIP_CODE_2_NAME varchar(255),
+            FINAL_CIP_CLUSTER_CODE varchar(10),
+            FINAL_CIP_CLUSTER_NAME varchar(255),
+            STP_CIP_CODE_4 varchar(4),
+            STP_CIP_CODE_4_NAME varchar(255),
+            STP_CIP_CODE_2 varchar(2),
+            STP_CIP_CODE_2_NAME varchar(255);
+"
+
+## qry_update_Credential_Non_Dup_DACSO_Final_CIPs ----
+qry_update_Credential_Non_Dup_DACSO_Final_CIPs <- "
+UPDATE     Credential_Non_Dup
+SET        OUTCOMES_CIP_CODE_4 = Credential_Non_Dup_Programs_DACSO_FinalCIPs.OUTCOMES_CIP_CODE_4, 
+           OUTCOMES_CIP_CODE_4_NAME = Credential_Non_Dup_Programs_DACSO_FinalCIPs.OUTCOMES_CIP_CODE_4_NAME, 
+           FINAL_CIP_CODE_4 = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CODE_4, 
+           FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CODE_4_NAME, 
+           FINAL_CIP_CODE_2 = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CODE_2, 
+           FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CODE_2_NAME, 
+           FINAL_CIP_CLUSTER_CODE = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CLUSTER_CODE, 
+           FINAL_CIP_CLUSTER_NAME = Credential_Non_Dup_Programs_DACSO_FinalCIPs.FINAL_CIP_CLUSTER_NAME, 
+           STP_CIP_CODE_4 = Credential_Non_Dup_Programs_DACSO_FinalCIPs.STP_CIP_CODE_4, 
+           STP_CIP_CODE_4_NAME = Credential_Non_Dup_Programs_DACSO_FinalCIPs.STP_CIP_CODE_4_NAME
+FROM       Credential_Non_Dup_Programs_DACSO_FinalCIPs 
+INNER JOIN Credential_Non_Dup 
+ON         Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_CODE = Credential_Non_Dup.PSI_CODE 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_PROGRAM_CODE = Credential_Non_Dup.PSI_PROGRAM_CODE 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_CREDENTIAL_PROGRAM_DESCRIPTION = Credential_Non_Dup.PSI_CREDENTIAL_PROGRAM_DESCRIPTION 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_CREDENTIAL_CIP = Credential_Non_Dup.PSI_CREDENTIAL_CIP 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_CREDENTIAL_LEVEL = Credential_Non_Dup.PSI_CREDENTIAL_LEVEL 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.PSI_CREDENTIAL_CATEGORY = Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY 
+AND        Credential_Non_Dup_Programs_DACSO_FinalCIPs.OUTCOMES_CRED = Credential_Non_Dup.OUTCOMES_CRED
+"
+
+## qry_update_Credential_Non_Dup_BGS_Final_CIPs ----
+qry_update_Credential_Non_Dup_BGS_Final_CIPs <- "
+UPDATE Credential_Non_Dup
+SET		 FINAL_CIP_CODE_4 = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_4_NAME, 
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_2, 
+			 FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_2_NAME, 
+       FINAL_CIP_CLUSTER_CODE = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CLUSTER_CODE, 
+       FINAL_CIP_CLUSTER_NAME = Credential_Non_Dup_BGS_IDs.FINAL_CIP_CLUSTER_NAME
+FROM   Credential_Non_Dup INNER JOIN Credential_Non_Dup_BGS_IDs 
+ON     Credential_Non_Dup.id = Credential_Non_Dup_BGS_IDs.id
+WHERE  Credential_Non_Dup.OUTCOMES_CRED = 'BGS'"
+
+## qry_update_Credential_Non_Dup_GRAD_Final_CIPs ----
+qry_update_Credential_Non_Dup_GRAD_Final_CIPs <- "
+UPDATE Credential_Non_Dup
+SET    FINAL_CIP_CODE_4 = Credential_Non_Dup_GRAD_IDs.FINAL_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_GRAD_IDs.FINAL_CIP_CODE_4_NAME, 
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_GRAD_IDs.FINAL_CIP_CODE_2, 
+       FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_GRAD_IDs.FINAL_CIP_CODE_2_NAME
+FROM   Credential_Non_Dup_GRAD_IDs INNER JOIN Credential_Non_Dup 
+ON     Credential_Non_Dup_GRAD_IDs.id = Credential_Non_Dup.id"
+
+## qry_update_Credential_Non_Dup_APPSO_Final_CIPs ----
+qry_update_Credential_Non_Dup_APPSO_Final_CIPs <- "
+UPDATE Credential_Non_Dup
+SET    FINAL_CIP_CODE_4 = Credential_Non_Dup_APPSO_IDs.FINAL_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_APPSO_IDs.FINAL_CIP_CODE_4_NAME, 
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_APPSO_IDs.FINAL_CIP_CODE_2, 
+       FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_APPSO_IDs.FINAL_CIP_CODE_2_NAME
+FROM   Credential_Non_Dup_APPSO_IDs INNER JOIN Credential_Non_Dup 
+ON     Credential_Non_Dup_APPSO_IDs.id = Credential_Non_Dup.id"
+
+
+## qry_update final cluster codes for GRAD and APPSO data
+qry_update_Credential_Non_Dup_GRAD_APPSO_Cluster <- "
+UPDATE Credential_Non_Dup
+SET    FINAL_CIP_CLUSTER_CODE = LCP2_LCIPPC_CD,
+       FINAL_CIP_CLUSTER_NAME = LCP2_LCIPPC_NAME
+FROM   Credential_Non_Dup INNER JOIN INFOWARE_L_CIP_2DIGITS_CIP2016
+ON     FINAL_CIP_CODE_2 = LCP2_CD
+WHERE OUTCOMES_CRED = 'GRAD' OR OUTCOMES_CRED = 'APPSO'
+"
+
+## final clean up queries for non dup CIPs
+# ---- SQLQuery1 ----
+## not used
+SQLQuery1 <- "
+SELECT   Match_Inst, 
+         Match_School_Year, 
+         Match_CIP_CODE_4, 
+         Match_Credential, 
+         Match_All_4_Flag, 
+         Match_CIP_CODE_2, 
+         Match_All_4_UseThisRecord, 
+         Final_Consider_A_Match, 
+         Final_Probable_Match, 
+         COUNT(*) AS Expr1
+FROM     DACSO_Matching_STP_Enrolment_PEN
+GROUP BY Match_Inst, 
+         Match_School_Year, 
+         Match_CIP_CODE_4, 
+         Match_Credential, 
+         Match_All_4_Flag, 
+         Match_CIP_CODE_2, 
+         Match_All_4_UseThisRecord, 
+         Final_Consider_A_Match, Final_Probable_Match
+ORDER BY Match_Inst DESC, 
+         Match_School_Year DESC, 
+         Match_CIP_CODE_4 DESC, 
+         Match_Credential DESC;"
+
+# ---- SQLQuery2 ----
+## not used
+SQLQuery2 <- "
+UPDATE    T_BGS_Data_Final
+SET       LCP2_DIGITS_NAME = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_DIGITS_NAME
+FROM      T_BGS_Data_Final 
+INNER JOIN INFOWARE.L_CIP_2DIGITS_CIP2016
+ON T_BGS_Data_Final.CIP_CODE_2 = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_CD
+WHERE     (T_BGS_Data_Final.LCP2_DIGITS_NAME IS NULL);"
+
+
+# ---- SQLQuery3 ----
+## not used, should be done already
+SQLQuery3 <- "
+UPDATE    Credential_Non_Dup
+SET       FINAL_CIP_CODE_2_NAME = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_DIGITS_NAME, 
+          FINAL_CIP_CLUSTER_CODE = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_LCIPPC_CD, 
+          FINAL_CIP_CLUSTER_NAME = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_LCIPPC_NAME
+FROM      Credential_Non_Dup 
+INNER JOIN INFOWARE_L_CIP_2DIGITS_CIP2016
+ON Credential_Non_Dup.FINAL_CIP_CODE_2 = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_CD
+WHERE     (Credential_Non_Dup.OUTCOMES_CRED = 'BGS');"
+
+
+# ---- SQLQuery4 ----
+## update some 99 codes for BGS
+SQLQuery4 <- "
+UPDATE    Credential_Non_Dup
+SET       FINAL_CIP_CODE_2_NAME = 'Undeclared activity', 
+          FINAL_CIP_CLUSTER_CODE = '99', 
+          FINAL_CIP_CLUSTER_NAME = 'Undeclared activity'
+WHERE     (OUTCOMES_CRED = 'BGS') AND (FINAL_CIP_CODE_2 = '99');"
+
+
+# ---- SQLQuery5 ----
+## not used (not credential_non_dup)
+SQLQuery5 <- "
+UPDATE    T_BGS_Data_Final
+SET       LCIP_LCIPPC_CD = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_LCIPPC_CD, 
+          LCIP_LCIPPC_NAME = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_LCIPPC_NAME
+FROM      T_BGS_Data_Final 
+INNER JOIN INFOWARE.L_CIP_2DIGITS_CIP2016 
+ON T_BGS_Data_Final.CIP_CODE_2 = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_CD;"
+
+# ---- SQLQuery6 ----
+## update final to be STP if final was missing
+SQLQuery6 <- "
+UPDATE    Credential_Non_Dup
+SET       FINAL_CIP_CODE_4 = STP_CIP_CODE_4, 
+          FINAL_CIP_CODE_4_NAME = STP_CIP_CODE_4_NAME, 
+          FINAL_CIP_CODE_2 = STP_CIP_CODE_2, 
+          FINAL_CIP_CODE_2_NAME = STP_CIP_CODE_2_NAME
+WHERE     (FINAL_CIP_CODE_4 IS NULL) OR
+                      (FINAL_CIP_CODE_4 = ' ');"
+
+# ---- SQLQuery7 ----
+## update some 99 codes to align
+SQLQuery7 <- "
+UPDATE    Credential_Non_Dup
+SET       FINAL_CIP_CLUSTER_CODE = '99',
+          FINAL_CIP_CLUSTER_NAME = 'Undeclared activity'
+WHERE     (OUTCOMES_CRED = 'GRAD') 
+AND (FINAL_CIP_CLUSTER_CODE IS NULL) 
+AND (FINAL_CIP_CLUSTER_NAME IS NULL) 
+AND (FINAL_CIP_CODE_2 = '99');"
+
+###############################################################################################
+# NULL IDS ----
+##
+## qry_NULL_STP_CIP_Cleaning ----
+## collect STP NULL data
+## this will grab any NULLs that are leftover in the final_4_cip_code column and try to match them on their STP codes
+## New (from documentation): create table Credential_Non_Dup_STP_NULL_Cleaning for cleaning STP CIP codes
+qry_NULL_STP_CIP_Cleaning <- "
+SELECT PSI_CREDENTIAL_CIP, 
+       OUTCOMES_CRED,
+       COUNT(*) AS Expr1
+INTO   Credential_Non_Dup_STP_NULL_Cleaning
+FROM   Credential_Non_Dup
+WHERE final_cip_code_4 IS NULL
+GROUP BY 
+       PSI_CREDENTIAL_CIP, 
+       OUTCOMES_CRED
+"
+
+# add columns
+qry_NULL_STP_CIP_add_columns <- "
+ALTER TABLE Credential_Non_Dup_STP_NULL_Cleaning
+ADD STP_CIP_CODE_4 varchar (255),
+STP_CIP_CODE_4_NAME varchar (255),
+STP_CIP_CODE_2 varchar (255),
+STP_CIP_CODE_2_NAME varchar (255),
+STP_CIP_CLUSTER_CODE varchar(10),
+STP_CIP_CLUSTER_NAME varchar(255),
+PSI_CREDENTIAL_CIP_orig varchar (255)
+"
+
+qry_NULL_STP_CIP_update_original <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET PSI_CREDENTIAL_CIP_orig = PSI_CREDENTIAL_CIP"
+
+# clean CIPs that are wrong length
+qry_NULL_STP_CIP_clean_cip_1 <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    PSI_CREDENTIAL_CIP = CONCAT(PSI_CREDENTIAL_CIP, '0')
+WHERE  LEN(PSI_CREDENTIAL_CIP) = 6 AND
+substring(PSI_CREDENTIAL_CIP,1,2) NOT LIKE '%.'"
+
+qry_NULL_STP_CIP_clean_cip_2 <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    PSI_CREDENTIAL_CIP = CONCAT('0', PSI_CREDENTIAL_CIP)
+WHERE LEN(PSI_CREDENTIAL_CIP) = 6"
+
+## qry_Clean_NULL_STP_CIP_Step1_a ----
+## Add 4 and 2D CIP codes from INFOWARE matching on PSI_CREDENTIAL_CIP
+qry_Clean_NULL_STP_CIP_Step1_a <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD],
+       Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_NULL_Cleaning INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP = INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD"
+
+## qry_Clean_NULL_STP_CIP_Step1_b ----
+## New: Add 4 and 2D CIP codes from INFOWARE matching on first 4 digits of PSI_CREDENTIAL_CIP
+qry_Clean_NULL_STP_CIP_Step1_b <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD],
+       Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_NULL_Cleaning 
+INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = substring(INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD,1,5)
+WHERE  STP_CIP_CODE_4 is NULL"
+
+## qry_Clean_NULL_STP_CIP_Step2_c ----
+## New: Add 4D CIP codes for general programs (if 00 change to 01)
+## Check which CIPs have general programs here: https://www.statcan.gc.ca/en/subjects/standard/cip/2021/index
+qry_Clean_NULL_STP_CIP_Step1_c <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET STP_CIP_CODE_4 = CONCAT(substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,2), '01')
+WHERE (substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 11.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 13.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 14.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 19.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 23.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 24.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 26.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 40.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 42.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 45.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 50.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 52.00 OR
+      substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,5) = 55.00) AND
+      STP_CIP_CODE_4 is NULL"
+
+## qry_Clean_NULL_STP_CIP_Step1_d ----
+## New: Add 2D CIP codes from INFOWARE matching on first 2 digits of PSI_CREDENTIAL_CIP
+qry_Clean_NULL_STP_CIP_Step1_d <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD]
+FROM   Credential_Non_Dup_STP_NULL_Cleaning INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP2016 
+ON     substring(Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP,1,2) = substring(INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD_WITH_PERIOD,1,2)
+WHERE  STP_CIP_CODE_2 is NULL"
+
+## qry_Clean_NULL_STP_CIP_Step2 ----
+# Add 4D names
+qry_Clean_NULL_STP_CIP_Step2 <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning 
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4_NAME = [INFOWARE_L_CIP_4DIGITS_CIP2016].[LCP4_CIP_4DIGITS_NAME]
+FROM   Credential_Non_Dup_STP_NULL_Cleaning INNER JOIN INFOWARE_L_CIP_4DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4 = INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD"
+
+## qry_Clean_NULL_STP_CIP_Step3 ----
+# Add 2D names
+qry_Clean_NULL_STP_CIP_Step3 <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2_NAME = [INFOWARE_L_CIP_2DIGITS_CIP2016].[LCP2_DIGITS_NAME],
+       Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CLUSTER_CODE = LCP2_LCIPPC_CD,
+       Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CLUSTER_NAME = LCP2_LCIPPC_NAME
+FROM   Credential_Non_Dup_STP_NULL_Cleaning 
+INNER JOIN INFOWARE_L_CIP_2DIGITS_CIP2016 
+ON     Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2 = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_CD"
+
+## qry_Clean_NULL_STP_CIP_step4 ----
+## New: Set blank 4D names to Invalid 4-digit CIP
+qry_Clean_NULL_STP_CIP_step4 <- "
+UPDATE Credential_Non_Dup_STP_NULL_Cleaning
+SET    Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4_NAME = 'Invalid 4-digit CIP'
+WHERE Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4_NAME is NULL"
+
+## qry_Update_Credential_with_STP_CIP_NULL ----
+## Update STP columns in Credential_Non_Dup and filter on NULL credentials
+qry_Update_Credential_with_STP_CIP_NULL <- "
+Select Credential_Non_Dup.ID,
+       Credential_Non_Dup.PSI_CODE,
+       Credential_Non_Dup.PSI_PROGRAM_CODE,
+       Credential_Non_Dup.PSI_CREDENTIAL_PROGRAM_DESCRIPTION,
+       Credential_Non_Dup.PSI_CREDENTIAL_CIP,
+       Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR,
+       Credential_Non_Dup.OUTCOMES_CRED,
+       FINAL_CIP_CODE_4 = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4_NAME,
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2, 
+       FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_2_NAME,
+       FINAL_CIP_CLUSTER_CODE = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CLUSTER_CODE,
+       FINAL_CIP_CLUSTER_NAME = Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CLUSTER_NAME
+INTO   Credential_Non_Dup_NULL_IDs
+FROM   Credential_Non_Dup INNER JOIN Credential_Non_Dup_STP_NULL_Cleaning 
+ON     Credential_Non_Dup.PSI_CREDENTIAL_CIP = Credential_Non_Dup_STP_NULL_Cleaning.PSI_CREDENTIAL_CIP_orig AND 
+       Credential_Non_Dup.OUTCOMES_CRED = Credential_Non_Dup_STP_NULL_Cleaning.OUTCOMES_CRED
+WHERE  Credential_Non_Dup.final_cip_code_4 is NULL"
+
+## replace unspecified with NULL
+qry_Update_Credential_with_STP_CIP_NULL_nulls <- "
+Update Credential_Non_Dup_NULL_IDs
+SET PSI_PROGRAM_CODE = NULL
+WHERE PSI_PROGRAM_CODE = '(Unspecified)'
+"
+
+## qry_update_Credential_Non_Dup_NULL_Final_CIPs ----
+qry_update_Credential_Non_Dup_NULL_Final_CIPs <- "
+UPDATE Credential_Non_Dup
+SET    FINAL_CIP_CODE_4 = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CODE_4, 
+       FINAL_CIP_CODE_4_NAME = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CODE_4_NAME, 
+       FINAL_CIP_CODE_2 = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CODE_2, 
+       FINAL_CIP_CODE_2_NAME = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CODE_2_NAME
+       FINAL_CIP_CLUSTER_CODE = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CLUSTER_CODE,
+       FINAL_CIP_CLUSTER_NAME = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CLUSTER_NAME
+FROM   Credential_Non_Dup_NULL_IDs INNER JOIN Credential_Non_Dup 
+ON     Credential_Non_Dup_NULL_IDs.id = Credential_Non_Dup.id"
+
+###############################################################################################
+APPSO_Graduates_Projection_Input <-
+  "SELECT t_appso_data_final.pssm_credential,
+       t_appso_data_final.pssm_credential AS PSSM_CRED,
+       tbl_age_groups.age_group_label,
+       t_year_survey_year.award_school_year,
+       Count(*)                           AS Count
+FROM   ((t_appso_data_final
+         INNER JOIN tbl_age
+                 ON t_appso_data_final.app_age_at_survey = tbl_age.age)
+        INNER JOIN tbl_age_groups
+                ON tbl_age.age_group = tbl_age_groups.age_group)
+       INNER JOIN t_year_survey_year
+               ON t_appso_data_final.subm_cd = t_year_survey_year.subm_cd
+WHERE  (( ( t_year_survey_year.survey ) = 'APPSO' ))
+GROUP  BY t_appso_data_final.pssm_credential,
+          tbl_age_groups.age_group_label,
+          t_year_survey_year.award_school_year,
+          t_appso_data_final.pssm_credential
+ORDER  BY tbl_age_groups.age_group_label,
+          t_year_survey_year.award_school_year;"
+
+APPSO_Program_Projection_Input <-
+  "SELECT tbl_age_groups.age_group_label,
+       t_appso_data_final.pssm_credential,
+       pssm_credential & age_group_label        AS Expr1,
+       t_appso_data_final.lcip_lcp4_cd,
+       LEFT(t_appso_data_final.lcip_lcp4_cd, 2) AS LCIP_CP2_CD,
+       t_year_survey_year.award_school_year,
+       Count(*)                                     AS Count
+FROM   ((t_appso_data_final
+         INNER JOIN tbl_age
+                 ON t_appso_data_final.app_age_at_survey = tbl_age.age)
+        INNER JOIN tbl_age_groups
+                ON tbl_age.age_group = tbl_age_groups.age_group)
+       INNER JOIN t_year_survey_year
+               ON t_appso_data_final.subm_cd = t_year_survey_year.subm_cd
+WHERE  (( ( t_year_survey_year.survey ) = 'APPSO' ))
+GROUP  BY tbl_age_groups.age_group_label,
+          t_appso_data_final.pssm_credential,
+          pssm_credential & age_group_label,
+          t_appso_data_final.lcip_lcp4_cd,
+          LEFT(t_appso_data_final.lcip_lcp4_cd, 2),
+          t_year_survey_year.award_school_year
+ORDER  BY tbl_age_groups.age_group_label,
+          t_year_survey_year.award_school_year;"
+
+APPSO_Q003b_Add_CURRENT_REGION_PSSM <-
+  "ALTER TABLE T_APPSO_Data_Final
+ADD CURRENT_REGION_PSSM_CODE INT NULL;"
+
+APPSO_Q003b_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE t_appso_data_final
+SET    t_appso_data_final.current_region_pssm_code = appso_current_region_data.current_region_pssm_code
+FROM   t_appso_data_final
+INNER JOIN appso_current_region_data
+ON     t_appso_data_final.[KEY] = appso_current_region_data.[KEY];"
+
+APPSO_Q003c_Derived_And_Weights <- "
+UPDATE t_appso_data_final
+SET   new_labour_supply = 
+      CASE 
+          WHEN APP_LABR_EMPLOYED = 1 THEN 1 
+          WHEN APP_LABR_IN_LABOUR_MARKET = 1 And APP_LABR_EMPLOYED = 0 THEN 1
+          WHEN APP_LABR_EMPLOYED = 0 THEN 0
+          WHEN RESPONDENT = '1' THEN 0
+          ELSE 0 
+      END,
+      weight = t_weights.weight,
+      t_appso_data_final.age_group = tbl_age.age_group,
+      t_appso_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_appso_data_final
+INNER JOIN t_weights
+  ON t_appso_data_final.subm_cd = t_weights.subm_cd)
+LEFT JOIN tbl_age
+  ON t_appso_data_final.app_age_at_survey = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE t_weights.model = '2022-2023'
+  AND t_weights.survey = 'APPSO';"
+
+
+APPSO_Q003c_Derived_And_Weights_QI <- "
+UPDATE t_appso_data_final
+SET   new_labour_supply = 
+      CASE 
+          WHEN APP_LABR_EMPLOYED = 1 THEN 1 
+          WHEN APP_LABR_IN_LABOUR_MARKET = 1 And APP_LABR_EMPLOYED = 0 THEN 1
+          WHEN APP_LABR_EMPLOYED = 0 THEN 0
+          WHEN RESPONDENT = '1' THEN 0
+          ELSE 0 
+      END,
+      weight = t_weights.weight,
+      t_appso_data_final.age_group = tbl_age.age_group,
+      t_appso_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_appso_data_final
+INNER JOIN t_weights
+  ON t_appso_data_final.subm_cd = t_weights.subm_cd)
+LEFT JOIN tbl_age
+  ON t_appso_data_final.app_age_at_survey = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE t_weights.model = '2022-2023'
+  AND t_weights.survey = 'APPSO';"
+
+
+APPSO_Q005_1b1_Delete_Cohort <-
+  "DELETE T_Cohorts_Recoded
+FROM T_Cohorts_Recoded
+WHERE T_Cohorts_Recoded.Survey = 'APPSO';"
+
+APPSO_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <-
+  "INSERT INTO t_cohorts_recoded
+            (pen,
+             stqu_id,
+             survey,
+             survey_year,
+             inst_cd,
+             lcip_cd,
+             lcp4_cd,
+             noc_cd,
+             age_at_survey,
+             age_group,
+             age_group_rollup,
+             grad_status,
+             respondent,
+             new_labour_supply,
+             weight,
+             pssm_credential,
+             pssm_cred,
+             lcip4_cred,
+             lcip2_cred,
+             current_region_pssm_code)
+SELECT t_appso_data_final.pen,
+       'APPSO - ' + cast(cast([key] AS INTEGER) AS NVARCHAR(255)) AS stqu_id,
+       t_year_survey_year.survey,
+       t_year_survey_year.survey_year,
+       t_appso_data_final.inst,
+       t_appso_data_final.lcip_cd,
+       t_appso_data_final.lcip_lcp4_cd as lcp4_cd,
+       CASE WHEN t_appso_data_final.noc_cd = 'xxxxx' THEN '99999' ELSE t_appso_data_final.noc_cd END AS NOC_CD,
+       t_appso_data_final.app_age_at_survey,
+       tbl_Age_Groups.age_group,
+       tbl_Age_Groups.age_group_rollup,
+       '1' AS grad_status,
+       t_appso_data_final.respondent,
+       t_appso_data_final.new_labour_supply,
+       t_appso_data_final.weight,
+       t_appso_data_final.pssm_credential,
+       t_appso_data_final.pssm_credential,
+       t_appso_data_final.lcip4_cred,
+       LEFT(lcip_lcp4_cd, 2) + ' - ' + pssm_credential AS LCIP2_CRED,
+       t_appso_data_final.current_region_pssm_code
+FROM   t_appso_data_final
+       INNER JOIN t_year_survey_year
+               ON t_appso_data_final.subm_cd = t_year_survey_year.subm_cd
+       LEFT JOIN (tbl_Age  INNER JOIN tbl_Age_Groups  ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group)
+	        ON tbl_Age.Age =  t_appso_data_final.APP_AGE_AT_SURVEY
+WHERE  t_year_survey_year.survey = 'appso';"
+
+
+APPSO_Q99A_ENDDT <-
+  "UPDATE (INFOWARE_APPRENTICE_COHORT_INFO INNER JOIN APPSO_Q99A_STQUI_ID ON INFOWARE_APPRENTICE_COHORT_INFO.KEY = APPSO_Q99A_STQUI_ID.KEY) 
+INNER JOIN T_Cohorts_Recoded 
+ON APPSO_Q99A_STQUI_ID.STQU_ID = T_Cohorts_Recoded.STQU_ID 
+SET T_Cohorts_Recoded.ENDDT = Left(INFOWARE_APPRENTICE_COHORT_INFO.ENDDT,4) + '-' & Right(INFOWARE_APPRENTICE_COHORT_INFO.ENDDT,2)
+WHERE (((T_Cohorts_Recoded.Survey)='APPSO'));"
+
+APPSO_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-1) & '-12'
+WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='APPSO'));"
+
+APPSO_Q99A_STQUI_ID <-
+  "SELECT INFOWARE_APPRENTICE_COHORT_INFO.KEY, 'APPSO - ' + KEY AS STQU_ID
+FROM INFOWARE_APPRENTICE_COHORT_INFO;"
+###############################################################################################
+
+BGS_Q001b_INST_Recode <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.inst = t_bgs_inst_recode.inst_recode
+FROM    t_bgs_data_final
+INNER JOIN t_bgs_inst_recode
+  ON t_bgs_data_final.inst = t_bgs_inst_recode.inst;"
+
+BGS_Q001c_Update_CIPs_After_Program_Matching <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.cip_code_4 = t_bgs_data_final_for_outcomesmatching.final_cip_code_4,
+       t_bgs_data_final.cip_code_2 = t_bgs_data_final_for_outcomesmatching.final_cip_code_2,
+       t_bgs_data_final.lcip_lcippc_cd = t_bgs_data_final_for_outcomesmatching.final_cip_cluster_code
+FROM   t_bgs_data_final
+INNER JOIN t_bgs_data_final_for_outcomesmatching
+    ON t_bgs_data_final.stqu_id = t_bgs_data_final_for_outcomesmatching.stqu_id;"
+
+BGS_Q002_LCP4_CRED <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.lcip4_cred = cip_code_4 + ' - ' + 'BACH',
+       t_bgs_data_final.pssm_credential = 'BACH';"
+
+BGS_Q003b_Add_CURRENT_REGION_PSSM <- "
+ALTER TABLE T_BGS_DATA_Final
+ADD CURRENT_REGION_PSSM_CODE INT NULL;"
+
+BGS_Q003b_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE      t_bgs_data_final
+SET         t_bgs_data_final.current_region_pssm_code =  bgs_current_region_data.current_region_pssm_code
+FROM        t_bgs_data_final
+INNER JOIN  bgs_current_region_data
+    ON      t_bgs_data_final.stqu_id = bgs_current_region_data.stqu_id;"
+
+BGS_Q003c_Derived_And_Weights <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.BGS_New_Labour_Supply =  
+        CASE
+	        	WHEN CURRENT_ACTIVITY = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 0 THEN 2
+	        	WHEN CURRENT_ACTIVITY = 3 And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL  And  FULL_TM_WRK IS NULL And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL And IN_LBR_FRC = 1 THEN 1
+	        	WHEN srv_y_n = 0 THEN 0
+	        	ELSE 0 
+	      END,
+       t_bgs_data_final.weight = t_weights.weight,
+       t_bgs_data_final.age_group = tbl_age.age_group,
+       t_bgs_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_bgs_data_final
+INNER JOIN t_weights
+  ON t_bgs_data_final.survey_year = t_weights.survey_year)
+LEFT JOIN tbl_age
+  ON t_bgs_data_final.age = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'BGS';"
+
+BGS_Q003c_Derived_And_Weights_QI <- "
+UPDATE t_bgs_data_final
+SET    t_bgs_data_final.BGS_New_Labour_Supply =  
+        CASE
+	        	WHEN CURRENT_ACTIVITY = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 1 THEN 1
+	        	WHEN CURRENT_ACTIVITY = 4 And FULL_TM_WRK = 0 THEN 2
+	        	WHEN CURRENT_ACTIVITY = 3 And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL  And  FULL_TM_WRK IS NULL And IN_LBR_FRC = 1 THEN 1 
+	        	WHEN CURRENT_ACTIVITY IS NULL And IN_LBR_FRC = 1 THEN 1
+	        	WHEN srv_y_n = 0 THEN 0
+	        	ELSE 0 
+	      END,
+       t_bgs_data_final.weight = t_weights.weight_QI,
+       t_bgs_data_final.age_group = tbl_age.age_group,
+       t_bgs_data_final.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_bgs_data_final
+INNER JOIN t_weights
+  ON t_bgs_data_final.survey_year = t_weights.survey_year)
+LEFT JOIN tbl_age
+  ON t_bgs_data_final.age = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'BGS';"
+
+
+BGS_Q005_1b1_Delete_Cohort <- "
+DELETE T_Cohorts_Recoded
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.Survey)='BGS'));"
+
+BGS_Q005_1b2_Cohort_Recoded <- "INSERT INTO t_cohorts_recoded
+            (pen,
+             stqu_id,
+             survey,
+             survey_year,
+             inst_cd,
+             lcp4_cd,
+             noc_cd,
+             age_at_survey,
+             age_group,
+             age_group_rollup,
+             grad_status,
+             respondent,
+             new_labour_supply,
+             old_labour_supply,
+             weight,
+             pssm_credential,
+             pssm_cred,
+             lcip4_cred,
+             lcip2_cred,
+             current_region_pssm_code)
+SELECT t_bgs_data_final.pen,
+       'BGS - ' + cast(cast(stqu_id as integer) as nvarchar(20)) AS stqu_id,
+       'BGS' AS survey,
+       t_bgs_data_final.survey_year,
+       t_bgs_data_final.inst,
+       t_bgs_data_final.cip_code_4,
+       CASE 
+          WHEN t_bgs_data_final.noc = 'XXXXX' THEN '99999' 
+			    ELSE t_bgs_data_final.noc
+	     END AS NOC_CD,
+       t_bgs_data_final.age,
+       t_bgs_data_final.age_group,
+       t_bgs_data_final.age_group_rollup,
+       '1' AS grad_status,
+       t_bgs_data_final.srv_y_n,
+       t_bgs_data_final.bgs_new_labour_supply,
+       t_bgs_data_final.old_labour_supply,
+       t_bgs_data_final.weight,
+       t_bgs_data_final.pssm_credential,
+       t_bgs_data_final.pssm_credential,
+       t_bgs_data_final.lcip4_cred,
+       LEFT(cip_code_4, 2) + ' - ' + 'BACH' AS lcip2_cred,
+       t_bgs_data_final.current_region_pssm_code
+FROM   t_bgs_data_final; "
+
+
+BGS_Q99A_ENDDT_IMPUTED <- "
+UPDATE t_cohorts_recoded
+SET    t_cohorts_recoded.enddt = ( [survey_year] - 2 ) & '-06'
+WHERE  ( ( ( t_cohorts_recoded.enddt ) IS NULL )
+         AND ( ( t_cohorts_recoded.survey ) = 'BGS' ) ); "
+
+BGS_Q00_Checking_Age <- "
+SELECT infoware_bgs_cohort_info.brthmnth,
+infoware_bgs_cohort_info.brthyear,
+infoware_bgs_cohort_info.subm_cd,
+Datevalue([brthdate_string])                       AS Birth_Date,
+[infoware_bgs_cohort_info].[brthyear] & '-' &
+  [infoware_bgs_cohort_info].[brthmnth] & '-' & '15' AS BRTHDATE_STRING,
+'20' & RIGHT([subm_cd], 2) & '-12-01'              AS Survey_Date,
+infoware_bgs_cohort_info.subm_cd, Datediff('yyyy', [Birth_Date],
+                                           [Survey_Date])+([Survey_Date]<Dateserial(Year([Survey_Date]), Month([Birth_Date]
+                                           ), Day([Birth_Date]))) AS expr1, infoware_bgs_dist.age
+FROM   infoware_bgs_cohort_info
+INNER JOIN infoware_bgs_dist
+ON infoware_bgs_cohort_info.stqu_id = infoware_bgs_dist.stqu_id
+WHERE  (((infoware_bgs_cohort_info.subm_cd)='C_Outc16' OR (
+  infoware_bgs_cohort_info.subm_cd)='C_Outc17'));"
+
+###############################################################################################
+# ---- Q003 - Q005 Pull DACSO Records ----
+DACSO_Q003_DACSO_Data_Part_1_stepB <-
+  "SELECT t_dacso_data_part_1_stepa.coci_pen,
+       t_dacso_data_part_1_stepa.coci_stqu_id,
+       t_dacso_data_part_1_stepa.coci_subm_cd,
+       t_dacso_data_part_1_stepa.coci_lrst_cd,
+       t_dacso_data_part_1_stepa.coci_inst_cd,
+       t_dacso_data_part_1_stepa.pfst_current_activity,
+       t_dacso_data_part_1_stepa.lcip_lcippc_name,
+       t_dacso_data_part_1_stepa.lcip_cd,
+       t_dacso_data_part_1_stepa.lcp4_cd,
+       t_dacso_data_part_1_stepa.current_region_pssm_code, 
+       t_dacso_data_part_1_stepa.lcp4_cip_4digits_name,
+       t_dacso_data_part_1_stepa.ttrain,
+       t_dacso_data_part_1_stepa.tpid_lgnd_cd,
+       t_dacso_data_part_1_stepa.labr_in_labour_market,
+       t_dacso_data_part_1_stepa.labr_employed,
+       t_dacso_data_part_1_stepa.labr_unemployed,
+       t_dacso_data_part_1_stepa.labr_employed_full_part_time,
+       t_dacso_data_part_1_stepa.labr_job_search_time_gp,
+       t_dacso_data_part_1_stepa.labr_job_training_related,
+       t_dacso_data_part_1_stepa.labr_occupation_lnoc_cd,
+       t_dacso_data_part_1_stepa.coci_age_at_survey,
+       tbl_age.age_group,
+       tbl_age_groups.age_group_rollup,
+       t_dacso_data_part_1_stepa.cosc_grad_status_lgds_cd_group,
+       t_dacso_data_part_1_stepa.respondent,
+       t_dacso_data_part_1_stepa.new_labour_supply,
+       t_dacso_data_part_1_stepa.old_labour_supply,
+       t_dacso_data_part_1_stepa.weight,
+       t_dacso_data_part_1_stepa.had_previous_credential,
+       t_dacso_data_part_1_stepa.pfst_in_post_sec_before,
+       t_dacso_data_part_1_stepa.pfst_had_previous_cdtl,
+       t_dacso_data_part_1_stepa.pfst_furstdy_incl_still_attd,
+       t_pssm_credential_grouping.prgm_credential_awarded,
+       t_pssm_credential_grouping.prgm_credential_awarded_name,
+       t_pssm_credential_grouping.pssm_credential,
+       t_pssm_credential_grouping.pssm_credential_name,
+       cast(cosc_grad_status_lgds_cd_group as varchar(20)) + ' - ' + lcp4_cd + ' - ' +  
+        CASE WHEN cast(ttrain as varchar(10)) = '2' THEN '1' ELSE cast(ttrain as varchar(10)) END + ' - ' + pssm_credential 
+        AS LCIP4_CRED
+INTO   t_dacso_data_part_1
+FROM   ((t_dacso_data_part_1_stepa
+         INNER JOIN t_pssm_credential_grouping
+                 ON t_dacso_data_part_1_stepa.prgm_credential = t_pssm_credential_grouping.prgm_credential_awarded)
+        LEFT JOIN tbl_age
+               ON t_dacso_data_part_1_stepa.coci_age_at_survey = tbl_age.age)
+       LEFT JOIN tbl_age_groups
+              ON tbl_age.age_group = tbl_age_groups.age_group;"
+
+# in 2023 I removed the inner join on c_out_c_clean2 as it seemed to do nothing.
+DACSO_Q003b_DACSO_DATA_Part_1_Further_Ed <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.had_previous_credential =
+          CASE WHEN infoware_c_outc_clean_short_resp.q08 = '1' 
+          THEN infoware_c_outc_clean_short_resp.pfst_had_previous_cdtl 
+          ELSE infoware_c_outc_clean_short_resp.q08 END,
+       t_dacso_data_part_1.pfst_in_post_sec_before = infoware_c_outc_clean_short_resp.q08,
+       t_dacso_data_part_1.pfst_had_previous_cdtl = infoware_c_outc_clean_short_resp.pfst_had_previous_cdtl,
+       t_dacso_data_part_1.pfst_furstdy_incl_still_attd = infoware_c_outc_clean_short_resp.pfst_furstdy_incl_still_attd
+FROM   t_dacso_data_part_1
+INNER JOIN infoware_c_outc_clean_short_resp  
+  ON  infoware_c_outc_clean_short_resp.stqu_id = t_dacso_data_part_1.coci_stqu_id;"
+
+DACSO_Q004_DACSO_DATA_Part_1_Delete_Credentials <- "
+DELETE t_dacso_data_part_1
+FROM       t_dacso_data_part_1
+INNER JOIN t_pssm_credential_grouping
+ON         t_dacso_data_part_1.prgm_credential_awarded = t_pssm_credential_grouping.prgm_credential_awarded
+WHERE      t_pssm_credential_grouping.dacso_include_in_model IS NULL;"
+
+DACSO_Q004b_DACSO_DATA_Part_1_Add_CURRENT_REGION_PSSM <- "
+ALTER TABLE T_DACSO_DATA_Part_1
+ADD CURRENT_REGION_PSSM_CODE INT NULL;"
+
+DACSO_Q004b_DACSO_DATA_Part_1_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.current_region_pssm_code = dacso_current_region_data.current_region_pssm_code
+FROM t_dacso_data_part_1
+INNER JOIN dacso_current_region_data
+  ON t_dacso_data_part_1.coci_stqu_id = dacso_current_region_data.coci_stqu_id;"
+
+DACSO_Q005_DACSO_DATA_Part_1a_Derived <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.new_labour_supply = 
+       CASE 
+	     		WHEN PFST_CURRENT_ACTIVITY = 3 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 1 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 0 THEN 2
+	     		WHEN PFST_CURRENT_ACTIVITY = 4 And LABR_IN_LABOUR_MARKET = 1 THEN 1
+	     		WHEN RESPONDENT = '1' THEN 0
+	        ELSE 0 
+	     END,
+       t_dacso_data_part_1.weight = t_weights.weight
+FROM t_dacso_data_part_1
+INNER JOIN t_weights
+  ON t_dacso_data_part_1.coci_subm_cd = t_weights.subm_cd
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'DACSO';"
+
+DACSO_Q005_DACSO_DATA_Part_1a_Derived_QI <- "
+UPDATE t_dacso_data_part_1
+SET    t_dacso_data_part_1.new_labour_supply = 
+       CASE 
+	     		WHEN PFST_CURRENT_ACTIVITY = 3 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 1 THEN 1
+	     		WHEN PFST_CURRENT_ACTIVITY = 2 And LABR_EMPLOYED_FULL_PART_TIME = 0 THEN 2
+	     		WHEN PFST_CURRENT_ACTIVITY = 4 And LABR_IN_LABOUR_MARKET = 1 THEN 1
+	     		WHEN RESPONDENT = '1' THEN 0
+	        ELSE 0 
+	     END,
+       t_dacso_data_part_1.weight = t_weights.weight_QI
+FROM t_dacso_data_part_1
+INNER JOIN t_weights
+  ON t_dacso_data_part_1.coci_subm_cd = t_weights.subm_cd
+WHERE  t_weights.model = '2022-2023'
+AND    t_weights.survey = 'DACSO';"
+
+
+DACSO_Q005_DACSO_DATA_Part_1b1_Delete_Cohort <- "
+DELETE t_cohorts_recoded
+FROM   t_cohorts_recoded
+WHERE  t_cohorts_recoded.survey = 'DACSO'; "
+
+DACSO_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <- "
+INSERT 
+INTO t_cohorts_recoded
+    (pen,stqu_id,survey,survey_year,inst_cd,lcp4_cd,ttrain,noc_cd,age_at_survey,age_group,age_group_rollup,grad_status,respondent,new_labour_supply,
+     old_labour_supply,weight,pssm_credential,pssm_cred,lcip4_cred,lcip2_cred,current_region_pssm_code)
+SELECT t_dacso_data_part_1.coci_pen AS pen,
+       'DACSO - ' + CAST(coci_stqu_id AS NVARCHAR(100)) AS stqu_id,
+       t_year_survey_year.survey,
+       t_year_survey_year.survey_year,
+       t_dacso_data_part_1.coci_inst_cd,
+       t_dacso_data_part_1.lcp4_cd,
+       CASE WHEN ttrain = 2 THEN 1 ELSE ttrain END AS TTRAIN,
+       CASE WHEN t_dacso_data_part_1.labr_occupation_lnoc_cd = 'XXXXX' THEN '99999' 
+			ELSE t_dacso_data_part_1.labr_occupation_lnoc_cd END AS NOC_CD,
+       t_dacso_data_part_1.coci_age_at_survey,
+       t_dacso_data_part_1.age_group,
+       t_dacso_data_part_1.age_group_rollup,
+       t_dacso_data_part_1.cosc_grad_status_lgds_cd_group as grad_status,
+       t_dacso_data_part_1.respondent,
+       t_dacso_data_part_1.new_labour_supply,
+       t_dacso_data_part_1.old_labour_supply,
+       t_dacso_data_part_1.weight,
+       t_dacso_data_part_1.pssm_credential,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + pssm_credential AS PSSM_CRED,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + lcp4_cd + ' - ' + 
+			CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS LCIP4_CRED,
+       cast(cosc_grad_status_lgds_cd_group as nvarchar(10)) + ' - ' + LEFT(lcp4_cd, 2) + ' - ' + 
+            CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS LCIP2_CRED,
+       t_dacso_data_part_1.current_region_pssm_code
+FROM   t_year_survey_year
+INNER JOIN t_dacso_data_part_1
+  ON t_year_survey_year.subm_cd = t_dacso_data_part_1.coci_subm_cd
+WHERE  t_year_survey_year.survey = 'DACSO';"
+
+
+DACSO_Q005_DACSO_DATA_Part_1b3_Check_Weights <- "
+SELECT t_cohorts_recoded.survey,
+       t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.weight
+FROM   t_cohorts_recoded
+GROUP  BY t_cohorts_recoded.survey,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.weight;"
+###############################################################################################
+Q000_TRD_Graduates_Projection_Input <-
+  "SELECT T_TRD_Data.PSSM_Credential, T_TRD_Data.PSSM_Credential AS PSSM_CRED, tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
+FROM (T_TRD_Data INNER JOIN T_Year_Survey_Year ON T_TRD_Data.SUBM_CD = T_Year_Survey_Year.SUBM_CD) 
+INNER JOIN (tbl_Age INNER JOIN tbl_Age_Groups ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group) ON T_TRD_Data.TRD_AGE_AT_SURVEY = tbl_Age.Age
+WHERE (((T_Year_Survey_Year.Survey)='TRD'))
+GROUP BY T_TRD_Data.PSSM_Credential, tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year, T_TRD_Data.PSSM_Credential
+ORDER BY tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year;"
+
+Q000_TRD_Program_Projection_Input <-
+  "SELECT tbl_Age_Groups.Age_Group_Label, T_TRD_Data.PSSM_Credential, [PSSM_Credential] + [Age_Group_Label] AS Expr1, T_TRD_Data.LCIP_LCP4_CD, Left([T_TRD_DATA].[LCIP_LCP4_CD],2) AS LCIP_CP2_CD, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
+FROM (T_TRD_Data INNER JOIN (tbl_Age INNER JOIN tbl_Age_Groups ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group) ON T_TRD_Data.TRD_AGE_AT_SURVEY = tbl_Age.Age) INNER JOIN T_Year_Survey_Year ON T_TRD_Data.SUBM_CD = T_Year_Survey_Year.SUBM_CD
+WHERE (((T_Year_Survey_Year.Survey)='TRD'))
+GROUP BY tbl_Age_Groups.Age_Group_Label, T_TRD_Data.PSSM_Credential, [PSSM_Credential] + [Age_Group_Label], T_TRD_Data.LCIP_LCP4_CD, Left([T_TRD_DATA].[LCIP_LCP4_CD],2), T_Year_Survey_Year.Award_School_Year
+ORDER BY tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year;"
+
+Q000_TRD_Q003b_Add_CURRENT_REGION_PSSM <-
+  "ALTER TABLE T_TRD_Data
+ADD CURRENT_REGION_PSSM_CODE INT;"
+
+Q000_TRD_Q003b_Add_CURRENT_REGION_PSSM2 <- "
+UPDATE t_trd_data
+SET    t_trd_data.current_region_pssm_code = trd_current_region_data.[current_region_pssm_code]
+FROM t_trd_data
+INNER JOIN trd_current_region_data
+ON t_trd_data.[KEY] = trd_current_region_data.[KEY];"
+
+Q000_TRD_Q003c_Derived_And_Weights <- "
+UPDATE t_trd_data
+SET    t_trd_data.new_labour_supply =
+       CASE 
+          WHEN TRD_LABR_EMPLOYED = 1 THEN 1 
+          WHEN TRD_LABR_IN_LABOUR_MARKET = 1 And TRD_LABR_EMPLOYED = 0 THEN 1
+          WHEN TRD_LABR_EMPLOYED = 0 THEN 0
+          WHEN RESPONDENT = '1' THEN 0
+          ELSE 0 
+      END, 
+      T_TRD_Data.Weight = T_Weights.Weight,
+      T_TRD_Data.age_group = tbl_age.age_group,
+      T_TRD_Data.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_trd_data
+INNER JOIN t_weights
+  ON t_trd_data.subm_cd = t_weights.subm_cd)
+LEFT JOIN tbl_age
+  ON t_trd_data.trd_age_at_survey = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+  AND t_weights.survey = 'TRD';"
+
+Q000_TRD_Q003c_Derived_And_Weights_QI <- "
+UPDATE t_trd_data
+SET    t_trd_data.new_labour_supply =
+       CASE 
+          WHEN TRD_LABR_EMPLOYED = 1 THEN 1 
+          WHEN TRD_LABR_IN_LABOUR_MARKET = 1 And TRD_LABR_EMPLOYED = 0 THEN 1
+          WHEN TRD_LABR_EMPLOYED = 0 THEN 0
+          WHEN RESPONDENT = '1' THEN 0
+          ELSE 0 
+      END, 
+      T_TRD_Data.Weight = T_Weights.Weight_QI,
+      T_TRD_Data.age_group = tbl_age.age_group,
+      T_TRD_Data.age_group_rollup = tbl_age_groups.age_group_rollup
+FROM ((t_trd_data
+INNER JOIN t_weights
+  ON t_trd_data.subm_cd = t_weights.subm_cd)
+LEFT JOIN tbl_age
+  ON t_trd_data.trd_age_at_survey = tbl_age.age)
+LEFT JOIN tbl_age_groups
+  ON tbl_age.age_group = tbl_age_groups.age_group
+WHERE  t_weights.model = '2022-2023'
+  AND t_weights.survey = 'TRD';"
+
+Q000_TRD_Q005_1b1_Delete_Cohort <- "
+DELETE  T_Cohorts_Recoded
+FROM T_Cohorts_Recoded
+WHERE T_Cohorts_Recoded.Survey='TRD';"
+
+Q000_TRD_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <- "
+INSERT INTO t_cohorts_recoded
+            (pen,
+             stqu_id,
+             survey,
+             survey_year,
+             inst_cd,
+             lcip_cd,
+             lcp4_cd,
+             ttrain,
+             noc_cd,
+             age_at_survey,
+             age_group,
+             age_group_rollup,
+             grad_status,
+             respondent,
+             new_labour_supply,
+             weight,
+             pssm_credential,
+             pssm_cred,
+             lcip4_cred,
+             lcip2_cred,
+             current_region_pssm_code)
+SELECT t_trd_data.pen,
+       'TRD - ' + cast([key] as nvarchar(255)) AS stqu_id,
+       t_year_survey_year.survey,
+       t_year_survey_year.survey_year,
+       t_trd_data.inst,
+       t_trd_data.lcip_cd,
+       t_trd_data.lcip_lcp4_cd,
+       CASE WHEN ttrain = 2 THEN 1 ELSE ttrain END AS ttrain,
+       CASE WHEN t_trd_data.noc_cd = 'XXXXX' THEN '99999' ELSE t_trd_data.noc_cd END AS NOC_CD,
+       t_trd_data.trd_age_at_survey,
+       tbl_age_groups.age_group,
+       tbl_age_groups.age_group_rollup,
+       t_trd_data.gradstat_group,
+       t_trd_data.respondent,
+       t_trd_data.new_labour_supply,
+       t_trd_data.weight,
+       t_trd_data.pssm_credential,
+       gradstat_group + ' - ' + pssm_credential  AS PSSM_CRED,
+       gradstat_group + ' - ' + lcip_lcp4_cd + ' - ' +
+       CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS lcip4_cred,
+       gradstat_group + ' - ' + LEFT(lcip_lcp4_cd, 2) + ' - ' +
+       CASE WHEN ttrain = 2 THEN '1' ELSE cast(ttrain as nvarchar(10)) END + ' - ' + pssm_credential AS lcip2_cred,
+       t_trd_data.current_region_pssm_code
+FROM   t_trd_data
+INNER JOIN t_year_survey_year
+  ON t_trd_data.subm_cd = t_year_survey_year.subm_cd
+  LEFT JOIN (tbl_Age  INNER JOIN tbl_Age_Groups  ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group)
+	        ON tbl_Age.Age =  t_trd_data.TRD_AGE_AT_SURVEY
+WHERE  t_year_survey_year.survey = 'TRD';"
+
+Q000_TRD_Q99A_ENDDT <-
+  "UPDATE infoware_trades_cohort_info 
+INNER JOIN (t_cohorts_recoded 
+INNER JOIN 000_trd_q99a_stqui_id 
+ON t_cohorts_recoded.stqu_id = [000_TRD_Q99A_STQUI_ID].stqu_id) 
+ON infoware_trades_cohort_info.KEY = [000_TRD_Q99A_STQUI_ID].KEY 
+SET t_cohorts_recoded.enddt = LEFT([INFOWARE_TRADES_COHORT_INFO].[ENDDT],4) + '-' + RIGHT([INFOWARE_TRADES_COHORT_INFO].[ENDDT],2)
+WHERE (((t_cohorts_recoded.survey)='TRD'));"
+
+Q000_TRD_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = ([Survey_year]-2) + '-12'
+WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='TRD'));"
+
+Q000_TRD_Q99A_STQUI_ID <-
+  "SELECT INFOWARE_TRADES_COHORT_INFO.KEY, 'TRD - ' + [KEY] AS STQU_ID
+FROM INFOWARE_TRADES_COHORT_INFO;"
+
+
+###############################################################################################
+# ---- DACSO_Q008_Z01_Base_OCC ----
+DACSO_Q008_Z01_Base_OCC <- "
+SELECT t_cohorts_recoded.survey,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       Count(*) AS Base,
+       t_cohorts_recoded.stqu_id,
+       t_cohorts_recoded.new_labour_supply
+INTO DACSO_Q008_Z01_Base_OCC
+FROM   t_cohorts_recoded
+WHERE  ( ( ( t_cohorts_recoded.weight ) > 0 )
+         AND ( ( t_cohorts_recoded.current_region_pssm_code ) <>- 1 ) )
+GROUP  BY t_cohorts_recoded.survey,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.stqu_id,
+          t_cohorts_recoded.new_labour_supply,
+          t_cohorts_recoded.grad_status
+HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+         AND ( ( t_cohorts_recoded.new_labour_supply ) = 1
+                OR ( t_cohorts_recoded.new_labour_supply ) = 2
+                OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.grad_status ) = '1'
+                OR ( t_cohorts_recoded.grad_status ) = '3' ) ); "
+
+
+# ---- DACSO_Q008_Z02a_Base ----
+DACSO_Q008_Z02a_Base <-
+  "
+SELECT t_cohorts_recoded.survey,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred,
+Count(*)              AS Count,
+t_cohorts_recoded.weight_nls,
+Count(*) * weight_nls AS Base
+INTO DACSO_Q008_Z02a_Base
+FROM   t_cohorts_recoded
+INNER JOIN (t_current_region_pssm_codes
+            INNER JOIN t_current_region_pssm_rollup_codes
+            ON
+            t_current_region_pssm_codes.current_region_pssm_code_rollup =
+              t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+ON t_cohorts_recoded.current_region_pssm_code =
+  t_current_region_pssm_codes.current_region_pssm_code
+WHERE  ( ( ( t_cohorts_recoded.new_labour_supply ) = 1
+           OR ( t_cohorts_recoded.new_labour_supply ) = 2
+           OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.respondent ) = '1' )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.survey,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred,
+t_cohorts_recoded.weight_nls
+HAVING
+(
+  ( ( t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup ) <> 9999 )
+  AND ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+  AND ( ( t_cohorts_recoded.grad_status ) = '1'
+        OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
+
+DACSO_Q008_Z02b_Respondents <-
+  "
+  SELECT t_cohorts_recoded.survey,
+  t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+  t_cohorts_recoded.survey_year,
+  t_cohorts_recoded.inst_cd,
+  t_cohorts_recoded.age_group_rollup,
+  t_cohorts_recoded.grad_status,
+  t_cohorts_recoded.ttrain,
+  t_cohorts_recoded.lcip4_cred,
+  Sum(CASE
+      WHEN respondent = '1'
+      AND t_cohorts_recoded.current_region_pssm_code <>- 1 THEN 1
+      ELSE 0
+      END) AS Respondents
+  INTO DACSO_Q008_Z02b_Respondents 
+  FROM   t_cohorts_recoded
+  INNER JOIN (t_current_region_pssm_codes
+              INNER JOIN t_current_region_pssm_rollup_codes
+              ON
+              t_current_region_pssm_codes.current_region_pssm_code_rollup =
+                t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+  ON t_cohorts_recoded.current_region_pssm_code =
+    t_current_region_pssm_codes.current_region_pssm_code
+  WHERE  ( ( ( t_cohorts_recoded.noc_cd ) IS NOT NULL
+             AND ( t_cohorts_recoded.noc_cd ) <> '99999' )
+           AND ( ( t_cohorts_recoded.new_labour_supply ) = 1
+                 OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+           AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+  GROUP  BY t_cohorts_recoded.survey,
+  t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+  t_cohorts_recoded.survey_year,
+  t_cohorts_recoded.inst_cd,
+  t_cohorts_recoded.age_group_rollup,
+  t_cohorts_recoded.grad_status,
+  t_cohorts_recoded.ttrain,
+  t_cohorts_recoded.lcip4_cred
+  HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+           AND ( ( t_cohorts_recoded.grad_status ) = '1'
+                 OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
+
+
+# ---- DACSO_Q008_Z02b_Respondents_NOC_99999 ----
+DACSO_Q008_Z02b_Respondents_NOC_99999 <-
+  "
+SELECT t_cohorts_recoded.survey,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred,
+Sum(CASE
+    WHEN respondent = '1'
+    AND t_cohorts_recoded.current_region_pssm_code <>- 1 THEN 1
+    ELSE 0
+    END) AS Respondents
+INTO DACSO_Q008_Z02b_Respondents_NOC_99999
+FROM   t_cohorts_recoded
+INNER JOIN (t_current_region_pssm_codes
+            INNER JOIN t_current_region_pssm_rollup_codes
+            ON
+            t_current_region_pssm_codes.current_region_pssm_code_rollup =
+              t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+ON t_cohorts_recoded.current_region_pssm_code =
+  t_current_region_pssm_codes.current_region_pssm_code
+WHERE  ( ( ( t_cohorts_recoded.noc_cd ) = '99999' )
+         AND ( ( t_cohorts_recoded.new_labour_supply ) = 1
+               OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.survey,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred
+HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+         AND ( ( t_cohorts_recoded.grad_status ) = '1'
+               OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
+
+
+# ---- DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc ----
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc <-
+  "
+SELECT dacso_q008_z02a_base.survey,
+       dacso_q008_z02a_base.current_region_pssm_code_rollup,
+       dacso_q008_z02a_base.survey_year,
+       dacso_q008_z02a_base.inst_cd,
+       dacso_q008_z02a_base.age_group_rollup,
+       dacso_q008_z02a_base.grad_status,
+       dacso_q008_z02a_base.ttrain,
+       dacso_q008_z02a_base.lcip4_cred,
+       dacso_q008_z02a_base.count,
+       dacso_q008_z02a_base.base,
+       dacso_q008_z02b_respondents_noc_99999.respondents,
+       respondents / count AS Expr1
+INTO DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc
+FROM   dacso_q008_z02a_base
+       INNER JOIN dacso_q008_z02b_respondents_noc_99999
+               ON ( dacso_q008_z02a_base.lcip4_cred =
+                               dacso_q008_z02b_respondents_noc_99999.lcip4_cred )
+                  AND ( dacso_q008_z02a_base.grad_status =
+                            dacso_q008_z02b_respondents_noc_99999.grad_status )
+                  AND ( dacso_q008_z02a_base.age_group_rollup =
+dacso_q008_z02b_respondents_noc_99999.age_group_rollup )
+AND ( dacso_q008_z02a_base.inst_cd =
+dacso_q008_z02b_respondents_noc_99999.inst_cd )
+AND ( dacso_q008_z02a_base.survey_year =
+dacso_q008_z02b_respondents_noc_99999.survey_year )
+AND ( dacso_q008_z02a_base.current_region_pssm_code_rollup =
+dacso_q008_z02b_respondents_noc_99999.current_region_pssm_code_rollup )
+AND ( dacso_q008_z02a_base.survey =
+dacso_q008_z02b_respondents_noc_99999.survey )
+WHERE  (( ( respondents / count ) = 1 ));"
+
+
+# ---- DACSO_Q008_Z02b_Respondents_Union ----
+DACSO_Q008_Z02b_Respondents_Union <-
+  "
+SELECT DACSO_Q008_Z02b_Respondents.Survey, 
+DACSO_Q008_Z02b_Respondents.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q008_Z02b_Respondents.Survey_Year, 
+DACSO_Q008_Z02b_Respondents.INST_CD, 
+DACSO_Q008_Z02b_Respondents.Age_Group_Rollup, 
+DACSO_Q008_Z02b_Respondents.GRAD_STATUS, 
+DACSO_Q008_Z02b_Respondents.TTRAIN, 
+DACSO_Q008_Z02b_Respondents.LCIP4_CRED, 
+DACSO_Q008_Z02b_Respondents.Respondents
+INTO DACSO_Q008_Z02b_Respondents_Union
+FROM DACSO_Q008_Z02b_Respondents
+UNION ALL 
+SELECT DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Survey, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Survey_Year, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.INST_CD, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Age_Group_Rollup, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.GRAD_STATUS,  
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.TTRAIN, 
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.LCIP4_CRED,
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Respondents
+FROM DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc;"
+
+
+# ---- DACSO_Q008_Z02c_Weight ----
+DACSO_Q008_Z02c_Weight <-
+  "SELECT DACSO_Q008_Z02a_Base.Survey, 
+        DACSO_Q008_Z02a_Base.Current_Region_PSSM_Code_Rollup, 
+        DACSO_Q008_Z02a_Base.Survey_Year, DACSO_Q008_Z02a_Base.INST_CD, 
+        DACSO_Q008_Z02a_Base.Age_Group_Rollup, DACSO_Q008_Z02a_Base.GRAD_STATUS, 
+        DACSO_Q008_Z02a_Base.TTRAIN, DACSO_Q008_Z02a_Base.LCIP4_CRED, 
+        DACSO_Q008_Z02a_Base.Weight_NLS, DACSO_Q008_Z02a_Base.Base, 
+        DACSO_Q008_Z02b_Respondents_Union.Respondents, 
+        CASE WHEN ISNULL(DACSO_Q008_Z02b_Respondents_Union.Respondents,0)=0 THEN 1 ELSE (DACSO_Q008_Z02a_Base.Base/DACSO_Q008_Z02b_Respondents_Union.Respondents) END AS Weight_NLS_Base, 
+        ISNULL(DACSO_Q008_Z02b_Respondents_Union.Respondents,0)*(CASE WHEN ISNULL(DACSO_Q008_Z02b_Respondents_Union.Respondents,0) = 0 THEN 1 ELSE DACSO_Q008_Z02a_Base.Base/DACSO_Q008_Z02b_Respondents_Union.Respondents END) AS Weighted
+INTO DACSO_Q008_Z02c_Weight
+FROM DACSO_Q008_Z02a_Base 
+LEFT JOIN DACSO_Q008_Z02b_Respondents_Union 
+  ON (DACSO_Q008_Z02a_Base.LCIP4_CRED = DACSO_Q008_Z02b_Respondents_Union.LCIP4_CRED) 
+  AND (DACSO_Q008_Z02a_Base.GRAD_STATUS = DACSO_Q008_Z02b_Respondents_Union.GRAD_STATUS) 
+  AND (DACSO_Q008_Z02a_Base.Age_Group_Rollup = DACSO_Q008_Z02b_Respondents_Union.Age_Group_Rollup) 
+  AND (DACSO_Q008_Z02a_Base.INST_CD = DACSO_Q008_Z02b_Respondents_Union.INST_CD) 
+  AND (DACSO_Q008_Z02a_Base.Survey_Year = DACSO_Q008_Z02b_Respondents_Union.Survey_Year) 
+  AND (DACSO_Q008_Z02a_Base.Current_Region_PSSM_Code_Rollup = DACSO_Q008_Z02b_Respondents_Union.Current_Region_PSSM_Code_Rollup)
+GROUP BY DACSO_Q008_Z02a_Base.Survey, 
+        DACSO_Q008_Z02a_Base.Current_Region_PSSM_Code_Rollup, 
+        DACSO_Q008_Z02a_Base.Survey_Year, DACSO_Q008_Z02a_Base.INST_CD, 
+        DACSO_Q008_Z02a_Base.Age_Group_Rollup, DACSO_Q008_Z02a_Base.GRAD_STATUS, 
+        DACSO_Q008_Z02a_Base.TTRAIN, DACSO_Q008_Z02a_Base.LCIP4_CRED, 
+        DACSO_Q008_Z02a_Base.Weight_NLS, DACSO_Q008_Z02a_Base.Base, 
+        DACSO_Q008_Z02b_Respondents_Union.Respondents;"
+
+
+# ---- DACSO_Q008_Z03_Weight_Total ----
+DACSO_Q008_Z03_Weight_Total <-
+  "SELECT dacso_q008_z02c_weight.survey,
+       dacso_q008_z02c_weight.current_region_pssm_code_rollup,
+       dacso_q008_z02c_weight.inst_cd,
+       dacso_q008_z02c_weight.age_group_rollup,
+       dacso_q008_z02c_weight.grad_status,
+       dacso_q008_z02c_weight.ttrain,
+       dacso_q008_z02c_weight.lcip4_cred,
+       Sum(dacso_q008_z02c_weight.base)     AS Base,
+       Sum(dacso_q008_z02c_weight.weighted) AS Weighted
+INTO DACSO_Q008_Z03_Weight_Total
+FROM   dacso_q008_z02c_weight
+GROUP  BY dacso_q008_z02c_weight.survey,
+          dacso_q008_z02c_weight.current_region_pssm_code_rollup,
+          dacso_q008_z02c_weight.inst_cd,
+          dacso_q008_z02c_weight.age_group_rollup,
+          dacso_q008_z02c_weight.grad_status,
+          dacso_q008_z02c_weight.ttrain,
+          dacso_q008_z02c_weight.lcip4_cred;"
+
+
+# ---- DACSO_Q008_Z04_Weight_Adj_Fac ----
+DACSO_Q008_Z04_Weight_Adj_Fac <-
+  "SELECT dacso_q008_z03_weight_total.survey,
+       dacso_q008_z03_weight_total.current_region_pssm_code_rollup,
+       dacso_q008_z03_weight_total.inst_cd,
+       dacso_q008_z03_weight_total.age_group_rollup,
+       dacso_q008_z03_weight_total.grad_status,
+       dacso_q008_z03_weight_total.ttrain,
+       dacso_q008_z03_weight_total.lcip4_cred,
+       dacso_q008_z03_weight_total.base,
+       dacso_q008_z03_weight_total.weighted,
+       CASE
+         WHEN weighted = 0 THEN 0
+         ELSE base / weighted
+       END AS Weight_Adj_Fac
+INTO DACSO_Q008_Z04_Weight_Adj_Fac
+FROM   dacso_q008_z03_weight_total;"
+
+
+# ---- DACSO_Q008_Z05_Weight_OCC ----
+DACSO_Q008_Z05_Weight_OCC <-
+  "SELECT DACSO_Q008_Z02c_Weight.Survey, 
+      DACSO_Q008_Z02c_Weight.Current_Region_PSSM_Code_Rollup,
+      T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, DACSO_Q008_Z02c_Weight.Survey_Year, 
+      DACSO_Q008_Z02c_Weight.INST_CD, DACSO_Q008_Z02c_Weight.Age_Group_Rollup, 
+      DACSO_Q008_Z02c_Weight.GRAD_STATUS, DACSO_Q008_Z02c_Weight.TTRAIN, 
+      DACSO_Q008_Z02c_Weight.LCIP4_CRED, DACSO_Q008_Z02c_Weight.Base, 
+      DACSO_Q008_Z02c_Weight.Respondents, DACSO_Q008_Z02c_Weight.Weight_NLS_Base, 
+      DACSO_Q008_Z04_Weight_Adj_Fac.Weighted, DACSO_Q008_Z04_Weight_Adj_Fac.Weight_Adj_Fac, 
+      Weight_NLS_Base*Weight_Adj_Fac AS Weight_OCC 
+INTO tmp_tbl_Weights_OCC
+FROM ((DACSO_Q008_Z02c_Weight 
+INNER JOIN DACSO_Q008_Z04_Weight_Adj_Fac 
+  ON (DACSO_Q008_Z02c_Weight.Age_Group_Rollup = DACSO_Q008_Z04_Weight_Adj_Fac.Age_Group_Rollup) 
+  AND (DACSO_Q008_Z02c_Weight.INST_CD = DACSO_Q008_Z04_Weight_Adj_Fac.INST_CD) 
+  AND (DACSO_Q008_Z02c_Weight.Survey = DACSO_Q008_Z04_Weight_Adj_Fac.Survey) 
+  AND (DACSO_Q008_Z02c_Weight.GRAD_STATUS = DACSO_Q008_Z04_Weight_Adj_Fac.GRAD_STATUS) 
+  AND (DACSO_Q008_Z02c_Weight.LCIP4_CRED = DACSO_Q008_Z04_Weight_Adj_Fac.LCIP4_CRED) 
+  AND (DACSO_Q008_Z02c_Weight.Current_Region_PSSM_Code_Rollup = DACSO_Q008_Z04_Weight_Adj_Fac.Current_Region_PSSM_Code_Rollup)) 
+  INNER JOIN T_Current_Region_PSSM_Rollup_Codes 
+    ON DACSO_Q008_Z02c_Weight.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup) 
+INNER JOIN T_Current_Region_PSSM_Codes 
+  ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code_Rollup;"
+
+
+# ---- DACSO_Q008_Z05b_Finding_NLS2_Missing ----
+DACSO_Q008_Z05b_Finding_NLS2_Missing <-
+  "SELECT 
+tmp_tbl_Weights_OCC.Survey, 
+tmp_tbl_Weights_OCC.INST_CD, 
+tmp_tbl_Weights_OCC.Age_Group_Rollup, 
+tmp_tbl_Weights_OCC.GRAD_STATUS, 
+tmp_tbl_Weights_NLS.TTRAIN, 
+tmp_tbl_Weights_OCC.LCIP4_CRED
+INTO DACSO_Q008_Z05b_Finding_NLS2_Missing
+FROM tmp_tbl_Weights_NLS 
+LEFT JOIN tmp_tbl_Weights_OCC 
+  ON (tmp_tbl_Weights_NLS.LCIP4_CRED = tmp_tbl_Weights_OCC.LCIP4_CRED) 
+  AND (tmp_tbl_Weights_NLS.GRAD_STATUS = tmp_tbl_Weights_OCC.GRAD_STATUS) 
+  AND (tmp_tbl_Weights_NLS.Age_Group_Rollup = tmp_tbl_Weights_OCC.Age_Group_Rollup) 
+  AND (tmp_tbl_Weights_NLS.INST_CD = tmp_tbl_Weights_OCC.INST_CD) 
+  AND (tmp_tbl_Weights_NLS.Survey = tmp_tbl_Weights_OCC.Survey)
+WHERE (((tmp_tbl_Weights_OCC.Survey) Is Null) 
+  AND ((tmp_tbl_Weights_OCC.INST_CD) Is Null) 
+  AND ((tmp_tbl_Weights_OCC.Age_Group_Rollup) Is Null) 
+  AND ((tmp_tbl_Weights_OCC.GRAD_STATUS) Is Null) 
+  AND ((tmp_tbl_Weights_OCC.LCIP4_CRED) Is Null));"
+
+# ---- DACSO_Q008_Z05b_NOC4D_NLS_XTab ----
+DACSO_Q008_Z05b_NOC4D_NLS_XTab <-
+  "
+SELECT age_group_rollup, noc_cd, english_name, [1],[3]
+INTO DACSO_Q008_Z05b_NOC4D_NLS_XTab
+FROM(
+SELECT t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.noc_cd,
+       T_NOC_Broad_Categories.english_name, 
+	   t_cohorts_recoded.new_labour_supply, 
+	   (CASE WHEN respondent='1' THEN 1 ELSE 0 END)*weight_nls as weight_nls
+FROM   t_cohorts_recoded
+LEFT JOIN T_NOC_Broad_Categories
+	ON t_cohorts_recoded.noc_cd = T_NOC_Broad_Categories.unit_group_code
+WHERE t_cohorts_recoded.age_group_rollup IS NOT NULL 
+ AND t_cohorts_recoded.noc_cd IS NOT NULL 
+ AND ( t_cohorts_recoded.new_labour_supply = 1 OR t_cohorts_recoded.new_labour_supply = 3 )
+ AND t_cohorts_recoded.weight > 0
+ AND ( t_cohorts_recoded.grad_status = '1' OR t_cohorts_recoded.grad_status = '3' )
+ AND t_cohorts_recoded.lcp4_cd IS NOT NULL) P
+PIVOT (
+    SUM(weight_nls) 
+	FOR new_labour_supply IN ([1], [3])
+) AS PivotTable
+order by age_group_rollup, noc_cd;"
+
+
+# ---- DACSO_Q008_Z05b_Weight_Comparison ----
+DACSO_Q008_Z05b_Weight_Comparison <-
+  "
+SELECT tmp_tbl_weights_nls.survey,
+       tmp_tbl_weights_nls.survey_year,
+       tmp_tbl_weights_nls.inst_cd,
+       tmp_tbl_weights_nls.age_group_rollup,
+       tmp_tbl_weights_nls.grad_status,
+       tmp_tbl_weights_nls.ttrain,
+       tmp_tbl_weights_nls.lcip4_cred,
+       tmp_tbl_weights_nls.weight_nls,
+       tmp_tbl_weights_occ.weight_occ,
+       tmp_tbl_weights_occ.respondents,
+       weight_occ / weight_nls AS Ratio
+INTO DACSO_Q008_Z05b_Weight_Comparison
+FROM   tmp_tbl_weights_nls
+       INNER JOIN tmp_tbl_weights_occ
+               ON ( tmp_tbl_weights_nls.survey_year =
+                    tmp_tbl_weights_occ.survey_year )
+                  AND ( tmp_tbl_weights_nls.inst_cd =
+                        tmp_tbl_weights_occ.inst_cd )
+                  AND ( tmp_tbl_weights_nls.grad_status =
+                        tmp_tbl_weights_occ.grad_status )
+                  AND ( tmp_tbl_weights_nls.lcip4_cred =
+                      tmp_tbl_weights_occ.lcip4_cred )
+                  AND ( tmp_tbl_weights_nls.age_group_rollup =
+                        tmp_tbl_weights_occ.age_group_rollup )
+WHERE  ( ( ( tmp_tbl_weights_occ.weight_occ ) <> weight_nls )
+         AND ( ( tmp_tbl_weights_occ.respondents ) IS NOT NULL ) ); "
+
+
+# ---- DACSO_Q008_Z06_Add_Weight_OCC_Field ----
+DACSO_Q008_Z06_Add_Weight_OCC_Field <-
+  "ALTER TABLE T_Cohorts_Recoded ADD Weight_OCC FLOAT NULL;"
+
+
+# ---- DACSO_Q008_Z07_Weight_OCC_Null ----
+DACSO_Q008_Z07_Weight_OCC_Null <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_OCC = Null;"
+
+
+# ---- DACSO_Q008_Z08_Weight_OCC_Update ----
+DACSO_Q008_Z08_Weight_OCC_Update <-
+  "UPDATE T_Cohorts_Recoded 
+SET T_Cohorts_Recoded.Weight_OCC = tmp_tbl_Weights_OCC.Weight_OCC
+FROM T_Current_Region_PSSM_Codes 
+INNER JOIN ((tmp_tbl_Weights_OCC INNER JOIN T_Cohorts_Recoded 
+  ON (tmp_tbl_Weights_OCC.Current_Region_PSSM_Code = T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE) 
+  AND (tmp_tbl_Weights_OCC.LCIP4_CRED = T_Cohorts_Recoded.LCIP4_CRED) 
+  AND (tmp_tbl_Weights_OCC.GRAD_STATUS = T_Cohorts_Recoded.GRAD_STATUS) 
+  AND (tmp_tbl_Weights_OCC.Survey_Year = T_Cohorts_Recoded.Survey_Year) 
+  AND (tmp_tbl_Weights_OCC.INST_CD = T_Cohorts_Recoded.INST_CD) 
+  AND (tmp_tbl_Weights_OCC.Age_Group_Rollup = T_Cohorts_Recoded.Age_Group_Rollup)) 
+INNER JOIN DACSO_Q008_Z01_Base_OCC 
+  ON T_Cohorts_Recoded.STQU_ID = DACSO_Q008_Z01_Base_OCC.STQU_ID) 
+  ON T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code = T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE 
+SET T_Cohorts_Recoded.Weight_OCC = tmp_tbl_Weights_OCC.Weight_OCC
+WHERE (((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)<>-1) 
+  AND ((T_Cohorts_Recoded.NOC_CD) Is Not Null 
+  And (T_Cohorts_Recoded.NOC_CD) <> '99999''));"
+
+
+# ---- DACSO_Q008_Z08_Weight_OCC_Update ----
+DACSO_Q008_Z08_Weight_OCC_Update <-
+  "UPDATE T_Cohorts_Recoded
+SET T_Cohorts_Recoded.Weight_OCC = tmp_tbl_Weights_OCC.Weight_OCC 
+from T_Cohorts_Recoded
+inner join tmp_tbl_Weights_OCC
+  ON  tmp_tbl_Weights_OCC.Current_Region_PSSM_Code = T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE 
+  AND tmp_tbl_Weights_OCC.LCIP4_CRED = T_Cohorts_Recoded.LCIP4_CRED
+  AND tmp_tbl_Weights_OCC.GRAD_STATUS = T_Cohorts_Recoded.GRAD_STATUS 
+  AND tmp_tbl_Weights_OCC.Survey_Year = T_Cohorts_Recoded.Survey_Year
+  AND tmp_tbl_Weights_OCC.INST_CD = T_Cohorts_Recoded.INST_CD
+  AND tmp_tbl_Weights_OCC.Age_Group_Rollup = T_Cohorts_Recoded.Age_Group_Rollup
+inner join T_Current_Region_PSSM_Codes
+on T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code = T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE
+inner join DACSO_Q008_Z01_Base_OCC 
+on DACSO_Q008_Z01_Base_OCC.STQU_ID = T_Cohorts_Recoded.STQU_ID
+WHERE T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE <> -1
+AND T_Cohorts_Recoded.NOC_CD Is Not Null 
+And T_Cohorts_Recoded.NOC_CD <> '99999';"
+
+# ---- DACSO_Q008_Z08_Weight_OCC_Update_NOC_99999_100_perc ----
+DACSO_Q008_Z08_Weight_OCC_Update_NOC_99999_100_perc <-
+  "UPDATE t_cohorts_recoded
+SET        t_cohorts_recoded.weight_occ = tmp_tbl_weights_occ.weight_occ
+from t_cohorts_recoded
+INNER JOIN t_current_region_pssm_codes
+ ON t_current_region_pssm_codes.current_region_pssm_code = t_cohorts_recoded.current_region_pssm_code
+INNER JOIN tmp_tbl_weights_occ
+ON         tmp_tbl_weights_occ.age_group_rollup = t_cohorts_recoded.age_group_rollup
+AND        tmp_tbl_weights_occ.inst_cd = t_cohorts_recoded.inst_cd
+AND        tmp_tbl_weights_occ.survey_year = t_cohorts_recoded.survey_year
+AND        tmp_tbl_weights_occ.grad_status = t_cohorts_recoded.grad_status
+AND        tmp_tbl_weights_occ.lcip4_cred = t_cohorts_recoded.lcip4_cred
+AND        tmp_tbl_weights_occ.current_region_pssm_code = t_cohorts_recoded.current_region_pssm_code
+INNER JOIN dacso_q008_z01_base_occ
+ON         t_cohorts_recoded.stqu_id = dacso_q008_z01_base_occ.stqu_id
+INNER JOIN dacso_q008_z02b_respondents_noc_99999_100_perc
+ON         tmp_tbl_weights_occ.survey = dacso_q008_z02b_respondents_noc_99999_100_perc.survey
+AND        tmp_tbl_weights_occ.current_region_pssm_code_rollup = dacso_q008_z02b_respondents_noc_99999_100_perc.current_region_pssm_code_rollup
+AND        tmp_tbl_weights_occ.survey_year = dacso_q008_z02b_respondents_noc_99999_100_perc.survey_year
+AND        tmp_tbl_weights_occ.inst_cd = dacso_q008_z02b_respondents_noc_99999_100_perc.inst_cd
+AND        dacso_q008_z02b_respondents_noc_99999_100_perc.age_group_rollup = tmp_tbl_weights_occ.age_group_rollup
+AND        tmp_tbl_weights_occ.grad_status = dacso_q008_z02b_respondents_noc_99999_100_perc.grad_status
+AND        tmp_tbl_weights_occ.lcip4_cred = dacso_q008_z02b_respondents_noc_99999_100_perc.lcip4_cred
+WHERE      t_cohorts_recoded.current_region_pssm_code<>-1
+AND        t_cohorts_recoded.noc_cd IS NOT NULL;"
+
+
+# ---- DACSO_Q008_Z09_Check_Weights ----
+DACSO_Q008_Z09_Check_Weights <-
+  "SELECT t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       Sum(Iif(respondent = '1'
+               AND t_cohorts_recoded.current_region_pssm_code <>- 1, 1, 0))  AS
+       Respondents,
+       t_cohorts_recoded.weight_occ,
+       Sum(Iif(respondent = '1'
+               AND
+       t_cohorts_recoded.current_region_pssm_code <>- 1, 1, 0)) * weight_occ AS Weighted,
+       Sum(dacso_q008_z01_base_occ.base) AS Base,
+       t_cohorts_recoded.respondent
+FROM   t_cohorts_recoded
+       INNER JOIN dacso_q008_z01_base_occ
+               ON t_cohorts_recoded.stqu_id = dacso_q008_z01_base_occ.stqu_id
+WHERE  (( ( dacso_q008_z01_base_occ.new_labour_supply ) = 1
+           OR ( dacso_q008_z01_base_occ.new_labour_supply ) = 3 ))
+GROUP  BY t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.weight_occ,
+          t_cohorts_recoded.respondent
+HAVING ( ( ( t_cohorts_recoded.weight_occ ) IS NOT NULL )
+         AND ( ( t_cohorts_recoded.respondent ) = '1' ) )
+ORDER  BY t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.weight_occ;"
+
+
+# ---- DACSO_Q009_Weight_Occs ----
+DACSO_Q009_Weight_Occs <- "
+SELECT t_cohorts_recoded.pssm_credential,
+t_cohorts_recoded.pssm_cred,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.lcp4_cd,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred,
+t_cohorts_recoded.lcip2_cred,
+(CASE WHEN t_cohorts_recoded.noc_cd = 'XXXXX' THEN '99999' ELSE t_cohorts_recoded.noc_cd END) AS NOC_CD,
+Count(*) AS Count,
+t_cohorts_recoded.weight_occ,
+Count(*) * weight_occ AS Weighted
+INTO DACSO_Q009_Weight_Occs
+FROM   t_cohorts_recoded
+INNER JOIN (t_current_region_pssm_codes
+        INNER JOIN t_current_region_pssm_rollup_codes
+        ON t_current_region_pssm_codes.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+ON t_cohorts_recoded.current_region_pssm_code = t_current_region_pssm_codes.current_region_pssm_code
+WHERE  ( ( ( t_cohorts_recoded.new_labour_supply ) = 1
+           OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.pssm_credential,
+t_cohorts_recoded.pssm_cred,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+t_cohorts_recoded.survey_year,
+t_cohorts_recoded.inst_cd,
+t_cohorts_recoded.age_group_rollup,
+t_cohorts_recoded.grad_status,
+t_cohorts_recoded.lcp4_cd,
+t_cohorts_recoded.ttrain,
+t_cohorts_recoded.lcip4_cred,
+t_cohorts_recoded.lcip2_cred,
+Iif(t_cohorts_recoded.noc_cd = 'XXXXX', '99999',
+    t_cohorts_recoded.noc_cd),
+t_cohorts_recoded.weight_occ
+HAVING t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup  <> 99999 
+  AND t_cohorts_recoded.age_group_rollup IS NOT NULL
+  AND ( t_cohorts_recoded.grad_status  = '1' OR t_cohorts_recoded.grad_status = '3' )
+  AND Iif(t_cohorts_recoded.noc_cd = 'XXXXX', '99999', t_cohorts_recoded.noc_cd) IS NOT NULL
+  AND t_cohorts_recoded.weight_occ IS NOT NULL
+ORDER  BY t_cohorts_recoded.grad_status,
+	t_cohorts_recoded.lcip4_cred,
+	CASE WHEN t_cohorts_recoded.noc_cd = 'XXXXX' THEN '99999' ELSE t_cohorts_recoded.noc_cd END;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_2D ----
+DACSO_Q009_Weighted_Occs_2D <-
+  "SELECT dacso_q009_weight_occs.pssm_credential,
+       dacso_q009_weight_occs.pssm_cred,
+       dacso_q009_weight_occs.current_region_pssm_code_rollup,
+       dacso_q009_weight_occs.age_group_rollup,
+       LEFT(lcp4_cd, 2)                     AS LCP2_CD,
+       dacso_q009_weight_occs.ttrain,
+       dacso_q009_weight_occs.lcip2_cred,
+       dacso_q009_weight_occs.noc_cd,
+       Sum(dacso_q009_weight_occs.weighted) AS Count
+INTO DACSO_Q009_Weighted_Occs_2D
+FROM   dacso_q009_weight_occs
+GROUP  BY dacso_q009_weight_occs.pssm_credential,
+          dacso_q009_weight_occs.pssm_cred,
+          dacso_q009_weight_occs.current_region_pssm_code_rollup,
+          dacso_q009_weight_occs.age_group_rollup,
+          LEFT(lcp4_cd, 2),
+          dacso_q009_weight_occs.ttrain,
+          dacso_q009_weight_occs.lcip2_cred,
+          dacso_q009_weight_occs.noc_cd; "
+
+
+# ---- DACSO_Q009_Weighted_Occs_2D_BC ----
+DACSO_Q009_Weighted_Occs_2D_BC <-
+  "SELECT dacso_q009_weight_occs.pssm_credential,
+       dacso_q009_weight_occs.pssm_cred,
+       LEFT(lcp4_cd, 2)                     AS LCP2_CD,
+       dacso_q009_weight_occs.ttrain,
+       dacso_q009_weight_occs.lcip2_cred,
+       dacso_q009_weight_occs.noc_cd,
+       Sum(dacso_q009_weight_occs.weighted) AS Count
+INTO DACSO_Q009_Weighted_Occs_2D_BC
+FROM   dacso_q009_weight_occs
+       INNER JOIN t_current_region_pssm_rollup_codes_bc
+               ON dacso_q009_weight_occs.current_region_pssm_code_rollup =
+t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup
+WHERE  (( (
+t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup_bc )
+     IS
+      NOT NULL ))
+GROUP  BY dacso_q009_weight_occs.pssm_credential,
+          dacso_q009_weight_occs.pssm_cred,
+          LEFT(lcp4_cd, 2),
+          dacso_q009_weight_occs.ttrain,
+          dacso_q009_weight_occs.lcip2_cred,
+          dacso_q009_weight_occs.noc_cd; "
+
+
+# ---- DACSO_Q009_Weighted_Occs_2D_BC_No_TT ----
+DACSO_Q009_Weighted_Occs_2D_BC_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, 
+IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
+DACSO_Q009_Weight_Occs.NOC_CD, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Count
+INTO DACSO_Q009_Weighted_Occs_2D_BC_No_TT
+FROM DACSO_Q009_Weight_Occs 
+INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC 
+ON DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
+WHERE (((T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC) Is Not Null))
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential, DACSO_Q009_Weight_Occs.NOC_CD;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_2D_No_TT ----
+DACSO_Q009_Weighted_Occs_2D_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q009_Weight_Occs.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
+DACSO_Q009_Weight_Occs.NOC_CD, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Count
+INTO DACSO_Q009_Weighted_Occs_2D_No_TT
+FROM DACSO_Q009_Weight_Occs
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential, DACSO_Q009_Weight_Occs.NOC_CD;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_Total_2D ----
+DACSO_Q009_Weighted_Occs_Total_2D <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED, 
+Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+INTO DACSO_Q009_Weighted_Occs_Total_2D 
+FROM DACSO_Q009_Weight_Occs
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+Left(LCP4_CD,2), DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_Total_2D_BC ----
+DACSO_Q009_Weighted_Occs_Total_2D_BC <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weight_Occs.PSSM_CRED, 
+Left(LCP4_CD,2) AS LCP2_CD, 
+DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+INTO DACSO_Q009_Weighted_Occs_Total_2D_BC
+FROM DACSO_Q009_Weight_Occs INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC 
+  ON DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
+WHERE (((T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC) Is Not Null))
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+Left(LCP4_CD,2), DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT ----
+DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+INTO DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT
+FROM DACSO_Q009_Weight_Occs INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
+WHERE (((T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC) Is Not Null))
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2), 
+IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),
+Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
+
+
+# ---- DACSO_Q009_Weighted_Occs_Total_2D_No_TT ----
+DACSO_Q009_Weighted_Occs_Total_2D_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),
+Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
+Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+INTO DACSO_Q009_Weighted_Occs_Total_2D_No_TT
+FROM DACSO_Q009_Weight_Occs
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
+
+
+# ---- DACSO_Q009b_Weighted_Occs ----
+DACSO_Q009b_Weighted_Occs <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, 
+DACSO_Q009_Weight_Occs.LCIP2_CRED, DACSO_Q009_Weight_Occs.NOC_CD, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Count
+INTO DACSO_Q009b_Weighted_Occs
+FROM DACSO_Q009_Weight_Occs
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
+DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, 
+DACSO_Q009_Weight_Occs.LCIP2_CRED, DACSO_Q009_Weight_Occs.NOC_CD
+ORDER BY DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.NOC_CD;"
+
+
+# ---- DACSO_Q009b_Weighted_Occs_No_TT ----
+DACSO_Q009b_Weighted_Occs_No_TT <-
+  "
+SELECT dacso_q009_weight_occs.pssm_credential,
+dacso_q009_weight_occs.pssm_cred,
+dacso_q009_weight_occs.current_region_pssm_code_rollup,
+dacso_q009_weight_occs.age_group_rollup,
+dacso_q009_weight_occs.lcp4_cd,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential          AS LCIP4_CRED,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential AS LCIP2_CRED,
+dacso_q009_weight_occs.noc_cd,
+Sum(dacso_q009_weight_occs.weighted)         AS Count
+INTO   dacso_q009b_weighted_occs_no_tt
+FROM   dacso_q009_weight_occs
+GROUP  BY dacso_q009_weight_occs.pssm_credential,
+dacso_q009_weight_occs.pssm_cred,
+dacso_q009_weight_occs.current_region_pssm_code_rollup,
+dacso_q009_weight_occs.age_group_rollup,
+dacso_q009_weight_occs.lcp4_cd,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential,
+dacso_q009_weight_occs.noc_cd
+ORDER  BY dacso_q009_weight_occs.noc_cd;"
+
+
+# ---- DACSO_Q009b_Weighted_Occs_Total ----
+DACSO_Q009b_Weighted_Occs_Total <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+INTO DACSO_Q009b_Weighted_Occs_Total
+FROM DACSO_Q009_Weight_Occs
+GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.LCIP2_CRED
+ORDER BY DACSO_Q009_Weight_Occs.LCIP4_CRED;"
+
+
+# ---- DACSO_Q009b_Weighted_Occs_Total_No_TT ----
+DACSO_Q009b_Weighted_Occs_Total_No_TT <-
+  "SELECT   dacso_q009_weight_occs.pssm_credential,
+dacso_q009_weight_occs.pssm_cred,
+dacso_q009_weight_occs.current_region_pssm_code_rollup,
+dacso_q009_weight_occs.age_group_rollup,
+dacso_q009_weight_occs.lcp4_cd,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar) + ' - ' END ) + lcp4_cd + ' - ' + pssm_credential as lcip4_cred,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar) + ' - ' END )  + LEFT(lcp4_cd,2) + ' - ' + pssm_credential AS lcip2_cred,
+sum(dacso_q009_weight_occs.weighted)                        AS total
+INTO     dacso_q009b_weighted_occs_total_no_tt
+FROM     dacso_q009_weight_occs
+GROUP BY dacso_q009_weight_occs.pssm_credential,
+dacso_q009_weight_occs.pssm_cred,
+dacso_q009_weight_occs.current_region_pssm_code_rollup,
+dacso_q009_weight_occs.age_group_rollup,
+dacso_q009_weight_occs.lcp4_cd,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar) + ' - ' END ) + lcp4_cd + ' - ' + pssm_credential,
+(CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar) + ' - ' END ) + LEFT(lcp4_cd,2) + ' - ' + pssm_credential;"
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist ----
+DACSO_Q010_Weighted_Occs_Dist <-
+  "
+SELECT dacso_q009b_weighted_occs_total.pssm_credential,
+       dacso_q009b_weighted_occs_total.pssm_cred,
+       dacso_q009b_weighted_occs_total.current_region_pssm_code_rollup,
+       dacso_q009b_weighted_occs_total.age_group_rollup,
+       dacso_q009b_weighted_occs_total.lcp4_cd,
+       dacso_q009b_weighted_occs_total.ttrain,
+       dacso_q009b_weighted_occs_total.lcip4_cred,
+       dacso_q009b_weighted_occs_total.lcip2_cred,
+       dacso_q009b_weighted_occs.noc_cd,
+       dacso_q009b_weighted_occs.count,
+       dacso_q009b_weighted_occs_total.total,
+       count / total AS perc_Dist
+INTO DACSO_Q010_Weighted_Occs_Dist
+FROM   dacso_q009b_weighted_occs_total
+       LEFT JOIN dacso_q009b_weighted_occs
+              ON ( dacso_q009b_weighted_occs_total.age_group_rollup =
+                             dacso_q009b_weighted_occs.age_group_rollup )
+                 AND (
+       dacso_q009b_weighted_occs_total.current_region_pssm_code_rollup
+       =
+           dacso_q009b_weighted_occs.current_region_pssm_code_rollup )
+                 AND ( dacso_q009b_weighted_occs_total.lcip4_cred =
+                           dacso_q009b_weighted_occs.lcip4_cred ); "
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist_2D ----
+DACSO_Q010_Weighted_Occs_Dist_2D <-
+  "SELECT dacso_q009_weighted_occs_total_2d.pssm_credential,
+       dacso_q009_weighted_occs_total_2d.pssm_cred,
+       dacso_q009_weighted_occs_total_2d.current_region_pssm_code_rollup,
+       dacso_q009_weighted_occs_total_2d.age_group_rollup,
+       dacso_q009_weighted_occs_total_2d.lcp2_cd,
+       dacso_q009_weighted_occs_total_2d.ttrain,
+       dacso_q009_weighted_occs_total_2d.lcip2_cred,
+       dacso_q009_weighted_occs_2d.noc_cd,
+       dacso_q009_weighted_occs_2d.count,
+       dacso_q009_weighted_occs_total_2d.total,
+       count / total AS perc_Dist
+INTO DACSO_Q010_Weighted_Occs_Dist_2D
+FROM   dacso_q009_weighted_occs_total_2d
+       LEFT JOIN dacso_q009_weighted_occs_2d
+              ON ( dacso_q009_weighted_occs_total_2d.lcip2_cred =
+                             dacso_q009_weighted_occs_2d.lcip2_cred )
+                 AND (
+       dacso_q009_weighted_occs_total_2d.current_region_pssm_code_rollup =
+           dacso_q009_weighted_occs_2d.current_region_pssm_code_rollup )
+                 AND ( dacso_q009_weighted_occs_total_2d.age_group_rollup =
+                           dacso_q009_weighted_occs_2d.age_group_rollup ); "
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist_2D_BC ----
+DACSO_Q010_Weighted_Occs_Dist_2D_BC <-
+  "SELECT dacso_q009_weighted_occs_total_2d_bc.pssm_credential,
+       dacso_q009_weighted_occs_total_2d_bc.pssm_cred,
+       dacso_q009_weighted_occs_total_2d_bc.lcp2_cd,
+       dacso_q009_weighted_occs_total_2d_bc.ttrain,
+       dacso_q009_weighted_occs_total_2d_bc.lcip2_cred,
+       dacso_q009_weighted_occs_2d_bc.noc_cd,
+       dacso_q009_weighted_occs_2d_bc.count,
+       dacso_q009_weighted_occs_total_2d_bc.total,
+       count / total AS perc_Dist
+INTO DACSO_Q010_Weighted_Occs_Dist_2D_BC 
+FROM   dacso_q009_weighted_occs_total_2d_bc
+       LEFT JOIN dacso_q009_weighted_occs_2d_bc
+              ON dacso_q009_weighted_occs_total_2d_bc.lcip2_cred =
+                 dacso_q009_weighted_occs_2d_bc.lcip2_cred; "
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT ----
+DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT <-
+  "SELECT dacso_q009_weighted_occs_total_2d_bc_no_tt.pssm_credential,
+       dacso_q009_weighted_occs_total_2d_bc_no_tt.pssm_cred,
+       dacso_q009_weighted_occs_total_2d_bc_no_tt.lcp2_cd,
+       dacso_q009_weighted_occs_total_2d_bc_no_tt.lcip2_cred,
+       dacso_q009_weighted_occs_2d_bc_no_tt.noc_cd,
+       dacso_q009_weighted_occs_2d_bc_no_tt.count,
+       dacso_q009_weighted_occs_total_2d_bc_no_tt.total,
+       count / total AS perc_Dist
+INTO DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT
+FROM   dacso_q009_weighted_occs_total_2d_bc_no_tt
+       LEFT JOIN dacso_q009_weighted_occs_2d_bc_no_tt
+              ON dacso_q009_weighted_occs_total_2d_bc_no_tt.lcip2_cred =
+                 dacso_q009_weighted_occs_2d_bc_no_tt.lcip2_cred; "
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist_2D_No_TT ----
+DACSO_Q010_Weighted_Occs_Dist_2D_No_TT <-
+  "SELECT dacso_q009_weighted_occs_total_2d_no_tt.pssm_credential,
+       dacso_q009_weighted_occs_total_2d_no_tt.pssm_cred,
+       dacso_q009_weighted_occs_total_2d_no_tt.current_region_pssm_code_rollup,
+       dacso_q009_weighted_occs_total_2d_no_tt.age_group_rollup,
+       dacso_q009_weighted_occs_total_2d_no_tt.lcp2_cd,
+       dacso_q009_weighted_occs_total_2d_no_tt.lcip2_cred,
+       dacso_q009_weighted_occs_2d_no_tt.noc_cd,
+       dacso_q009_weighted_occs_2d_no_tt.count,
+       dacso_q009_weighted_occs_total_2d_no_tt.total,
+       count / total AS perc_Dist
+INTO   dacso_q010_weighted_occs_dist_2d_no_tt
+FROM   dacso_q009_weighted_occs_total_2d_no_tt
+       LEFT JOIN dacso_q009_weighted_occs_2d_no_tt
+              ON ( dacso_q009_weighted_occs_total_2d_no_tt.age_group_rollup =
+dacso_q009_weighted_occs_2d_no_tt.age_group_rollup )
+AND (
+dacso_q009_weighted_occs_total_2d_no_tt.current_region_pssm_code_rollup =
+dacso_q009_weighted_occs_2d_no_tt.current_region_pssm_code_rollup )
+AND ( dacso_q009_weighted_occs_total_2d_no_tt.lcip2_cred =
+dacso_q009_weighted_occs_2d_no_tt.lcip2_cred ); "
+
+
+# ---- DACSO_Q010_Weighted_Occs_Dist_No_TT ----
+DACSO_Q010_Weighted_Occs_Dist_No_TT <-
+  "SELECT dacso_q009b_weighted_occs_total_no_tt.pssm_credential,
+       dacso_q009b_weighted_occs_total_no_tt.pssm_cred,
+       dacso_q009b_weighted_occs_total_no_tt.current_region_pssm_code_rollup,
+       dacso_q009b_weighted_occs_total_no_tt.age_group_rollup,
+       dacso_q009b_weighted_occs_total_no_tt.lcp4_cd,
+       dacso_q009b_weighted_occs_total_no_tt.lcip4_cred,
+       dacso_q009b_weighted_occs_total_no_tt.lcip2_cred,
+       dacso_q009b_weighted_occs_no_tt.noc_cd,
+       dacso_q009b_weighted_occs_no_tt.count,
+       dacso_q009b_weighted_occs_total_no_tt.total,
+       count / total AS perc_Dist
+INTO DACSO_Q010_Weighted_Occs_Dist_No_TT
+FROM   dacso_q009b_weighted_occs_total_no_tt
+LEFT JOIN dacso_q009b_weighted_occs_no_tt
+  ON  (dacso_q009b_weighted_occs_total_no_tt.lcip4_cred = cast(dacso_q009b_weighted_occs_no_tt.lcip4_cred as nvarchar(20)))
+  AND (dacso_q009b_weighted_occs_total_no_tt.current_region_pssm_code_rollup = dacso_q009b_weighted_occs_no_tt.current_region_pssm_code_rollup )
+  AND (dacso_q009b_weighted_occs_total_no_tt.age_group_rollup = dacso_q009b_weighted_occs_no_tt.age_group_rollup ); "
+
+
+# ---- DACSO_Q010a0_Delete_Occupational_Distribution ----
+DACSO_Q010a0_Delete_Occupational_Distribution <-
+  "DELETE 
+FROM Occupation_Distributions
+WHERE (((Occupation_Distributions.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010a0_Delete_Occupational_Distribution_No_TT ----
+DACSO_Q010a0_Delete_Occupational_Distribution_No_TT <-
+  "DELETE 
+FROM Occupation_Distributions_No_TT
+WHERE (((Occupation_Distributions_No_TT.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010a0_Delete_Occupational_Distribution_No_TT_QI ----
+DACSO_Q010a0_Delete_Occupational_Distribution_No_TT_QI <-
+  "DELETE
+FROM Occupation_Distributions_No_TT_QI
+WHERE (((Occupation_Distributions_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_No_TT_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010a0_Delete_Occupational_Distribution_QI ----
+DACSO_Q010a0_Delete_Occupational_Distribution_QI <-
+  "DELETE 
+FROM Occupation_Distributions_QI
+WHERE (((Occupation_Distributions_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010a1_Append_Occupational_Distribution ----
+DACSO_Q010a1_Append_Occupational_Distribution <-
+  "INSERT INTO Occupation_Distributions (Survey, PSSM_Credential, PSSM_CRED, 
+  Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, LCIP2_CRED, NOC, [Count], Total, [Percent])
+SELECT 'Student Outcomes' AS Survey, 
+DACSO_Q010_Weighted_Occs_Dist.PSSM_Credential, 
+DACSO_Q010_Weighted_Occs_Dist.PSSM_CRED, 
+DACSO_Q010_Weighted_Occs_Dist.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010_Weighted_Occs_Dist.Age_Group_Rollup, 
+DACSO_Q010_Weighted_Occs_Dist.LCP4_CD, 
+DACSO_Q010_Weighted_Occs_Dist.TTRAIN, 
+DACSO_Q010_Weighted_Occs_Dist.LCIP4_CRED, 
+DACSO_Q010_Weighted_Occs_Dist.LCIP2_CRED, 
+DACSO_Q010_Weighted_Occs_Dist.NOC_CD, 
+DACSO_Q010_Weighted_Occs_Dist.Count, 
+DACSO_Q010_Weighted_Occs_Dist.Total, 
+DACSO_Q010_Weighted_Occs_Dist.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist;"
+
+
+# ---- DACSO_Q010a1_Append_Occupational_Distribution_No_TT ----
+DACSO_Q010a1_Append_Occupational_Distribution_No_TT <-
+  "INSERT INTO Occupation_Distributions_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
+Age_Group_Rollup, LCP4_CD, LCIP4_CRED, LCIP2_CRED, NOC, [Count], Total, [Percent])
+SELECT 'Student Outcomes' AS Survey, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.PSSM_Credential, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.PSSM_CRED, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.Age_Group_Rollup, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.LCP4_CD, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.LCIP4_CRED, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.LCIP2_CRED, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.NOC_CD, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.Count, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.Total, 
+DACSO_Q010_Weighted_Occs_Dist_No_TT.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist_No_TT;"
+
+
+# ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2 ----
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2 <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2
+WHERE (((Occupation_Distributions_LCP2.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT ----
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_No_TT
+WHERE (((Occupation_Distributions_LCP2_No_TT.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT_QI ----
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT_QI <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_No_TT_QI
+WHERE (((Occupation_Distributions_LCP2_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_No_TT_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_QI ----
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_QI <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_QI
+WHERE (((Occupation_Distributions_LCP2_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010b1_Append_Occupational_Distribution_LCP2 ----
+DACSO_Q010b1_Append_Occupational_Distribution_LCP2 <-
+  "INSERT INTO Occupation_Distributions_LCP2 ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D.Age_Group_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D.TTRAIN, DACSO_Q010_Weighted_Occs_Dist_2D.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D.Count, DACSO_Q010_Weighted_Occs_Dist_2D.Total, DACSO_Q010_Weighted_Occs_Dist_2D.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist_2D;"
+
+
+# ---- DACSO_Q010b1_Append_Occupational_Distribution_LCP2_No_TT ----
+DACSO_Q010b1_Append_Occupational_Distribution_LCP2_No_TT <-
+  "INSERT INTO Occupation_Distributions_LCP2_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Age_Group_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Count, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Total, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist_2D_No_TT;"
+
+
+# ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC ----
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_BC
+WHERE (((Occupation_Distributions_LCP2_BC.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT ----
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_BC_No_TT
+WHERE (((Occupation_Distributions_LCP2_BC_No_TT.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT_QI ----
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT_QI <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_BC_No_TT_QI
+WHERE (((Occupation_Distributions_LCP2_BC_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_BC_No_TT_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_QI ----
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_QI <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_BC_QI
+WHERE (((Occupation_Distributions_LCP2_BC_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_BC_QI.Survey)='PTIB'));"
+
+
+# ---- DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC ----
+DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC <-
+  "INSERT INTO Occupation_Distributions_LCP2_BC ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_BC.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_BC.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC.TTRAIN, DACSO_Q010_Weighted_Occs_Dist_2D_BC.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC.Count, DACSO_Q010_Weighted_Occs_Dist_2D_BC.Total, DACSO_Q010_Weighted_Occs_Dist_2D_BC.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist_2D_BC;"
+
+
+# ---- DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC_No_TT ----
+DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC_No_TT <-
+  "INSERT INTO Occupation_Distributions_LCP2_BC_No_TT ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.Count, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.Total, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.perc_Dist
+FROM DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT;"
+
+# ---- Q010d1 - DACSO_Q010e PDEG Law Modifications ----
+
+# ---- DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply ----
+DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply <-
+  "DELETE 
+FROM Labour_Supply_Distribution
+WHERE (((Labour_Supply_Distribution.Survey)='2021 Census PSSM 2023-2024') 
+AND   ((Labour_Supply_Distribution.PSSM_Credential)='PDEG') 
+AND   ((Labour_Supply_Distribution.LCP4_CD)='07'));"
+
+
+# ---- DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply_QI ----
+DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply_QI <-
+  "DELETE 
+FROM Labour_Supply_Distribution_QI
+WHERE (((Labour_Supply_Distribution_QI.Survey)='2021 Census PSSM 2023-2024') 
+AND ((Labour_Supply_Distribution_QI.PSSM_Credential)='PDEG') 
+AND ((Labour_Supply_Distribution_QI.LCP4_CD)='07'));"
+
+
+# ---- DACSO_Q010d2_NLS_PDEG_07_Count ----
+DACSO_Q010d2_NLS_PDEG_07_Count <-
+  "SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
+Labour_Supply_Distribution.Current_Region_PSSM_Code_Rollup, Labour_Supply_Distribution.Age_Group_Rollup, Sum(Labour_Supply_Distribution.Count) AS Count
+INTO DACSO_Q010d2_NLS_PDEG_07_Count
+FROM Labour_Supply_Distribution
+WHERE (((Left(LCP4_CD,2))=22) AND ((Labour_Supply_Distribution.PSSM_Credential)='BACH'))
+GROUP BY Labour_Supply_Distribution.Survey, Labour_Supply_Distribution.TTRAIN, Labour_Supply_Distribution.Current_Region_PSSM_Code_Rollup, Labour_Supply_Distribution.Age_Group_Rollup
+HAVING (((Labour_Supply_Distribution.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010d3_NLS_PDEG_07_Subtotal ----
+DACSO_Q010d3_NLS_PDEG_07_Subtotal <-
+  "SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
+Labour_Supply_Distribution.Age_Group_Rollup, Labour_Supply_Distribution.Total AS Subtotal
+INTO DACSO_Q010d3_NLS_PDEG_07_Subtotal
+FROM Labour_Supply_Distribution
+WHERE (((Left(LCP4_CD,2))=22) AND ((Labour_Supply_Distribution.PSSM_Credential)='BACH'))
+GROUP BY Labour_Supply_Distribution.Survey, Labour_Supply_Distribution.TTRAIN, Labour_Supply_Distribution.Age_Group_Rollup, Labour_Supply_Distribution.Total
+HAVING (((Labour_Supply_Distribution.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010d4_NLS_PDEG_07_Total ----
+DACSO_Q010d4_NLS_PDEG_07_Total <-
+  "SELECT DACSO_Q010d3_NLS_PDEG_07_Subtotal.Survey, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_Credential, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_CRED, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCP4_CD, DACSO_Q010d3_NLS_PDEG_07_Subtotal.TTRAIN, DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCIP4_CRED, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal.Age_Group_Rollup, Sum(DACSO_Q010d3_NLS_PDEG_07_Subtotal.Subtotal) AS Total
+INTO DACSO_Q010d4_NLS_PDEG_07_Total
+FROM DACSO_Q010d3_NLS_PDEG_07_Subtotal
+GROUP BY DACSO_Q010d3_NLS_PDEG_07_Subtotal.Survey, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_Credential, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_CRED, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCP4_CD, DACSO_Q010d3_NLS_PDEG_07_Subtotal.TTRAIN, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCIP4_CRED, DACSO_Q010d3_NLS_PDEG_07_Subtotal.Age_Group_Rollup;"
+
+
+# ---- DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply ----
+DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply <-
+  "SELECT DACSO_Q010d4_NLS_PDEG_07_Total.Survey, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_Credential, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_CRED, 
+DACSO_Q010d2_NLS_PDEG_07_Count.Current_Region_PSSM_Code_Rollup, DACSO_Q010d2_NLS_PDEG_07_Count.Age_Group_Rollup, DACSO_Q010d2_NLS_PDEG_07_Count.LCP4_CD, 
+DACSO_Q010d4_NLS_PDEG_07_Total.TTRAIN, DACSO_Q010d4_NLS_PDEG_07_Total.LCIP4_CRED, DACSO_Q010d2_NLS_PDEG_07_Count.Count, DACSO_Q010d4_NLS_PDEG_07_Total.Total, 
+ISNULL(Count,0)/Total AS perc
+INTO DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply
+FROM DACSO_Q010d4_NLS_PDEG_07_Total 
+LEFT JOIN DACSO_Q010d2_NLS_PDEG_07_Count ON (DACSO_Q010d4_NLS_PDEG_07_Total.LCIP4_CRED = DACSO_Q010d2_NLS_PDEG_07_Count.LCIP4_CRED) 
+AND (DACSO_Q010d4_NLS_PDEG_07_Total.Age_Group_Rollup = DACSO_Q010d2_NLS_PDEG_07_Count.Age_Group_Rollup) 
+AND (DACSO_Q010d4_NLS_PDEG_07_Total.Survey = DACSO_Q010d2_NLS_PDEG_07_Count.Survey)
+WHERE (((DACSO_Q010d2_NLS_PDEG_07_Count.Current_Region_PSSM_Code_Rollup) Is Not Null));"
+
+
+# ---- DACSO_Q010d6_Append_NLS_PDEG_07_New_Labour_Supply ----
+DACSO_Q010d6_Append_NLS_PDEG_07_New_Labour_Supply <-
+  "INSERT INTO Labour_Supply_Distribution ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, Count, Total, New_Labour_Supply )
+SELECT DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Survey, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.PSSM_Credential, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.PSSM_CRED, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Age_Group_Rollup, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.LCP4_CD, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.TTRAIN, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.LCIP4_CRED, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Count, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Total, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.perc
+FROM DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply;"
+
+
+# ---- DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist ----
+DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist <-
+  "DELETE  
+FROM Occupation_Distributions
+WHERE (((Occupation_Distributions.Survey)='2021 Census PSSM 2022-2023') 
+AND ((Occupation_Distributions.PSSM_Credential)='PDEG') AND ((Occupation_Distributions.LCP4_CD)='07'));"
+
+
+# ---- DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist_QI ----
+DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist_QI <-
+  "DELETE  
+FROM Occupation_Distributions_QI
+WHERE (((Occupation_Distributions_QI.Survey)='2021 Census PSSM 2022-2023') 
+AND ((Occupation_Distributions_QI.PSSM_Credential)='PDEG') AND ((Occupation_Distributions_QI.LCP4_CD)='07'));"
+
+
+# ---- DACSO_Q010e2_Weighted_Occs_PDEG_07 ----
+DACSO_Q010e2_Weighted_Occs_PDEG_07 <-
+  "SELECT Occupation_Distributions.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Occupation_Distributions.TTRAIN, '07 - PDEG' AS LCIP4_CRED, Occupation_Distributions.Current_Region_PSSM_Code_Rollup, Occupation_Distributions.Age_Group_Rollup, Occupation_Distributions.NOC, Sum(Occupation_Distributions.Count) AS Count
+INTO DACSO_Q010e2_Weighted_Occs_PDEG_07
+FROM Occupation_Distributions
+WHERE (((Left(LCP4_CD,2))=22) AND ((Occupation_Distributions.PSSM_Credential)='BACH'))
+GROUP BY Occupation_Distributions.Survey, Occupation_Distributions.TTRAIN, Occupation_Distributions.Current_Region_PSSM_Code_Rollup, 
+Occupation_Distributions.Age_Group_Rollup, Occupation_Distributions.NOC
+HAVING (((Occupation_Distributions.Survey)='Student Outcomes'));"
+
+
+# ---- DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 ----
+DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 <-
+  "SELECT DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey, DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_Credential, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_CRED, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.Age_Group_Rollup, DACSO_Q010e2_Weighted_Occs_PDEG_07.LCP4_CD, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.TTRAIN, DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED, 
+Sum(DACSO_Q010e2_Weighted_Occs_PDEG_07.Count) AS Total
+INTO DACSO_Q010e3_Weighted_Occs_Total_PDEG_07
+FROM DACSO_Q010e2_Weighted_Occs_PDEG_07
+GROUP BY DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey, DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_Credential, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_CRED, DACSO_Q010e2_Weighted_Occs_PDEG_07.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.Age_Group_Rollup, DACSO_Q010e2_Weighted_Occs_PDEG_07.LCP4_CD, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.TTRAIN, DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED
+ORDER BY DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED;"
+
+
+# ---- DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07 ----
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07 <-
+  "SELECT DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Survey, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.PSSM_Credential, 
+DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.PSSM_CRED, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Age_Group_Rollup, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCP4_CD, 
+DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.TTRAIN, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCIP4_CRED, DACSO_Q010e2_Weighted_Occs_PDEG_07.NOC, 
+DACSO_Q010e2_Weighted_Occs_PDEG_07.Count, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Total, Count/Total AS perc_Dist
+INTO DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07
+FROM DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 LEFT JOIN DACSO_Q010e2_Weighted_Occs_PDEG_07 ON (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Survey = DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Current_Region_PSSM_Code_Rollup = DACSO_Q010e2_Weighted_Occs_PDEG_07.Current_Region_PSSM_Code_Rollup) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Age_Group_Rollup = DACSO_Q010e2_Weighted_Occs_PDEG_07.Age_Group_Rollup) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCIP4_CRED = DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED);"
+
+
+# ---- DACSO_Q010e5_Append_Occupational_Distribution_PDEG_07 ----
+DACSO_Q010e5_Append_Occupational_Distribution_PDEG_07 <-
+  "INSERT INTO Occupation_Distributions ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
+Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, NOC, Count, Total, [Percent])
+SELECT DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Survey, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.PSSM_Credential, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.PSSM_CRED, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Age_Group_Rollup, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.LCP4_CD, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.TTRAIN, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.LCIP4_CRED, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.NOC, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Count, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Total, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.perc_Dist
+FROM DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07;"
+
+
+# ---- DACSO_Q99A_ENDDT_IMPUTED ----
+DACSO_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-2) + '-12'
+WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='DACSO'));"
+
+#DACSO_Q99A_ENDDT - NOT USED <-
+#"UPDATE (INFOWARE_SURV_COHORT_COLLECTION_INFO INNER JOIN DACSO_Q99A_STQUI_ID ON INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_STQU_ID = DACSO_Q99A_STQUI_ID.COCI_STQU_ID) INNER JOIN T_Cohorts_Recoded ON DACSO_Q99A_STQUI_ID.STQU_ID_Only=T_Cohorts_Recoded.STQU_ID SET T_Cohorts_Recoded.ENDDT = INFOWARE_SURV_COHORT_COLLECTION_INFO.COSC_ENRL_END_DATE
+#WHERE (((T_Cohorts_Recoded.Survey)='DACSO'));"
+
+#DACSO_Q99A_STQUI_ID - NOT USED <-
+#"SELECT T_Cohorts_Recoded.STQU_ID AS Survey_STQU_ID, T_Cohorts_Recoded.Survey, CDbl(Right(STQU_ID,Len(STQU_ID)-InStr(1,STQU_ID,"-")-1)) AS STQU_ID_Only
+#FROM T_Cohorts_Recoded;"
+
+# ---- DACSO_qry99_Suppression_Public_Release_NOC ----
+DACSO_qry99_Suppression_Public_Release_NOC <-
+  "SELECT T_Cohorts_Recoded.Age_Group_Rollup, 
+tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
+T_Cohorts_Recoded.NOC_CD, 
+Count(*) AS Expr1 INTO T_Suppression_Public_Release_NOC
+FROM T_Cohorts_Recoded 
+INNER JOIN tbl_Age_Groups_Rollup ON T_Cohorts_Recoded.Age_Group_Rollup = tbl_Age_Groups_Rollup.Age_Group_Rollup
+WHERE (((T_Cohorts_Recoded.Weight)>0))
+GROUP BY T_Cohorts_Recoded.Age_Group_Rollup, tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, T_Cohorts_Recoded.NOC_CD
+HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((Count(*))<5))
+ORDER BY Count(*);"
+
+
+###############################################################################################
+
+# ---- Q005 - Q007 New labour supply ----
+DACSO_Q99A_STQUI_ID <- "
+SELECT STQU_ID AS Survey_STQU_ID, 
+       Survey, 
+       Right(STQU_ID,LEN(STQU_ID)-CHARINDEX('-',STQU_ID)-1) AS STQU_ID_Only
+INTO   DACSO_Q99A_STQUI_ID
+FROM   T_Cohorts_Recoded;"
+
+DACSO_Q005_DACSO_DATA_Part_1b4_Check_NOC_Valid <- "
+SELECT    dacso_q99a_stqui_id.stqu_id_only,
+          t_cohorts_recoded.stqu_id,
+          t_cohorts_recoded.survey,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.noc_cd,
+          T_NOC_Broad_Categories.unit_group_code
+FROM      (t_cohorts_recoded
+  LEFT JOIN T_NOC_Broad_Categories
+    ON t_cohorts_recoded.noc_cd =  T_NOC_Broad_Categories.unit_group_code)
+  INNER JOIN dacso_q99a_stqui_id
+   ON t_cohorts_recoded.stqu_id = dacso_q99a_stqui_id.survey_stqu_id
+WHERE     t_cohorts_recoded.age_group_rollup IS NOT NULL
+  AND     t_cohorts_recoded.current_region_pssm_code <>- 1
+GROUP  BY dacso_q99a_stqui_id.stqu_id_only,
+          t_cohorts_recoded.stqu_id,
+          t_cohorts_recoded.survey,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.noc_cd,
+          T_NOC_Broad_Categories.unit_group_code
+HAVING    t_cohorts_recoded.survey_year IN ('2019','2020','2021','2022','2023') 
+  AND     t_cohorts_recoded.noc_cd IS NOT NULL
+  AND     t_cohorts_recoded.noc_cd <> ''
+  AND     T_NOC_Broad_Categories.unit_group_code IS NULL;"
+
+
+DACSO_Q005_DACSO_Data_Part_1b7_Update_After_Recoding <- "
+UPDATE t_dacso_data_part_1
+INNER JOIN t_dacso_noc_recoding
+ON t_dacso_data_part_1.coci_stqu_id = t_dacso_noc_recoding.stqu_id_only
+SET    t_dacso_data_part_1.labr_occupation_lnoc_cd = t_dacso_noc_recoding.noc_cd;"
+
+DACSO_Q005_DACSO_Data_Part_1b8_Update_After_Recoding <- "
+UPDATE t_bgs_data_final
+INNER JOIN bgs_noc_recoded_imputed
+ON t_bgs_data_final.stqu_id = bgs_noc_recoded_imputed.stqu_id
+SET    t_bgs_data_final.noc_cd_2016 = bgs_noc_recoded_imputed.noc;"
+
+
+DACSO_Q005_DACSO_DATA_Part_1c_NLS1 <- "
+SELECT  t_cohorts_recoded.survey,
+        t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+        t_cohorts_recoded.age_group_rollup,
+        t_cohorts_recoded.inst_cd,
+        t_cohorts_recoded.lcip4_cred,
+        t_cohorts_recoded.grad_status,
+        t_cohorts_recoded.new_labour_supply,
+        Count(*) AS Base
+INTO    DACSO_Q005_DACSO_DATA_Part_1c_NLS1
+FROM    t_cohorts_recoded
+        INNER JOIN (t_current_region_pssm_codes
+                INNER JOIN t_current_region_pssm_rollup_codes
+                ON t_current_region_pssm_codes.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+        ON t_cohorts_recoded.current_region_pssm_code = t_current_region_pssm_codes.current_region_pssm_code
+WHERE   CAST(t_cohorts_recoded.weight AS FLOAT) > 0
+  AND   t_cohorts_recoded.noc_cd IS NOT NULL
+GROUP BY t_cohorts_recoded.survey,
+        t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+        t_cohorts_recoded.age_group_rollup,
+        t_cohorts_recoded.inst_cd,
+        t_cohorts_recoded.lcip4_cred,
+        t_cohorts_recoded.grad_status,
+        t_cohorts_recoded.new_labour_supply
+HAVING  t_cohorts_recoded.age_group_rollup IS NOT NULL
+  AND   Count(*) > 0
+  AND  (t_cohorts_recoded.grad_status = '1' OR t_cohorts_recoded.grad_status = '3' )
+  AND  CAST(t_cohorts_recoded.new_labour_supply AS FLOAT) = 1;"
+
+DACSO_Q005_DACSO_DATA_Part_1c_NLS2 <- "
+SELECT t_cohorts_recoded.survey,
+       t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.lcip4_cred,
+       t_cohorts_recoded.grad_status,
+       t_cohorts_recoded.new_labour_supply,
+       t_cohorts_recoded.stqu_id
+INTO   DACSO_Q005_DACSO_DATA_Part_1c_NLS2
+FROM   t_cohorts_recoded
+       INNER JOIN (t_current_region_pssm_codes
+            INNER JOIN t_current_region_pssm_rollup_codes
+            ON t_current_region_pssm_codes.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+       ON t_cohorts_recoded.current_region_pssm_code = t_current_region_pssm_codes.current_region_pssm_code
+WHERE  CAST(t_cohorts_recoded.weight AS FLOAT) > 0
+GROUP BY t_cohorts_recoded.survey,
+       t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.lcip4_cred,
+       t_cohorts_recoded.grad_status,
+       t_cohorts_recoded.new_labour_supply,
+       t_cohorts_recoded.stqu_id
+HAVING t_cohorts_recoded.age_group_rollup IS NOT NULL
+  AND  (t_cohorts_recoded.grad_status = '1' OR t_cohorts_recoded.grad_status = '3')
+  AND  CAST(t_cohorts_recoded.new_labour_supply AS FLOAT) = 2;"
+
+DACSO_Q005_DACSO_DATA_Part_1c_NLS2_Recode <- "
+UPDATE t_cohorts_recoded 
+SET t_cohorts_recoded.new_labour_supply = 3 
+WHERE t_cohorts_recoded.STQU_ID IN (
+SELECT t_cohorts_recoded.STQU_ID 
+FROM      dacso_q005_dacso_data_part_1c_nls2
+INNER JOIN t_cohorts_recoded
+ON        dacso_q005_dacso_data_part_1c_nls2.stqu_id = t_cohorts_recoded.stqu_id
+LEFT JOIN dacso_q005_dacso_data_part_1c_nls1
+ON        dacso_q005_dacso_data_part_1c_nls2.lcip4_cred = dacso_q005_dacso_data_part_1c_nls1.lcip4_cred
+  AND     dacso_q005_dacso_data_part_1c_nls2.inst_cd = dacso_q005_dacso_data_part_1c_nls1.inst_cd
+  AND     dacso_q005_dacso_data_part_1c_nls2.age_group_rollup = dacso_q005_dacso_data_part_1c_nls1.age_group_rollup
+  AND     dacso_q005_dacso_data_part_1c_nls2.current_region_pssm_code_rollup = dacso_q005_dacso_data_part_1c_nls1.current_region_pssm_code_rollup
+  AND     dacso_q005_dacso_data_part_1c_nls2.survey = dacso_q005_dacso_data_part_1c_nls1.survey
+WHERE     dacso_q005_dacso_data_part_1c_nls1.survey IS NULL
+  AND     dacso_q005_dacso_data_part_1c_nls1.current_region_pssm_code_rollup IS NULL
+  AND     dacso_q005_dacso_data_part_1c_nls1.age_group_rollup IS NULL
+  AND     dacso_q005_dacso_data_part_1c_nls1.inst_cd IS NULL
+  AND     dacso_q005_dacso_data_part_1c_nls1.lcip4_cred IS NULL);"
+
+DACSO_Q005_Z_Cohort_Resp_by_Region <- "
+SELECT      T_Cohorts_Recoded.Survey, 
+            T_Cohorts_Recoded.Survey_Year,
+            T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, 
+            T_Current_Region_PSSM_Codes.Current_Region_PSSM_Name, 
+            T_Cohorts_Recoded.Age_Group_Rollup,
+            Count(*) as N
+FROM        T_Cohorts_Recoded 
+INNER JOIN  T_Current_Region_PSSM_Codes 
+ON          T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE = T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code
+WHERE       T_Cohorts_Recoded.Age_Group_Rollup Is Not Null
+AND         T_Cohorts_Recoded.Respondent='1'
+AND         T_Cohorts_Recoded.Weight > 0
+GROUP BY    T_Cohorts_Recoded.Survey, 
+            T_Cohorts_Recoded.Survey_Year,
+            T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, 
+            T_Current_Region_PSSM_Codes.Current_Region_PSSM_Name, 
+            T_Cohorts_Recoded.Age_Group_Rollup
+ORDER BY    T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.Survey_Year,
+            T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code;"
+
+DACSO_Q005_Z01_Base_NLS <-
+  "SELECT t_cohorts_recoded.survey,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       Count(*) AS Base,
+       t_cohorts_recoded.stqu_id
+INTO DACSO_Q005_Z01_Base_NLS
+FROM   t_cohorts_recoded
+WHERE  ( ( ( t_cohorts_recoded.new_labour_supply ) = 0
+            OR ( t_cohorts_recoded.new_labour_supply ) = 1
+            OR ( t_cohorts_recoded.new_labour_supply ) = 2
+            OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.survey,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.stqu_id,
+          t_cohorts_recoded.grad_status
+HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+         AND ( ( t_cohorts_recoded.grad_status ) = '1'
+                OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
+
+DACSO_Q005_Z02a_Base <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Count(*) AS Count, Count(*) AS Base
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
+GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
+HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
+
+DACSO_Q005_Z02b_Respondents <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1' And Current_Region_PSSM_Code<>-1,1,0)) AS Respondents
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
+GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
+HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
+
+DACSO_Q005_Z02b_Respondents_Region_9999 <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1',1,0)) AS Respondents
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)=-1) AND ((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
+GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
+HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
+
+#DACSO_Q005_Z02b_Respondents_Region_9999=100% <-
+#"SELECT DACSO_Q005_Z02a_Base.Survey, DACSO_Q005_Z02a_Base.INST_CD, DACSO_Q005_Z02a_Base.Age_Group_Rollup, DACSO_Q005_Z02a_Base.GRAD_STATUS, DACSO_Q005_Z02a_Base.TTRAIN, DACSO_Q005_Z02a_Base.LCIP4_CRED, DACSO_Q005_Z02a_Base.Count, DACSO_Q005_Z02a_Base.Base, DACSO_Q005_Z02b_Respondents_Region_9999.Respondents, Respondents/Count AS Expr1
+#FROM DACSO_Q005_Z02a_Base INNER JOIN DACSO_Q005_Z02b_Respondents_Region_9999 ON (DACSO_Q005_Z02a_Base.Survey = DACSO_Q005_Z02b_Respondents_Region_9999.Survey) AND (DACSO_Q005_Z02a_Base.INST_CD = DACSO_Q005_Z02b_Respondents_Region_9999.INST_CD) AND (DACSO_Q005_Z02a_Base.Age_Group_Rollup = DACSO_Q005_Z02b_Respondents_Region_9999.Age_Group_Rollup) AND (DACSO_Q005_Z02a_Base.GRAD_STATUS = DACSO_Q005_Z02b_Respondents_Region_9999.GRAD_STATUS) AND (DACSO_Q005_Z02a_Base.LCIP4_CRED = DACSO_Q005_Z02b_Respondents_Region_9999.LCIP4_CRED)
+#WHERE (((Respondents/Count)=1));"
+
+DACSO_Q005_Z02b_Respondents_Union <-
+  "SELECT DACSO_Q005_Z02b_Respondents.Survey, DACSO_Q005_Z02b_Respondents.INST_CD, DACSO_Q005_Z02b_Respondents.Age_Group_Rollup, DACSO_Q005_Z02b_Respondents.GRAD_STATUS, DACSO_Q005_Z02b_Respondents.TTRAIN, DACSO_Q005_Z02b_Respondents.LCIP4_CRED, DACSO_Q005_Z02b_Respondents.Respondents
+FROM DACSO_Q005_Z02b_Respondents
+UNION ALL SELECT DACSO_Q005_Z02b_Respondents_Region_9999=100%.Survey, DACSO_Q005_Z02b_Respondents_Region_9999=100%.INST_CD, DACSO_Q005_Z02b_Respondents_Region_9999=100%.Age_Group_Rollup, DACSO_Q005_Z02b_Respondents_Region_9999=100%.GRAD_STATUS, DACSO_Q005_Z02b_Respondents_Region_9999=100%.TTRAIN, DACSO_Q005_Z02b_Respondents_Region_9999=100%.LCIP4_CRED, DACSO_Q005_Z02b_Respondents_Region_9999=100%.Respondents
+FROM DACSO_Q005_Z02b_Respondents_Region_9999=100%;"
+
+DACSO_Q005_Z02c_Weight_tmp <-
+  "SELECT t_cohorts_recoded.survey,
+       t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.grad_status,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       Count(*) AS Count,
+       Sum(CASE WHEN respondent = '1' AND current_region_pssm_code <>- 1 THEN 1 ELSE 0 END) AS Respondents,
+       t_cohorts_recoded.weight AS weight_year
+INTO DACSO_Q005_Z02c_Weight_tmp
+FROM   t_cohorts_recoded
+WHERE  ( ( ( t_cohorts_recoded.new_labour_supply ) = 0
+            OR ( t_cohorts_recoded.new_labour_supply ) = 1
+            OR ( t_cohorts_recoded.new_labour_supply ) = 2
+            OR ( t_cohorts_recoded.new_labour_supply ) = 3 )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.survey,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.grad_status,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.weight
+HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
+         AND ( ( t_cohorts_recoded.grad_status ) = '1'
+                OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
+
+DACSO_Q005_Z02c_Weight <- "
+SELECT *, 
+    Weight_Prob * Weight_Year AS Weight, 
+    Respondents * Weight_Prob * Weight_Year AS Weighted
+INTO DACSO_Q005_Z02c_Weight
+FROM
+  (SELECT *, CASE WHEN (Respondents = 0) THEN 1 ELSE cast(Count as float)/cast(Respondents as float) END AS Weight_Prob
+  FROM  DACSO_Q005_Z02c_Weight_tmp) T;"
+
+DACSO_Q005_Z03_Weight_Total <-
+  "SELECT dacso_q005_z02c_weight.survey,
+       dacso_q005_z02c_weight.inst_cd,
+       dacso_q005_z02c_weight.age_group_rollup,
+       dacso_q005_z02c_weight.grad_status,
+       dacso_q005_z02c_weight.ttrain,
+       dacso_q005_z02c_weight.lcip4_cred,
+       Sum(dacso_q005_z02c_weight.count)    AS Base,
+       Sum(dacso_q005_z02c_weight.weighted) AS Weighted
+INTO DACSO_Q005_Z03_Weight_Total
+FROM   dacso_q005_z02c_weight
+GROUP  BY dacso_q005_z02c_weight.survey,
+          dacso_q005_z02c_weight.inst_cd,
+          dacso_q005_z02c_weight.age_group_rollup,
+          dacso_q005_z02c_weight.grad_status,
+          dacso_q005_z02c_weight.ttrain,
+          dacso_q005_z02c_weight.lcip4_cred;"
+
+DACSO_Q005_Z04_Weight_Adj_Fac <-
+  "SELECT dacso_q005_z03_weight_total.survey,
+       dacso_q005_z03_weight_total.inst_cd,
+       dacso_q005_z03_weight_total.age_group_rollup,
+       dacso_q005_z03_weight_total.grad_status,
+       dacso_q005_z03_weight_total.ttrain,
+       dacso_q005_z03_weight_total.lcip4_cred,
+       dacso_q005_z03_weight_total.base,
+       dacso_q005_z03_weight_total.weighted,
+       CASE WHEN weighted = 0 THEN 0 ELSE (base / weighted) END AS Weight_Adj_Fac
+INTO DACSO_Q005_Z04_Weight_Adj_Fac
+FROM   dacso_q005_z03_weight_total;"
+
+DACSO_Q005_Z05_Weight_NLS <- "
+SELECT dacso_q005_z02c_weight.survey,
+       dacso_q005_z02c_weight.survey_year,
+       dacso_q005_z02c_weight.inst_cd,
+       dacso_q005_z02c_weight.age_group_rollup,
+       dacso_q005_z02c_weight.grad_status,
+       dacso_q005_z02c_weight.ttrain,
+       dacso_q005_z02c_weight.lcip4_cred,
+       dacso_q005_z02c_weight.count,
+       dacso_q005_z02c_weight.respondents,
+       dacso_q005_z02c_weight.weight_prob,
+       dacso_q005_z02c_weight.weight_year,
+       dacso_q005_z02c_weight.weight,
+       dacso_q005_z02c_weight.weighted,
+       dacso_q005_z04_weight_adj_fac.weight_adj_fac,
+       weight * weight_adj_fac AS Weight_NLS
+INTO   tmp_tbl_weights_nls
+FROM   dacso_q005_z02c_weight
+       INNER JOIN dacso_q005_z04_weight_adj_fac
+               ON ( dacso_q005_z02c_weight.lcip4_cred = dacso_q005_z04_weight_adj_fac.lcip4_cred )
+                  AND ( dacso_q005_z02c_weight.grad_status = dacso_q005_z04_weight_adj_fac.grad_status )
+                  AND ( dacso_q005_z02c_weight.survey = dacso_q005_z04_weight_adj_fac.survey )
+                  AND ( dacso_q005_z02c_weight.inst_cd = dacso_q005_z04_weight_adj_fac.inst_cd )
+                  AND ( dacso_q005_z02c_weight.age_group_rollup = dacso_q005_z04_weight_adj_fac.age_group_rollup );"
+
+DACSO_Q005_Z06_Add_Weight_NLS_Field <-
+  "ALTER TABLE T_Cohorts_Recoded ADD Weight_NLS Float NULL;"
+
+DACSO_Q005_Z07_Weight_NLS_Null <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_NLS = Null;"
+
+DACSO_Q005_Z08_Weight_NLS_Update <- "
+UPDATE t_cohorts_recoded
+SET    t_cohorts_recoded.weight_nls = tmp_tbl_Weights_NLS.weight_nls
+FROM   tmp_tbl_Weights_NLS
+INNER JOIN (t_cohorts_recoded
+  INNER JOIN dacso_q005_z01_base_nls
+  ON t_cohorts_recoded.stqu_id = dacso_q005_z01_base_nls.stqu_id)
+ON   tmp_tbl_Weights_NLS.lcip4_cred = t_cohorts_recoded.lcip4_cred
+AND tmp_tbl_Weights_NLS.grad_status =  t_cohorts_recoded.grad_status
+AND tmp_tbl_Weights_NLS.age_group_rollup =  t_cohorts_recoded.age_group_rollup
+AND tmp_tbl_Weights_NLS.inst_cd =  t_cohorts_recoded.inst_cd
+AND tmp_tbl_Weights_NLS.survey_year = t_cohorts_recoded.survey_year
+AND tmp_tbl_Weights_NLS.survey = t_cohorts_recoded.survey
+WHERE  t_cohorts_recoded.current_region_pssm_code <>- 1;"
+
+DACSO_Q005_Z09_Check_Weights <- "
+SELECT t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.grad_status,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       Sum(CASE WHEN respondent = '1' AND current_region_pssm_code <>- 1 THEN 1 ELSE 0 END) AS Respondents,
+       t_cohorts_recoded.weight_nls,
+       Sum(CASE WHEN respondent = '1' AND current_region_pssm_code <>- 1 THEN 1 ELSE 0 END) * cast(weight_nls as float) AS Weighted,
+       Sum(dacso_q005_z01_base_nls.base) AS Base
+FROM   t_cohorts_recoded
+INNER JOIN dacso_q005_z01_base_nls
+   ON t_cohorts_recoded.stqu_id = dacso_q005_z01_base_nls.stqu_id
+GROUP  BY t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.grad_status,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.weight_nls
+ORDER  BY t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.weight_nls;"
+
+DACSO_Q005_Z09_Check_Weights_No_Weight_CIP <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, 
+T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Count(*) AS Base
+FROM T_Cohorts_Recoded
+WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0) AND ((T_Cohorts_Recoded.Weight_NLS)=0 Or (T_Cohorts_Recoded.Weight_NLS) Is Null) AND ((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)<>-1))
+GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, T_Cohorts_Recoded.GRAD_STATUS
+HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='2' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
+
+DACSO_Q006a_Weight_New_Labour_Supply <-
+  "SELECT t_cohorts_recoded.pssm_credential,
+       t_cohorts_recoded.pssm_cred,
+       t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+       t_cohorts_recoded.survey_year,
+       t_cohorts_recoded.inst_cd,
+       t_cohorts_recoded.age_group_rollup,
+       t_cohorts_recoded.grad_status,
+       t_cohorts_recoded.lcp4_cd,
+       t_cohorts_recoded.ttrain,
+       t_cohorts_recoded.lcip4_cred,
+       t_cohorts_recoded.lcip2_cred,
+       t_cohorts_recoded.new_labour_supply,
+       Count(*) AS Count,
+       t_cohorts_recoded.weight_nls,
+       Count(*) * weight_nls AS Weighted
+INTO DACSO_Q006a_Weight_New_Labour_Supply
+FROM   t_cohorts_recoded
+INNER JOIN (t_current_region_pssm_codes
+     INNER JOIN t_current_region_pssm_rollup_codes
+      ON t_current_region_pssm_codes.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup)
+ON t_cohorts_recoded.current_region_pssm_code = t_current_region_pssm_codes.current_region_pssm_code
+WHERE  ( ( ( t_cohorts_recoded.respondent ) = '1' )
+         AND ( ( t_cohorts_recoded.weight ) > 0 ) )
+GROUP  BY t_cohorts_recoded.pssm_credential,
+          t_cohorts_recoded.pssm_cred,
+          t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+          t_cohorts_recoded.survey_year,
+          t_cohorts_recoded.inst_cd,
+          t_cohorts_recoded.age_group_rollup,
+          t_cohorts_recoded.grad_status,
+          t_cohorts_recoded.lcp4_cd,
+          t_cohorts_recoded.ttrain,
+          t_cohorts_recoded.lcip4_cred,
+          t_cohorts_recoded.lcip2_cred,
+          t_cohorts_recoded.new_labour_supply,
+          t_cohorts_recoded.weight_nls
+HAVING  t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup  <> 9999
+AND     t_cohorts_recoded.age_group_rollup IS NOT NULL
+AND   ( t_cohorts_recoded.grad_status = '1' 
+  OR    t_cohorts_recoded.grad_status = '3' )
+AND   ( t_cohorts_recoded.new_labour_supply = 0 
+  OR    t_cohorts_recoded.new_labour_supply = 1
+  OR    t_cohorts_recoded.new_labour_supply = 2 
+  OR    t_cohorts_recoded.new_labour_supply = 3 ); "
+
+DACSO_Q006b_Weighted_New_Labour_Supply <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+       dacso_q006a_weight_new_labour_supply.pssm_cred,
+       dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+       dacso_q006a_weight_new_labour_supply.age_group_rollup,
+       dacso_q006a_weight_new_labour_supply.lcp4_cd,
+       dacso_q006a_weight_new_labour_supply.ttrain,
+       dacso_q006a_weight_new_labour_supply.lcip4_cred,
+       dacso_q006a_weight_new_labour_supply.lcip2_cred,
+       Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Count,
+       Sum(dacso_q006a_weight_new_labour_supply.count)    AS Unweighted_Count
+INTO   dacso_q006b_weighted_new_labour_supply
+FROM   dacso_q006a_weight_new_labour_supply
+WHERE  (( ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 1
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 2
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 3 ))
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          dacso_q006a_weight_new_labour_supply.lcp4_cd,
+          dacso_q006a_weight_new_labour_supply.ttrain,
+          dacso_q006a_weight_new_labour_supply.lcip4_cred,
+          dacso_q006a_weight_new_labour_supply.lcip2_cred
+HAVING (( ( dacso_q006a_weight_new_labour_supply.age_group_rollup ) IS NOT NULL
+        ));"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_0 <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.LCP4_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP4_CRED, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+INTO DACSO_Q006b_Weighted_New_Labour_Supply_0
+FROM DACSO_Q006a_Weight_New_Labour_Supply
+WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0))
+GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.LCP4_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP4_CRED, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+INTO DACSO_Q006b_Weighted_New_Labour_Supply_0_2D
+FROM DACSO_Q006a_Weight_New_Labour_Supply
+WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0))
+GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT <- "
+SELECT  dacso_q006a_weight_new_labour_supply.pssm_credential,
+        dacso_q006a_weight_new_labour_supply.pssm_cred,
+        dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+        dacso_q006a_weight_new_labour_supply.age_group_rollup,
+        LEFT(lcp4_cd, 2) AS LCP2_CD,
+        (CASE WHEN LEFT(pssm_cred, 1) = '1' OR LEFT(pssm_cred, 1) = '3' THEN LEFT(pssm_cred, 1) + ' - ' ELSE '' END)
+        + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential AS LCP2_CRED,
+        Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Count
+INTO    dacso_q006b_weighted_new_labour_supply_0_2d_no_tt
+FROM    dacso_q006a_weight_new_labour_supply
+WHERE   dacso_q006a_weight_new_labour_supply.new_labour_supply = 0
+GROUP BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+        dacso_q006a_weight_new_labour_supply.pssm_cred,
+        dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+        dacso_q006a_weight_new_labour_supply.age_group_rollup,
+        LEFT(lcp4_cd, 2),
+       (CASE WHEN LEFT(pssm_cred, 1) = '1' OR LEFT(pssm_cred, 1) = '3' THEN LEFT(pssm_cred, 1) + ' - ' ELSE '' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT <- "
+SELECT  dacso_q006a_weight_new_labour_supply.pssm_credential,
+        dacso_q006a_weight_new_labour_supply.pssm_cred,
+        dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+        dacso_q006a_weight_new_labour_supply.age_group_rollup,
+        dacso_q006a_weight_new_labour_supply.lcp4_cd,
+        (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential AS LCIP4_CRED,
+        (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential AS LCIP2_CRED,
+        Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Count
+INTO   dacso_q006b_weighted_new_labour_supply_0_no_tt
+FROM   dacso_q006a_weight_new_labour_supply
+WHERE  dacso_q006a_weight_new_labour_supply.new_labour_supply = 0
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+  dacso_q006a_weight_new_labour_supply.pssm_cred,
+  dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+  dacso_q006a_weight_new_labour_supply.age_group_rollup,
+  dacso_q006a_weight_new_labour_supply.lcp4_cd,
+  (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential,
+  (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+INTO DACSO_Q006b_Weighted_New_Labour_Supply_2D
+FROM DACSO_Q006a_Weight_New_Labour_Supply
+WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
+GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT <- "
+SELECT    dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          LEFT(lcp4_cd, 2) AS LCP2_CD,
+          (CASE WHEN LEFT(pssm_cred, 1) = '1'  OR LEFT(pssm_cred, 1) = '3' THEN LEFT(pssm_cred, 1) + ' - ' ELSE '' END) +
+          LEFT(lcp4_cd, 2) + ' - ' + pssm_credential AS LCP2_CRED,
+          Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Count
+INTO      dacso_q006b_weighted_new_labour_supply_2d_no_tt
+FROM      dacso_q006a_weight_new_labour_supply
+WHERE     (dacso_q006a_weight_new_labour_supply.new_labour_supply = 1)
+    OR    (dacso_q006a_weight_new_labour_supply.new_labour_supply = 2)
+    OR    (dacso_q006a_weight_new_labour_supply.new_labour_supply = 3)
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          LEFT(lcp4_cd, 2),
+          (CASE WHEN LEFT(pssm_cred, 1) = '1'  OR LEFT(pssm_cred, 1) = '3' THEN LEFT(pssm_cred, 1) + ' - ' ELSE '' END) +
+          LEFT(lcp4_cd, 2) + ' - ' + pssm_credential; "
+
+DACSO_Q006b_Weighted_New_Labour_Supply_No_TT <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+       dacso_q006a_weight_new_labour_supply.pssm_cred,
+       dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+       dacso_q006a_weight_new_labour_supply.age_group_rollup,
+       dacso_q006a_weight_new_labour_supply.lcp4_cd,
+       (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) 
+       + lcp4_cd + ' - ' + pssm_credential                AS LCIP4_CRED,
+     (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) 
+       + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential       AS LCIP2_CRED,
+       Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Count,
+       Sum(dacso_q006a_weight_new_labour_supply.count)    AS Unweighted_Count
+INTO   dacso_q006b_weighted_new_labour_supply_no_tt
+FROM   dacso_q006a_weight_new_labour_supply
+WHERE  (( ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 1
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 2
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 3 ))
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          dacso_q006a_weight_new_labour_supply.lcp4_cd,
+         (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) 
+          + lcp4_cd + ' - ' + pssm_credential,
+          (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) 
+          + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential
+HAVING (( ( dacso_q006a_weight_new_labour_supply.age_group_rollup ) IS NOT NULL
+        )); "
+
+DACSO_Q006b_Weighted_New_Labour_Supply_Total <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+       dacso_q006a_weight_new_labour_supply.pssm_cred,
+       dacso_q006a_weight_new_labour_supply.age_group_rollup,
+       dacso_q006a_weight_new_labour_supply.lcp4_cd,
+       dacso_q006a_weight_new_labour_supply.ttrain,
+       dacso_q006a_weight_new_labour_supply.lcip4_cred,
+       dacso_q006a_weight_new_labour_supply.lcip2_cred,
+       Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Total
+INTO   dacso_q006b_weighted_new_labour_supply_total
+FROM   dacso_q006a_weight_new_labour_supply
+WHERE  (( ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 0
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 1
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 2
+           OR ( dacso_q006a_weight_new_labour_supply.new_labour_supply ) = 3 ))
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          dacso_q006a_weight_new_labour_supply.lcp4_cd,
+          dacso_q006a_weight_new_labour_supply.ttrain,
+          dacso_q006a_weight_new_labour_supply.lcip4_cred,
+          dacso_q006a_weight_new_labour_supply.lcip2_cred;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, 
+DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, 
+Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Total
+INTO DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D
+FROM DACSO_Q006a_Weight_New_Labour_Supply
+WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
+GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Total
+INTO DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT
+FROM DACSO_Q006a_Weight_New_Labour_Supply
+WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
+GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
+
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+       dacso_q006a_weight_new_labour_supply.pssm_cred,
+       dacso_q006a_weight_new_labour_supply.age_group_rollup,
+       dacso_q006a_weight_new_labour_supply.lcp4_cd,
+       (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential  AS LCIP4_CRED,
+       (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential  AS LCIP2_CRED,
+       Sum(dacso_q006a_weight_new_labour_supply.weighted) AS Total
+INTO   dacso_q006b_weighted_new_labour_supply_total_no_tt
+FROM   DACSO_Q006a_Weight_New_Labour_Supply
+WHERE  dacso_q006a_weight_new_labour_supply.new_labour_supply = 0
+           OR dacso_q006a_weight_new_labour_supply.new_labour_supply = 1
+           OR dacso_q006a_weight_new_labour_supply.new_labour_supply = 2
+           OR dacso_q006a_weight_new_labour_supply.new_labour_supply = 3
+GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
+          dacso_q006a_weight_new_labour_supply.pssm_cred,
+          dacso_q006a_weight_new_labour_supply.age_group_rollup,
+          dacso_q006a_weight_new_labour_supply.lcp4_cd,
+          (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential,
+          (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential;"
+
+DACSO_Q007a_Weighted_New_Labour_Supply <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total.TTRAIN, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP2_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total.Total, ISNULL(Count,0)/Total AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total 
+LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply.LCIP4_CRED)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup) Is Not Null));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_0 <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total.TTRAIN, DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total.Total, 
+1-(ISNULL(Count,0)/Total) AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_0
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0 ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0.LCIP4_CRED)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.TTRAIN, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Count, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Total, 1-(ISNULL(Count,0)/Total) AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_2D
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_2D ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.LCP2_CRED)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Total, 1-(ISNULL(Count,0)/Total) AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.LCP2_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Age_Group_Rollup)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_0_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Count, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Total, 1-(ISNULL(Count,0)/Total) AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_No_TT
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.LCIP4_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Age_Group_Rollup)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_2D <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Age_Group_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.TTRAIN, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Total, ISNULL(Count,0)/Total AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_2D
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_2D ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_2D.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CRED)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup) Is Not Null));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Age_Group_Rollup,
+DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Total, ISNULL(Count,0)/Total AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT 
+LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Age_Group_Rollup)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Current_Region_PSSM_Code_Rollup) Is Not Null));"
+
+DACSO_Q007a_Weighted_New_Labour_Supply_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.PSSM_Credential, 
+DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.PSSM_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Age_Group_Rollup, 
+DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Count, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Total, ISNULL(Count,0)/Total AS perc
+INTO DACSO_Q007a_Weighted_New_Labour_Supply_No_TT
+FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.LCIP4_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Age_Group_Rollup)
+WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Current_Region_PSSM_Code_Rollup) Is Not Null));"
+
+
+DACSO_Q007b0_Delete_New_Labour_Supply <- "
+DELETE
+FROM Labour_Supply_Distribution
+WHERE (((Labour_Supply_Distribution.Survey)='Student Outcomes'));"
+
+DACSO_Q007b0_Delete_New_Labour_Supply_No_TT <- "
+DELETE 
+FROM Labour_Supply_Distribution_No_TT
+WHERE (((Labour_Supply_Distribution_No_TT.Survey)='Student Outcomes'));"
+
+DACSO_Q007b0_Delete_New_Labour_Supply_No_TT_QI <- "
+DELETE 
+FROM Labour_Supply_Distribution_No_TT_QI
+WHERE (((Labour_Supply_Distribution_No_TT_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_No_TT_QI.Survey)='PTIB'));"
+
+DACSO_Q007b0_Delete_New_Labour_Supply_QI <- "
+DELETE 
+FROM Labour_Supply_Distribution_QI
+WHERE (((Labour_Supply_Distribution_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_QI.Survey)='PTIB'));"
+
+DACSO_Q007b1_Append_New_Labour_Supply <- "
+INSERT INTO Labour_Supply_Distribution ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, LCIP2_CRED, Count, Total, New_Labour_Supply )
+SELECT 'Student Outcomes' AS Survey, 
+DACSO_Q007a_Weighted_New_Labour_Supply.PSSM_Credential, 
+DACSO_Q007a_Weighted_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply.Age_Group_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply.LCP4_CD, 
+DACSO_Q007a_Weighted_New_Labour_Supply.TTRAIN, 
+DACSO_Q007a_Weighted_New_Labour_Supply.LCIP4_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply.LCIP2_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply.Count, 
+DACSO_Q007a_Weighted_New_Labour_Supply.Total, 
+DACSO_Q007a_Weighted_New_Labour_Supply.perc AS New_Labour_Supply
+FROM DACSO_Q007a_Weighted_New_Labour_Supply;"
+
+DACSO_Q007b1_Append_New_Labour_Supply_No_TT <- "
+INSERT INTO Labour_Supply_Distribution_No_TT (survey, pssm_credential, pssm_cred, current_region_pssm_code_rollup, age_group_rollup, lcp4_cd, lcip4_cred, lcip2_cred, count, total, new_labour_supply)
+SELECT 'Student Outcomes' AS Survey,
+dacso_q007a_weighted_new_labour_supply_no_tt.pssm_credential,
+dacso_q007a_weighted_new_labour_supply_no_tt.pssm_cred,
+dacso_q007a_weighted_new_labour_supply_no_tt.current_region_pssm_code_rollup,
+dacso_q007a_weighted_new_labour_supply_no_tt.age_group_rollup,
+dacso_q007a_weighted_new_labour_supply_no_tt.lcp4_cd,
+dacso_q007a_weighted_new_labour_supply_no_tt.lcip4_cred,
+dacso_q007a_weighted_new_labour_supply_no_tt.lcip2_cred,
+dacso_q007a_weighted_new_labour_supply_no_tt.count,
+dacso_q007a_weighted_new_labour_supply_no_tt.total,
+dacso_q007a_weighted_new_labour_supply_no_tt.perc AS New_Labour_Supply
+FROM   dacso_q007a_weighted_new_labour_supply_no_tt"
+
+DACSO_Q007b2_Append_New_Labour_Supply_0 <- "
+INSERT INTO Labour_Supply_Distribution (survey,pssm_credential,pssm_cred,current_region_pssm_code_rollup,age_group_rollup,lcp4_cd,ttrain,lcip4_cred,lcip2_cred,count,total,new_labour_supply)
+SELECT 'Student Outcomes' AS Survey,
+       dacso_q007a_weighted_new_labour_supply_0.pssm_credential,
+       dacso_q007a_weighted_new_labour_supply_0.pssm_cred,
+       dacso_q007a_weighted_new_labour_supply_0.current_region_pssm_code_rollup,
+       dacso_q007a_weighted_new_labour_supply_0.age_group_rollup,
+       dacso_q007a_weighted_new_labour_supply_0.lcp4_cd,
+       dacso_q007a_weighted_new_labour_supply_0.ttrain,
+       dacso_q007a_weighted_new_labour_supply_0.lcip4_cred,
+       dacso_q007a_weighted_new_labour_supply_0.lcip2_cred,
+       dacso_q007a_weighted_new_labour_supply_0.count,
+       dacso_q007a_weighted_new_labour_supply_0.total,
+       dacso_q007a_weighted_new_labour_supply_0.perc AS New_Labour_Supply
+FROM   dacso_q007a_weighted_new_labour_supply_0; "
+
+DACSO_Q007b2_Append_New_Labour_Supply_0_No_TT <- "
+INSERT INTO Labour_Supply_Distribution_No_TT(survey,pssm_credential,pssm_cred,current_region_pssm_code_rollup,age_group_rollup,lcp4_cd,lcip4_cred,lcip2_cred,count,total,new_labour_supply)
+SELECT 'Student Outcomes' AS Survey,
+       dacso_q007a_weighted_new_labour_supply_0_no_tt.pssm_credential,
+       dacso_q007a_weighted_new_labour_supply_0_no_tt.pssm_cred,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.current_region_pssm_code_rollup,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.age_group_rollup,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.lcp4_cd,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.lcip4_cred,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.lcip2_cred,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.count,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.total,
+dacso_q007a_weighted_new_labour_supply_0_no_tt.perc
+FROM   dacso_q007a_weighted_new_labour_supply_0_no_tt;"
+
+DACSO_Q007c0_Delete_New_Labour_Supply_2D <-
+  "DELETE 
+FROM Labour_Supply_Distribution_LCP2
+WHERE (((Labour_Supply_Distribution_LCP2.Survey)='Student Outcomes'));"
+
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT <-
+  "DELETE 
+FROM Labour_Supply_Distribution_LCP2_No_TT
+WHERE (((Labour_Supply_Distribution_LCP2_No_TT.Survey)='Student Outcomes'));"
+
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT_QI <-
+  "DELETE 
+FROM Labour_Supply_Distribution_LCP2_No_TT_QI
+WHERE (((Labour_Supply_Distribution_LCP2_No_TT_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_LCP2_No_TT_QI.Survey)='PTIB'));"
+
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_QI <-
+  "DELETE 
+FROM Labour_Supply_Distribution_LCP2_QI
+WHERE (((Labour_Supply_Distribution_LCP2_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_LCP2_QI.Survey)='PTIB'));"
+
+DACSO_Q007c1_Append_New_Labour_Supply_2D <- "
+INSERT INTO Labour_Supply_Distribution_LCP2 ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, TTRAIN, LCP2_CRED, Count, Total, New_Labour_Supply )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q007a_Weighted_New_Labour_Supply_2D.PSSM_Credential, DACSO_Q007a_Weighted_New_Labour_Supply_2D.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q007a_Weighted_New_Labour_Supply_2D.Age_Group_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D.LCP2_CD, DACSO_Q007a_Weighted_New_Labour_Supply_2D.TTRAIN, DACSO_Q007a_Weighted_New_Labour_Supply_2D.LCP2_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D.Count, DACSO_Q007a_Weighted_New_Labour_Supply_2D.Total, DACSO_Q007a_Weighted_New_Labour_Supply_2D.perc AS New_Labour_Supply
+FROM DACSO_Q007a_Weighted_New_Labour_Supply_2D;"
+
+DACSO_Q007c1_Append_New_Labour_Supply_2D_No_TT <- "
+INSERT INTO Labour_Supply_Distribution_LCP2_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, LCP2_CRED, Count, Total, New_Labour_Supply )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.PSSM_Credential, DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.Age_Group_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CD, DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.Count, DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.Total, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT.perc AS New_Labour_Supply
+FROM DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT;"
+
+DACSO_Q007c2_Append_New_Labour_Supply_0_2D <- "
+INSERT INTO Labour_Supply_Distribution_LCP2 ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, TTRAIN, LCP2_CRED, Count, Total, New_Labour_Supply )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.PSSM_Credential, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.Age_Group_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.LCP2_CD, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.TTRAIN, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.LCP2_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.Count, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.Total, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D.perc AS New_Labour_Supply
+FROM DACSO_Q007a_Weighted_New_Labour_Supply_0_2D;"
+
+DACSO_Q007c2_Append_New_Labour_Supply_0_2D_No_TT <- "
+INSERT INTO Labour_Supply_Distribution_LCP2_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, LCP2_CRED, Count, Total, New_Labour_Supply )
+SELECT 'Student Outcomes' AS Survey, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_Credential, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_CRED, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.Current_Region_PSSM_Code_Rollup, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.Age_Group_Rollup, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.LCP2_CD, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.LCP2_CRED, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.Count,
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.Total, DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT.perc AS New_Labour_Supply
+FROM DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT;"
+
+###############################################################################################
+qry_000_TRD_Current_Region_Data <-
+  "SELECT trades_cohort_info.KEY,
+       trades_cohort_info.subm_cd,
+       trades_cohort_info.respondent,
+       trades_cohort_info.new_postal_code,
+       trades_cohort_info.current_region1,
+       trades_cohort_info.current_region2,
+       trades_cohort_info.current_region3,
+       trades_cohort_info.current_region4
+FROM   trades_cohort_info
+WHERE subm_cd IN ('C_Outc14', 'C_Outc15', 'C_Outc16', 'C_Outc17', 'C_Outc18', 'C_Outc19', 'C_Outc20', 'C_Outc21')"
+
+
+qry_000_TRD_Update_Current_Region_PSSM_step1 <- "
+UPDATE trd_current_region_data
+SET    trd_current_region_data.current_region_pssm_code = trd_current_region_data.current_region1
+WHERE   trd_current_region_data.current_region_pssm_code IS NULL 
+AND trd_current_region_data.current_region1 >= 1
+AND trd_current_region_data.current_region1 <= 8;"
+
+qry_000_TRD_Update_Current_Region_PSSM_step2 <- "
+UPDATE  trd_current_region_data
+SET     trd_current_region_data.current_region_pssm_code = 
+        CASE WHEN current_region4 = 5 THEN 9
+             WHEN current_region4 = 6 THEN 10
+             WHEN current_region4 = 7 THEN 11
+             WHEN current_region4 = 8 THEN -1
+             ELSE NULL
+        END
+WHERE   trd_current_region_data.current_region_pssm_code IS NULL;"
+
+qry_000_TRD_results <- "
+SELECT current_region_pssm_code, [C_Outc14], [C_Outc15], [C_Outc16], [C_Outc17], [C_Outc18], [C_Outc19]
+FROM (
+	SELECT current_region_pssm_code, -- implicit group by column, result will have one row for each distinct value
+	       [key], --column being aggregated
+		     SUBM_CD --column that contains the values that will become column headers
+	FROM   trd_current_region_data
+	WHERE  respondent = '1') P
+PIVOT (Count([key]) FOR SUBM_CD IN ([C_Outc14],[C_Outc15],[C_Outc16],[C_Outc17],[C_Outc18],[C_Outc19])) AS PVT
+ORDER BY cast(current_region_pssm_code AS INT)"
+
+qry_APPSO_Current_Region_Data <-
+  "SELECT apprentice_cohort_info.KEY,
+       apprentice_cohort_info.subm_cd,
+       apprentice_cohort_info.respondent,
+       apprentice_cohort_info.lrst_cd,
+       apprentice_cohort_info.postal_code_new,
+       apprentice_cohort_info.current_region1,
+       apprentice_cohort_info.current_region2,
+       apprentice_cohort_info.current_region3,
+       apprentice_cohort_info.current_region4
+FROM   apprentice_cohort_info
+WHERE  apprentice_cohort_info.subm_cd IN ('C_Outc18', 'C_Outc19')"
+
+qry_APPSO_Update_Current_Region_PSSM_step1 <- "
+UPDATE appso_current_region_data
+SET    appso_current_region_data.current_region_pssm_code = appso_current_region_data.current_region1
+WHERE  appso_current_region_data.current_region_pssm_code IS NULL
+  AND  appso_current_region_data.current_region1 >= 1
+  AND  appso_current_region_data.current_region1 <= 8
+  AND appso_current_region_data.subm_cd IN ('C_Outc18', 'C_Outc19')"
+
+qry_APPSO_Update_Current_Region_PSSM_step2 <- "
+UPDATE appso_current_region_data
+SET    appso_current_region_data.current_region_pssm_code = 
+       CASE WHEN current_region4 = 5 THEN 9
+            WHEN current_region4 = 6 THEN 10
+            WHEN current_region4 = 7 THEN 11
+            WHEN current_region4 = 8 THEN -1
+            ELSE NULL
+       END 
+WHERE  appso_current_region_data.current_region_pssm_code IS NULL
+AND    appso_current_region_data.subm_cd IN ('C_Outc18', 'C_Outc19')"
+
+qry_APPSO100_Unknown_2016 <-
+  "INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], [New Phone2], [Phone Status2], [Phone category2], [New Phone3], [Phone Status3], [Phone category3], [New Phone4], [Phone Status4], [Phone category4], [New Phone5], [Phone Status5], [Phone category5], [New Phone6], [Phone Status6], [Phone category6], CURRENT_REGION_PSSM_CODE )
+SELECT APPSO_Current_Region_Data.KEY, APPRENTICE_COHORT_INFO.SUBM_CD, APPRENTICE_COHORT_INFO.INST, APPRENTICE_COHORT_INFO.CURRENT_REGION3, 'APPSO' AS Expr1, APPRENTICE_COHORT_INFO.ADDRESS, APPRENTICE_COHORT_INFO.OPHONE1, APPRENTICE_COHORT_INFO.OPHONE2, APPRENTICE_COHORT_INFO.PHONE, APPRENTICE_COHORT_INFO.POSTAL, IIf(IsNull([APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]),[Q59],[APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]) AS Expr2, APPSO_sourcing_2016.[Research Results], APPSO_sourcing_2016.[New Phone1], APPSO_sourcing_2016.[Phone Status1], APPSO_sourcing_2016.[Phone category1], APPSO_sourcing_2016.[New Phone2], APPSO_sourcing_2016.[Phone Status2], APPSO_sourcing_2016.[Phone category2], APPSO_sourcing_2016.[New Phone3], APPSO_sourcing_2016.[Phone Status3], APPSO_sourcing_2016.[Phone category3], APPSO_sourcing_2016.[New Phone4], APPSO_sourcing_2016.[Phone Status4], APPSO_sourcing_2016.[Phone category4], APPSO_sourcing_2016.[New Phone5], APPSO_sourcing_2016.[Phone Status5], APPSO_sourcing_2016.[Phone category5], APPSO_sourcing_2016.[New Phone6], APPSO_sourcing_2016.[Phone Status6], APPSO_sourcing_2016.[Phone category6], APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE
+FROM APPSO_Current_Region_Data INNER JOIN ((APPRENTICE_COHORT_INFO LEFT JOIN APPSO_sourcing_2016 ON APPRENTICE_COHORT_INFO.KEY = APPSO_sourcing_2016.KEY) LEFT JOIN APPSO_long_response_2016 ON APPRENTICE_COHORT_INFO.KEY = APPSO_long_response_2016.KEY) ON APPSO_Current_Region_Data.KEY = APPRENTICE_COHORT_INFO.KEY
+WHERE (((APPRENTICE_COHORT_INFO.SUBM_CD)='C_Outc16') AND ((APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=-1 Or (APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=9) AND ((APPRENTICE_COHORT_INFO.RESPONDENT)='1'));"
+
+qry_APPSO100_Unknown_2017 <-
+  "INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], CURRENT_REGION_PSSM_CODE )
+SELECT APPSO_Current_Region_Data.KEY, APPRENTICE_COHORT_INFO.SUBM_CD, APPRENTICE_COHORT_INFO.INST, APPRENTICE_COHORT_INFO.CURRENT_REGION3, 'APPSO' AS Expr1, APPRENTICE_COHORT_INFO.ADDRESS, APPRENTICE_COHORT_INFO.OPHONE1, APPRENTICE_COHORT_INFO.OPHONE2, APPRENTICE_COHORT_INFO.PHONE, APPRENTICE_COHORT_INFO.POSTAL, IIf(IsNull([APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]),[Q59],[APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]) AS Expr2, APPSO_sourcing_2017.[Reseach Found], APPSO_sourcing_2017.[New Phone], APPSO_sourcing_2017.[Phone Status], APPSO_sourcing_2017.[Phone Category], APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE
+FROM ((APPSO_Current_Region_Data INNER JOIN APPRENTICE_COHORT_INFO ON APPSO_Current_Region_Data.KEY = APPRENTICE_COHORT_INFO.KEY) LEFT JOIN APPSO_sourcing_2017 ON APPRENTICE_COHORT_INFO.KEY = APPSO_sourcing_2017.key) LEFT JOIN APPSO_long_responses_2017 ON APPRENTICE_COHORT_INFO.KEY = APPSO_long_responses_2017.KEY
+WHERE (((APPRENTICE_COHORT_INFO.SUBM_CD)='C_Outc17') AND ((APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=-1 Or (APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=9) AND ((APPRENTICE_COHORT_INFO.RESPONDENT)='1'));"
+
+qry_APPSO_results <- "
+SELECT current_region_pssm_code, [C_Outc05],[C_Outc06],[C_Outc07],[C_Outc08],[C_Outc09],[C_Outc10],[C_Outc11],[C_Outc12],[C_Outc13],[C_Outc14], [C_Outc15], [C_Outc16], [C_Outc17], [C_Outc18], [C_Outc19]
+FROM (
+	SELECT current_region_pssm_code, -- implicit group by column, result will have one row for each distinct value
+	       [key], --column being aggregated
+		     SUBM_CD --column that contains the values that will become column headers
+	FROM   appso_current_region_data
+	WHERE  respondent = '1') P
+PIVOT (Count([key]) FOR SUBM_CD IN ([C_Outc05],[C_Outc06],[C_Outc07],[C_Outc08],[C_Outc09],[C_Outc10],[C_Outc11],[C_Outc12],[C_Outc13],[C_Outc14],[C_Outc15],[C_Outc16],[C_Outc17],[C_Outc18],[C_Outc19])) AS PVT
+ORDER BY cast(current_region_pssm_code AS INT)"
+
+qry_BGS_00_Append <- "
+select D.stqu_id,
+       D.year AS survey_year, 
+       C.inst, 
+       C.srv_y_n,
+       D.region_cd,
+       D.current_region, 
+       D.current_region_name 
+from  bgs_dist_15_19 D
+inner join bgs_cohort_info C
+    on C.stqu_id = D.stqu_id
+where D.year IN (2018, 2019)"
+
+qry_BGS_00_NEW_POSTAL <- "
+SELECT BGS_S18_USO_V.STQU_ID, BGS_S18_USO_V.NEW_POST, BGS_S18_USO_V.NEW_POSTAL, 2018 AS SURVEY_YEAR
+FROM BGS_S18_USO_V
+UNION ALL 
+SELECT BGS_Y19_USO_V.STQU_ID, BGS_Y19_USO_V.NEW_POST, BGS_Y19_USO_V.NEW_POSTAL, 2019 AS SURVEY_YEAR
+FROM BGS_Y19_USO_V"
+
+qry_BGS_00_Region_Codes <-
+  "SELECT BGS_DIST_13_17.REGION_CD, BGS_DIST_13_17.CURRENT_REGION, BGS_DIST_13_17.CURRENT_REGION_NAME, BGS_DIST_13_17.CUR_RES, BGS_DIST_13_17.CUR_RES_NAME
+FROM BGS_DIST_13_17
+GROUP BY BGS_DIST_13_17.REGION_CD, BGS_DIST_13_17.CURRENT_REGION, BGS_DIST_13_17.CURRENT_REGION_NAME, BGS_DIST_13_17.CUR_RES, BGS_DIST_13_17.CUR_RES_NAME"
+
+qry_BGS_results <-
+  "TRANSFORM Count(*) AS Expr1
+SELECT T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, T_Current_Region_PSSM_Codes.Current_Region_PSSM_Name
+FROM T_Current_Region_PSSM_Codes INNER JOIN BGS_Current_Region_Data ON T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code = BGS_Current_Region_Data.[CURRENT_REGION_PSSM_CODE]
+WHERE (((BGS_Current_Region_Data.srv_y_n)=1))
+GROUP BY T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, T_Current_Region_PSSM_Codes.Current_Region_PSSM_Name
+ORDER BY T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, BGS_Current_Region_Data.survey_year
+PIVOT BGS_Current_Region_Data.survey_year;"
+
+qry_BGS_results <- "
+SELECT current_region_pssm_code, [2014], [2015], [2016], [2017], [2018], [2019]
+FROM (
+  SELECT current_region_pssm_code,
+  [stqu_id],
+  survey_year
+  FROM   bgs_current_region_data
+  WHERE  srv_y_n = '1') P
+PIVOT (Count([stqu_id]) FOR survey_year IN ([2014], [2015], [2016], [2017], [2018], [2019])) AS PVT
+ORDER BY cast(current_region_pssm_code AS INT)"
+
+qry_BGS_update_Current_Region_PSSM_step0 <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = Null
+WHERE (((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step1 <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = [BGS_Current_Region_Data].REGION_CD
+WHERE (((BGS_Current_Region_Data.REGION_CD)>=1 
+And (BGS_Current_Region_Data.REGION_CD)<=8) 
+AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step2 <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 10
+WHERE (((BGS_Current_Region_Data.CURRENT_REGION)=6 Or (BGS_Current_Region_Data.CURRENT_REGION)=9 Or (BGS_Current_Region_Data.CURRENT_REGION)=10) 
+AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step3 <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 11
+WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) AND ((BGS_Current_Region_Data.CURRENT_REGION)=7) 
+AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step4 <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 9
+WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) 
+AND ((BGS_Current_Region_Data.CURRENT_REGION)=5) 
+AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step4b <-
+  "UPDATE BGS_Current_Region_Data 
+SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = -1
+WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) 
+AND ((BGS_Current_Region_Data.CURRENT_REGION)=8) 
+AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
+
+qry_BGS_update_Current_Region_PSSM_step5 <- "
+UPDATE    BGS_Current_Region_Data 
+SET       BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = [tmp_BGS_INST_REGION_CDS].Current_Region_PSSM
+FROM      BGS_Current_Region_Data 
+INNER JOIN tmp_BGS_INST_REGION_CDS 
+  ON      BGS_Current_Region_Data.inst = tmp_BGS_INST_REGION_CDS.inst 
+WHERE     (BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE=-1 Or BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE Is Null) 
+AND       (BGS_Current_Region_Data.srv_y_n=0 Or BGS_Current_Region_Data.srv_y_n Is Null) 
+AND       (BGS_Current_Region_Data.survey_year='2018' Or BGS_Current_Region_Data.survey_year='2019');"
+
+qry_BGS99_Update_from_Geocoding <- "
+UPDATE BGS_Current_Region_Data 
+INNER JOIN Unknown_Geocoding_Investigation 
+ON BGS_Current_Region_Data.POSTAL = Unknown_Geocoding_Investigation.POSTAL 
+SET Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE = [BGS_Current_Region_Data].[CURRENT_REGION_PSSM_CODE]
+WHERE (((Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE)=-1) AND ((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE)<>-1));"
+
+# won't always be accurate-not used
+qry_BGS99b_FSA_Recoding <-
+  "UPDATE Unknown_Geocoding_Investigation INNER JOIN T_BGS99_FSA ON Unknown_Geocoding_Investigation.FSA = T_BGS99_FSA.Expr1 SET Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE = [T_BGS99_FSA].[CURRENT_REGION_PSSM_CODE], Unknown_Geocoding_Investigation.FSA_Used = '1'
+WHERE (((Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE)=-1));"
+
+qry_DACSO_Current_Region_Data <- "
+SELECT surv_cohort_collection_info.coci_stqu_id,
+       surv_cohort_collection_info.coci_subm_cd,
+       surv_cohort_collection_info.coci_lrst_cd,
+       surv_cohort_collection_info.tpid_address_postal_new,
+       surv_cohort_collection_info.tpid_current_region1,
+       surv_cohort_collection_info.tpid_current_region2,
+       surv_cohort_collection_info.tpid_current_region3,
+       surv_cohort_collection_info.tpid_current_region4
+FROM   surv_cohort_collection_info
+INNER JOIN c_outc_clean2
+    ON surv_cohort_collection_info.coci_stqu_id = c_outc_clean2.stqu_id
+WHERE  surv_cohort_collection_info.coci_subm_cd IN ('C_Outc18', 'C_Outc19')"
+
+qry_DACSO_Update_Current_Region_PSSM_step1 <- "
+UPDATE  dacso_current_region_data
+SET     dacso_current_region_data.current_region_pssm_code = tpid_current_region1
+WHERE   dacso_current_region_data.current_region_pssm_code IS NULL 
+    AND dacso_current_region_data.tpid_current_region1 >= 1
+    AND dacso_current_region_data.tpid_current_region1 <= 8
+    AND dacso_current_region_data.coci_subm_cd IN ('C_Outc18', 'C_Outc19');"
+
+qry_DACSO_Update_Current_Region_PSSM_step2 <- "
+UPDATE  dacso_current_region_data
+SET     dacso_current_region_data.current_region_pssm_code = 
+        CASE 
+          WHEN tpid_current_region4 = 5 THEN 9
+          WHEN tpid_current_region4 = 6 THEN 10
+          WHEN tpid_current_region4 = 7 THEN 11
+          WHEN tpid_current_region4 = 8 THEN -1
+          ELSE NULL
+       END 
+WHERE  dacso_current_region_data.current_region_pssm_code IS NULL
+AND    dacso_current_region_data.coci_subm_cd IN ('C_Outc18', 'C_Outc19'); "
+
+qry_DACSO_results <- "
+SELECT current_region_pssm_code,  [C_Outc02],[C_Outc03],[C_Outc04],[C_Outc05],[C_Outc06],[C_Outc07],[C_Outc08],[C_Outc09],[C_Outc10],[C_Outc11],[C_Outc12],[C_Outc13],[C_Outc14], [C_Outc15], [C_Outc16], [C_Outc17], [C_Outc18], [C_Outc19]
+FROM (
+	SELECT  current_region_pssm_code, -- implicit group by column, result will have one row for each distinct value
+	        COCI_STQU_ID, --column being aggregated
+		      COCI_SUBM_CD--column that contains the values that will become column headers
+	FROM    dacso_current_region_data
+	WHERE   COCI_LRST_CD = '000') P
+PIVOT (Count(COCI_STQU_ID) 
+FOR COCI_SUBM_CD IN ( [C_Outc02],[C_Outc03],[C_Outc04],[C_Outc05],[C_Outc06],[C_Outc07],[C_Outc08],[C_Outc09],[C_Outc10],[C_Outc11],[C_Outc12],[C_Outc13],[C_Outc14], [C_Outc15], [C_Outc16], [C_Outc17], [C_Outc18], [C_Outc19])) AS PVT
+ORDER BY cast(current_region_pssm_code AS INT)"
+
+qry98_BGS_PC <-
+  "INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
+SELECT Left([POSTAL],3) AS FSA, BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE, BGS_Current_Region_Data.POSTAL
+FROM BGS_Current_Region_Data
+WHERE (((BGS_Current_Region_Data.survey_year)='2014' Or (BGS_Current_Region_Data.survey_year)='2015' Or (BGS_Current_Region_Data.survey_year)='2016' Or (BGS_Current_Region_Data.survey_year)='2017') AND ((BGS_Current_Region_Data.srv_y_n)=1))
+GROUP BY Left([POSTAL],3), BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE, BGS_Current_Region_Data.POSTAL
+HAVING (((BGS_Current_Region_Data.POSTAL) Like 'V#?*' And (BGS_Current_Region_Data.POSTAL) Not Like 'V0R*'));"
+
+qry98_DACSO_FSA <-
+  "INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
+SELECT Left([TPID_ADDRESS_POSTAL_NEW],3) AS Expr1, DACSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE, DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW
+FROM DACSO_Current_Region_Data
+WHERE (((DACSO_Current_Region_Data.COCI_SUBM_CD) In ('C_Outc14','C_Outc15','C_Outc16','C_Outc17')) AND ((DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW) Like 'V#?*' And (DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW) Not Like 'V0R*') AND ((DACSO_Current_Region_Data.COCI_LRST_CD)='000'))
+GROUP BY Left([TPID_ADDRESS_POSTAL_NEW],3), DACSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE, DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW;"
+
+
+###############################################################################################
+# ---- qry01_Match_DACSO_to_STP_Credential_Non_DUP_on_PEN ----
+qry01_Match_DACSO_to_STP_Credential_Non_DUP_on_PEN <- "
+SELECT 
+    T_DACSO_DATA_Part_1.COCI_STQU_ID, 
+    T_DACSO_DATA_Part_1.COCI_INST_CD,
+    Credential_Non_Dup.ID, 
+    T_DACSO_DATA_Part_1.COCI_PEN,  
+    Credential_Non_Dup.PSI_CODE, 
+    T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, 
+    T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+    T_DACSO_DATA_Part_1.PSSM_Credential, 
+    T_DACSO_DATA_Part_1.PSSM_Credential_Name, 
+    Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, 
+    Credential_Non_Dup.OUTCOMES_CRED, 
+    T_DACSO_DATA_Part_1.LCP4_CD, 
+    Credential_Non_Dup.FINAL_CIP_CODE_4, 
+    T_DACSO_DATA_Part_1.COCI_SUBM_CD, 
+    Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR, 
+    T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group 
+INTO DACSO_Matching_STP_Credential_PEN
+FROM T_DACSO_DATA_Part_1 
+INNER JOIN Credential_Non_Dup 
+    ON T_DACSO_DATA_Part_1.COCI_PEN = Credential_Non_Dup.PSI_PEN
+GROUP BY 
+    T_DACSO_DATA_Part_1.COCI_STQU_ID, 
+    T_DACSO_DATA_Part_1.COCI_INST_CD,
+    Credential_Non_Dup.ID, 
+    T_DACSO_DATA_Part_1.COCI_PEN,  
+    Credential_Non_Dup.PSI_CODE, 
+    T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, 
+    T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+    T_DACSO_DATA_Part_1.PSSM_Credential, 
+    T_DACSO_DATA_Part_1.PSSM_Credential_Name, 
+    Credential_Non_Dup.PSI_CREDENTIAL_CATEGORY, 
+    Credential_Non_Dup.OUTCOMES_CRED, 
+    T_DACSO_DATA_Part_1.LCP4_CD, 
+    Credential_Non_Dup.FINAL_CIP_CODE_4, 
+    T_DACSO_DATA_Part_1.COCI_SUBM_CD, 
+    Credential_Non_Dup.PSI_AWARD_SCHOOL_YEAR, 
+    T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group 
+HAVING (((T_DACSO_DATA_Part_1.COCI_PEN)<> ' '));"
+
+# ---- qry_Update_STP_PRGM_Credential_Awarded_Name ----
+qry_Update_STP_PRGM_Credential_Awarded_Name <- "
+UPDATE dacso_matching_stp_credential_pen
+SET dacso_matching_stp_credential_pen.stp_prgm_credential_awarded_name = stp_dacso_prgm_credential_lookup.stp_prgm_credential_awarded_name
+FROM dacso_matching_stp_credential_pen
+INNER JOIN stp_dacso_prgm_credential_lookup
+  ON dacso_matching_stp_credential_pen.prgm_credential_awarded = stp_dacso_prgm_credential_lookup.prgrm_credential_awarded;"
+
+# ---- qry02_Match_DACSO_STP_Credential_PSI_CRED_Category ----
+qry02_Match_DACSO_STP_Credential_PSI_CRED_Category <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.match_credential = 'yes'
+WHERE  dacso_matching_stp_credential_pen.prgm_credential_awarded_name = dacso_matching_stp_credential_pen.psi_credential_category;"
+
+# ---- qry03_Match_DACSO_STP_Credential_CIPCODE4 ----
+qry03_Match_DACSO_STP_Credential_CIPCODE4 <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.match_cip_code_4 = 'yes'
+WHERE  dacso_matching_stp_credential_pen.lcp4_cd = dacso_matching_stp_credential_pen.final_cip_code_4;"
+
+# ---- qry03b_Match_DACSO_STP_Credential_CIPCODE2 ----
+qry03b_Match_DACSO_STP_Credential_CIPCODE2 <- "
+UPDATE DACSO_Matching_STP_Credential_PEN 
+SET DACSO_Matching_STP_Credential_PEN.Match_CIP_CODE_2 = 'Yes'
+WHERE Left(LCP4_CD,2)=Left(DACSO_Matching_STP_Credential_PEN.FINAL_CIP_CODE_4,2);"
+
+# ---- qry04_Match_DACSO_STP_Credential_AwardYear ----
+qry04_Match_DACSO_STP_Credential_AwardYear <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.match_award_school_year = 'yes'
+WHERE  ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc06' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2003/2004' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc06' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2004/2005' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc07' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2004/2005' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc07' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2005/2006' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc08' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2005/2006' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc08' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2006/2007' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc09' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2006/2007' ) ) 
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc09' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2007/2008' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc10' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2007/2008' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc10' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2008/2009' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc11' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2008/2009' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc11' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2009/2010' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc12' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2009/2010' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc12' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2010/2011' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc13' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2010/2011' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc13' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2011/2012' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc14' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2011/2012' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc14' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2012/2013' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc15' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2012/2013' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc15' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2013/2014' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc16' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2013/2014' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc16' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2014/2015' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc17' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2014/2015' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc17' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2015/2016' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc18' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2015/2016' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc18' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2016/2017' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc19' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2016/2017' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc19' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2017/2018' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc20' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2017/2018' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc20' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2018/2019' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc21' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2018/2019' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc21' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2019/2020' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc22' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2019/2020' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc22' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2020/2021' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc23' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2020/2021' ) )
+OR ( ( ( dacso_matching_stp_credential_pen.coci_subm_cd ) = 'C_Outc23' ) AND ( ( dacso_matching_stp_credential_pen.psi_award_school_year ) = '2021/2022' ) );"
+
+
+# ---- qry05_Match_DACSO_STP_Credential_Inst ----
+qry05_Match_DACSO_STP_Credential_Inst <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.match_inst = 'yes'
+WHERE PSI_CODE = COCI_INST_CD
+Or (((PSI_CODE)='CAP') And ((COCI_INST_CD)='CAPU')) 
+Or (((PSI_CODE)='KWAN') And ((COCI_INST_CD)='KPU')) 
+Or (((PSI_CODE)='OLA') And ((COCI_INST_CD)='TRU')) 
+Or (((PSI_CODE)='MALA') And ((COCI_INST_CD)='VIU')) 
+Or (((PSI_CODE)='OUC') And ((COCI_INST_CD)='OKAN')) 
+Or (((PSI_CODE)='UCFV') And ((COCI_INST_CD)='UFV')) 
+Or (((PSI_CODE)='UCC') And ((COCI_INST_CD)='TRU')) 
+Or (((PSI_CODE)='NWCC') And ((COCI_INST_CD)='CMTN'));"
+
+# ---- qry06_Match_DACSO_STP_Credential_Summary ----
+qry06_Match_DACSO_STP_Credential_Summary <- "
+SELECT dacso_matching_stp_credential_pen.match_credential,
+       dacso_matching_stp_credential_pen.match_cip_code_4,
+       dacso_matching_stp_credential_pen.match_award_school_year,
+       dacso_matching_stp_credential_pen.match_inst,
+       Count(*) AS Expr1
+FROM   dacso_matching_stp_credential_pen
+GROUP  BY dacso_matching_stp_credential_pen.match_credential,
+          dacso_matching_stp_credential_pen.match_cip_code_4,
+          dacso_matching_stp_credential_pen.match_award_school_year,
+          dacso_matching_stp_credential_pen.match_inst
+ORDER  BY dacso_matching_stp_credential_pen.match_credential DESC,
+          dacso_matching_stp_credential_pen.match_cip_code_4 DESC,
+          dacso_matching_stp_credential_pen.match_award_school_year DESC,
+          dacso_matching_stp_credential_pen.match_inst DESC;"
+
+# ---- qry07_DACSO_STP_Credential_MatchAll4_Flag ----
+qry07_DACSO_STP_Credential_MatchAll4_Flag <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.final_consider_a_match = 'yes',
+       dacso_matching_stp_credential_pen.match_all_4_flag = 'yes'
+WHERE  ((( dacso_matching_stp_credential_pen.match_credential ) = 'yes') 
+    AND (( dacso_matching_stp_credential_pen.match_cip_code_4 ) = 'yes')
+    AND (( dacso_matching_stp_credential_pen.match_award_school_year ) = 'yes')
+    AND (( dacso_matching_stp_credential_pen.match_inst ) = 'yes' ));"
+
+# ---- qry08_DACSO_STP_Credential_Final_Match_Flag ----
+qry08_DACSO_STP_Credential_Final_Match_Flag <- "
+UPDATE dacso_matching_stp_credential_pen
+SET    dacso_matching_stp_credential_pen.final_consider_a_match = 'yes'
+WHERE  (( ( dacso_matching_stp_credential_pen.match_credential ) = 'yes')
+    AND (( dacso_matching_stp_credential_pen.match_cip_code_2 ) = 'yes')
+    AND (( dacso_matching_stp_credential_pen.match_cip_code_4 ) IS NULL)
+    AND (( dacso_matching_stp_credential_pen.match_award_school_year ) = 'yes')
+    AND (( dacso_matching_stp_credential_pen.match_inst ) = 'yes' ));"
+
+###############################################################################################
+
+#---- qry_make_tmp_table_Age_step2 ----
+qry_make_tmp_table_Age_step2 <- "
+UPDATE tmp_tbl_Age_AppendNewYears 
+SET tmp_tbl_Age_AppendNewYears.BTHDT_CLEANED = Right(tmp_tbl_Age_AppendNewYears.BTHDT,2)+'/1/'+Left(tmp_tbl_Age_AppendNewYears.BTHDT,4), 
+tmp_tbl_Age_AppendNewYears.ENDDT_CLEANED = Right(tmp_tbl_Age_AppendNewYears.ENDDT,2)+'/1/'+Left(tmp_tbl_Age_AppendNewYears.ENDDT,4);"
+
+#---- qry_make_tmp_table_Age_step3 ----
+qry_make_tmp_table_Age_step3 <- "
+UPDATE tmp_tbl_Age_AppendNewYears 
+SET tmp_tbl_Age_AppendNewYears.BTHDT_DATE = TRY_CONVERT(DATE, tmp_tbl_Age_AppendNewYears.BTHDT_CLEANED), 
+tmp_tbl_Age_AppendNewYears.ENDDT_DATE = TRY_CONVERT(DATE, tmp_tbl_Age_AppendNewYears.ENDDT_CLEANED);"
+
+#---- qry_make_tmp_table_Age_step4 ----
+qry_make_tmp_table_Age_step4 <- "
+INSERT INTO tmp_tbl_Age ( COSC_STQU_ID, COSC_SUBM_CD, TPID_DATE_OF_BIRTH, COSC_ENRL_END_DATE, COCI_AGE_AT_SURVEY )
+SELECT tmp_tbl_Age_AppendNewYears.COCI_STQU_ID, 
+tmp_tbl_Age_AppendNewYears.COCI_SUBM_CD, 
+tmp_tbl_Age_AppendNewYears.BTHDT_DATE, 
+tmp_tbl_Age_AppendNewYears.ENDDT_DATE,
+tmp_tbl_Age_AppendNewYears.COCI_AGE_AT_SURVEY
+FROM tmp_tbl_Age_AppendNewYears;"
+
+#---- qry99_Update_Age_At_Grad ----
+qry99_Update_Age_At_Grad <- "
+UPDATE tmp_tbl_age
+SET Age_At_Grad = Datediff(yyyy, tpid_date_of_birth, Isnull(cosc_grad_credential_date, cosc_enrl_end_date)) + 
+CASE WHEN (Isnull(cosc_grad_credential_date, cosc_enrl_end_date) < 
+    DateFromParts(Year(Isnull(cosc_grad_credential_date, cosc_enrl_end_date)), Month([tpid_date_of_birth]), Day(tpid_date_of_birth))) THEN -1 ELSE 0 END;"
+
+#---- qry99a_Update_Age_At_Grad ----
+qry99a_Update_Age_At_Grad <- "
+UPDATE  T_DACSO_DATA_Part_1
+SET     Age_At_Grad = tmp_tbl_Age.Age_At_Grad
+FROM    tmp_tbl_Age 
+INNER JOIN T_DACSO_DATA_Part_1 
+ON tmp_tbl_Age.COSC_STQU_ID = T_DACSO_DATA_Part_1.COCI_STQU_ID"
+
+
+#---- qry_make_T_DACSO_DATA_Part_1_TempSelection ----
+qry_make_T_DACSO_DATA_Part_1_TempSelection <- "
+SELECT T_DACSO_DATA_Part_1.COCI_STQU_ID, 
+T_DACSO_DATA_Part_1.COCI_SUBM_CD, 
+T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY, 
+T_DACSO_DATA_Part_1.Age_At_Grad, 
+T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+T_DACSO_DATA_Part_1.PSSM_Credential, 
+T_DACSO_DATA_Part_1.PSSM_Credential_Name 
+INTO T_DACSO_DATA_Part_1_TempSelection
+FROM T_DACSO_DATA_Part_1;"
+
+#---- qry99_Investigate_Near_Completes_vs_Graduates_by_Year ----
+qry99_Investigate_Near_Completes_vs_Graduates_by_Year <-
+  "select COSC_GRAD_STATUS_LGDS_CD_Group, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],
+[C_Outc22],[C_Outc23]
+FROM
+(
+SELECT COSC_GRAD_STATUS_LGDS_CD_Group, COCI_STQU_ID , COCI_SUBM_CD 
+FROM T_DACSO_DATA_Part_1_TempSelection
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group) Is Not Null) 
+AND ((T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)>=17 And (T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)<=64))
+) As P
+PIVOT (
+  Count(COCI_STQU_ID) 
+  FOR COCI_SUBM_CD 
+    IN([C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23])
+  ) AS PT;"
+
+#---- qry_Find_NearCompleters_in_STP_Credential_Step1 ----
+qry_Find_NearCompleters_in_STP_Credential_Step1 <-
+  "SELECT t_dacso_data_part_1.coci_stqu_id,
+       t_dacso_data_part_1.coci_subm_cd,
+       t_dacso_data_part_1.age_at_grad,
+       t_dacso_data_part_1.prgm_credential_awarded AS DACSO_PRGM_Credential_Awarded,
+       t_dacso_data_part_1.prgm_credential_awarded_name AS DACSO_PRGM_Credential_Awarded_Name,
+       t_dacso_data_part_1.pssm_credential AS DACSO_PSSM_Credential,
+       t_dacso_data_part_1.pssm_credential_name AS DACSO_PSSM_Credential_Name,
+       --dacso_matching_stp_credential_pen.coci_stqu_id,
+       dacso_matching_stp_credential_pen.id,
+       dacso_matching_stp_credential_pen.coci_pen,
+       dacso_matching_stp_credential_pen.psi_code,
+       dacso_matching_stp_credential_pen.coci_inst_cd,
+       dacso_matching_stp_credential_pen.prgm_credential_awarded,
+       dacso_matching_stp_credential_pen.prgm_credential_awarded_name,
+       dacso_matching_stp_credential_pen.stp_prgm_credential_awarded_name,
+       dacso_matching_stp_credential_pen.pssm_credential,
+       dacso_matching_stp_credential_pen.pssm_credential_name,
+       dacso_matching_stp_credential_pen.psi_credential_category,
+       dacso_matching_stp_credential_pen.outcomes_cred,
+       t_dacso_data_part_1.lcp4_cd,
+       dacso_matching_stp_credential_pen.final_cip_code_4,
+       dacso_matching_stp_credential_pen.cosc_grad_status_lgds_cd_group,
+       --dacso_matching_stp_credential_pen.coci_subm_cd,
+       dacso_matching_stp_credential_pen.psi_award_school_year,
+       dacso_matching_stp_credential_pen.match_credential,
+       dacso_matching_stp_credential_pen.match_cip_code_4,
+       dacso_matching_stp_credential_pen.match_award_school_year,
+       dacso_matching_stp_credential_pen.match_inst,
+       dacso_matching_stp_credential_pen.match_all_4_flag,
+       dacso_matching_stp_credential_pen.match_cip_code_2,
+       -- dacso_matching_stp_credential_pen.dup_stquid_usethisrecord,
+       -- dacso_matching_stp_credential_pen.match to use dup cpc,
+       -- dacso_matching_stp_credential_pen.match_all_4_usethisrecord,
+       dacso_matching_stp_credential_pen.final_consider_a_match
+       -- dacso_matching_stp_credential_pen.final_probable_match
+INTO   nearcompleters_in_stp_credential_step1
+FROM   t_dacso_data_part_1
+LEFT JOIN dacso_matching_stp_credential_pen
+  ON t_dacso_data_part_1.coci_stqu_id = dacso_matching_stp_credential_pen.coci_stqu_id
+WHERE  ( ( ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc07'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc08'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc09'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc10'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc11'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc12'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc13'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc14'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc15'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc16'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc17'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc18'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc19'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc20'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc21'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc22'
+    OR ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc23')
+  AND ( ( t_dacso_data_part_1.age_at_grad ) >= 17 AND ( t_dacso_data_part_1.age_at_grad ) <= 64 )
+  AND ( ( t_dacso_data_part_1.cosc_grad_status_lgds_cd_group ) = '3' )
+  AND ( ( dacso_matching_stp_credential_pen.coci_stqu_id ) IS NOT NULL ));"
+
+# ---- qry_Update_STP_Credential_Awarded_Before_DACSO ----
+qry_Update_STP_Credential_Awarded_Before_DACSO <-
+  "UPDATE NearCompleters_in_STP_Credential_Step1 
+  SET NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_Before_DACSO = 'Yes'
+WHERE (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc07') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc08') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc09') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc10') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc11') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc12') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc13') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc14') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc15') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014')) 
+OR (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc16') 
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015')) 
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc17'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc18'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc19'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2017/2018'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc20'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2017/2018'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2018/2019'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc21'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2017/2018'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2018/2019'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2019/2020'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc22'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2017/2018'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2018/2019'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2019/2020'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2020/2021'))
+OR (NearCompleters_in_STP_Credential_Step1.coci_subm_cd ='C_Outc23'
+  AND ((NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2002/2003' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2003/2004' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2004/2005' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2005/2006' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2006/2007' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2007/2008' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2008/2009' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2009/2010' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2010/2011' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2011/2012' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2012/2013' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2013/2014' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2014/2015' 
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2015/2016'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2016/2017'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2017/2018'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2018/2019'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2019/2020'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2020/2021'
+    Or (NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR)='2021/2022'));"
+
+# ---- qry_Update_STP_Credential_Awarded_After_DACSO ----
+qry_Update_STP_Credential_Awarded_After_DACSO <- "
+UPDATE NearCompleters_in_STP_Credential_Step1 
+  SET NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_After_DACSO = 'Yes'
+WHERE (((NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_Before_DACSO) Is Null));"
+
+# ---- qry_make_table_NearCompleters ----
+qry_make_table_NearCompleters <- "
+SELECT T_DACSO_DATA_Part_1.coci_STQU_ID, 
+T_DACSO_DATA_Part_1.coci_subm_cd, 
+T_DACSO_DATA_Part_1.Age_At_Grad, 
+T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+T_DACSO_DATA_Part_1.PSSM_Credential, 
+T_DACSO_DATA_Part_1.PSSM_Credential_Name 
+INTO T_DACSO_NearCompleters
+FROM T_DACSO_DATA_Part_1
+WHERE (((T_DACSO_DATA_Part_1.Age_At_Grad)>=17 
+And (T_DACSO_DATA_Part_1.Age_At_Grad)<=64) 
+AND ((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group)='3'));"
+
+# ---- qry_update_T_DACSO_Near_Completers_step1 ----
+qry_update_T_DACSO_Near_Completers_step1 <- "
+UPDATE T_DACSO_NearCompleters 
+SET T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO = [NearCompleters_in_STP_Credential_Step1].[STP_Credential_Awarded_Before_DACSO]
+FROM NearCompleters_in_STP_Credential_Step1
+INNER JOIN T_DACSO_NearCompleters 
+ON NearCompleters_in_STP_Credential_Step1.coci_STQU_ID = T_DACSO_NearCompleters.coci_STQU_ID;"
+
+# ---- qry_update_T_DACSO_Near_Completers_step2 ----
+qry_update_T_DACSO_Near_Completers_step2 <- "
+UPDATE t_dacso_nearcompleters
+SET   t_dacso_nearcompleters.stp_credential_awarded_after_dacso =
+nearcompleters_in_stp_credential_step1.stp_credential_awarded_after_dacso
+FROM nearcompleters_in_stp_credential_step1
+INNER JOIN t_dacso_nearcompleters
+  ON nearcompleters_in_stp_credential_step1.coci_stqu_id = t_dacso_nearcompleters.coci_stqu_id;"
+
+# ---- qry_NearCompleters_With_More_Than_One_Cdtl ----
+qry_NearCompleters_With_More_Than_One_Cdtl <- "
+SELECT NearCompleters_in_STP_Credential_Step1.COCI_STQU_ID, Count(*) AS Expr1 
+INTO tmp_DACSO_NearCompleters_with_Multiple_Cdtls
+FROM NearCompleters_in_STP_Credential_Step1
+GROUP BY NearCompleters_in_STP_Credential_Step1.COCI_STQU_ID
+HAVING (((Count(*))>1));"
+
+# ---- qry_Update_T_NearCompleters_HasMultipleCdtls ----
+qry_Update_T_NearCompleters_HasMultipleCdtls <- "
+UPDATE T_DACSO_NearCompleters
+SET T_DACSO_NearCompleters.Has_Multiple_STP_Credentials = 'Yes'
+FROM tmp_DACSO_NearCompleters_with_Multiple_Cdtls 
+INNER JOIN T_DACSO_NearCompleters 
+ON tmp_DACSO_NearCompleters_with_Multiple_Cdtls.COCI_STQU_ID = T_DACSO_NearCompleters.COCI_STQU_ID;"
+
+# ---- qry_Clean_NearCompleters_MultiCdtls_Step1 ----
+qry_Clean_NearCompleters_MultiCdtls_Step1 <- "
+UPDATE NearCompleters_in_STP_Credential_Step1 
+SET NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials = 'Yes'
+FROM tmp_DACSO_NearCompleters_with_Multiple_Cdtls 
+INNER JOIN NearCompleters_in_STP_Credential_Step1
+ON NearCompleters_in_STP_Credential_Step1.COCI_STQU_ID = tmp_DACSO_NearCompleters_with_Multiple_Cdtls.COCI_STQU_ID;"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step2 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step2 <- "
+SELECT NearCompleters_in_STP_Credential_Step1.COCI_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.ID, 
+NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials, 
+NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR 
+INTO tmp_NearCompletersWithMultiCredentials_Cleaning
+FROM NearCompleters_in_STP_Credential_Step1
+WHERE (((NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials)='Yes'))
+ORDER BY NearCompleters_in_STP_Credential_Step1.COCI_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.ID,
+NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR DESC;"
+
+# ---- qry_PickMaxYear_step ----
+qry_PickMaxYear_step1 <- "
+SELECT tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID, 
+Max(tmp_NearCompletersWithMultiCredentials_Cleaning.PSI_AWARD_SCHOOL_YEAR) AS MaxOfPSI_AWARD_SCHOOL_YEAR 
+INTO tmp_MaxAwardYear
+FROM tmp_NearCompletersWithMultiCredentials_Cleaning
+GROUP BY tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID;"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step3 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step3 <- "
+UPDATE tmp_NearCompletersWithMultiCredentials_Cleaning
+SET tmp_NearCompletersWithMultiCredentials_Cleaning.Max_Award_School_Year = 'Yes'
+FROM tmp_MaxAwardYear 
+INNER JOIN tmp_NearCompletersWithMultiCredentials_Cleaning 
+ON (tmp_MaxAwardYear.MaxOfPSI_AWARD_SCHOOL_YEAR = tmp_NearCompletersWithMultiCredentials_Cleaning.PSI_AWARD_SCHOOL_YEAR) 
+AND (tmp_MaxAwardYear.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID);"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step4 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step4 <- "
+UPDATE NearCompleters_in_STP_Credential_Step1
+SET NearCompleters_in_STP_Credential_Step1.Dup_STQUID_UseThisRecord = 'Yes'
+FROM tmp_NearCompletersWithMultiCredentials_Cleaning
+INNER JOIN NearCompleters_in_STP_Credential_Step1 
+ON (tmp_NearCompletersWithMultiCredentials_Cleaning.ID = NearCompleters_in_STP_Credential_Step1.ID) 
+AND (tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID = NearCompleters_in_STP_Credential_Step1.coci_STQU_ID) 
+WHERE (((tmp_NearCompletersWithMultiCredentials_Cleaning.Max_Award_School_Year)='Yes') 
+AND ((NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials)='Yes'));"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step5 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step5 <- "
+SELECT NearCompleters_in_STP_Credential_Step1.coci_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials, 
+NearCompleters_in_STP_Credential_Step1.Dup_STQUID_UseThisRecord, Count(*) AS Expr1 
+INTO tmp_NearCompletersWithMultiCredentials_MaxYear
+FROM NearCompleters_in_STP_Credential_Step1
+GROUP BY NearCompleters_in_STP_Credential_Step1.coci_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials, 
+NearCompleters_in_STP_Credential_Step1.Dup_STQUID_UseThisRecord
+HAVING (((NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials)='Yes') 
+AND ((NearCompleters_in_STP_Credential_Step1.Dup_STQUID_UseThisRecord)='Yes') 
+AND ((Count(*))>1));"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step6 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step6 <- "
+SELECT 
+NearCompleters_in_STP_Credential_Step1.coci_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.coci_SUBM_CD, 
+NearCompleters_in_STP_Credential_Step1.Age_At_Grad, 
+NearCompleters_in_STP_Credential_Step1.COSC_GRAD_STATUS_LGDS_CD_Group, 
+NearCompleters_in_STP_Credential_Step1.DACSO_PRGM_Credential_Awarded, 
+NearCompleters_in_STP_Credential_Step1.DACSO_PRGM_Credential_Awarded_Name, 
+NearCompleters_in_STP_Credential_Step1.DACSO_PSSM_Credential, 
+NearCompleters_in_STP_Credential_Step1.DACSO_PSSM_Credential_Name, 
+--NearCompleters_in_STP_Credential_Step1.DACSO_Matching_STP_Credential_PEN_coci_STQU_ID, 
+NearCompleters_in_STP_Credential_Step1.ID, 
+NearCompleters_in_STP_Credential_Step1.COCI_PEN, 
+NearCompleters_in_STP_Credential_Step1.PSI_CODE, 
+NearCompleters_in_STP_Credential_Step1.COCI_INST_CD, 
+NearCompleters_in_STP_Credential_Step1.PRGM_Credential_Awarded, 
+NearCompleters_in_STP_Credential_Step1.PRGM_Credential_Awarded_Name, 
+--NearCompleters_in_STP_Credential_Step1.STP_PRGM_Credential_Awarded_Name, 
+NearCompleters_in_STP_Credential_Step1.PSSM_Credential, 
+NearCompleters_in_STP_Credential_Step1.PSSM_Credential_Name, 
+NearCompleters_in_STP_Credential_Step1.PSI_CREDENTIAL_CATEGORY, 
+NearCompleters_in_STP_Credential_Step1.OUTCOMES_CRED, 
+NearCompleters_in_STP_Credential_Step1.LCP4_CD, 
+NearCompleters_in_STP_Credential_Step1.FINAL_CIP_CODE_4, 
+--NearCompleters_in_STP_Credential_Step1.DACSO_Matching_STP_Credential_PEN_coci_SUBM_CD, 
+NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR, 
+NearCompleters_in_STP_Credential_Step1.Match_Credential, 
+NearCompleters_in_STP_Credential_Step1.Match_CIP_CODE_4, 
+NearCompleters_in_STP_Credential_Step1.Match_Award_School_Year, 
+NearCompleters_in_STP_Credential_Step1.Match_Inst, 
+NearCompleters_in_STP_Credential_Step1.Match_All_4_Flag, 
+NearCompleters_in_STP_Credential_Step1.Match_CIP_CODE_2, 
+NearCompleters_in_STP_Credential_Step1.Dup_STQUID_UseThisRecord, 
+--NearCompleters_in_STP_Credential_Step1.[Match to Use DUP CPC], 
+--NearCompleters_in_STP_Credential_Step1.Match_All_4_UseThisRecord, 
+NearCompleters_in_STP_Credential_Step1.Final_Consider_A_Match, 
+--NearCompleters_in_STP_Credential_Step1.Final_Probable_Match, 
+NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_Before_DACSO, 
+NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_After_DACSO, 
+NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials 
+INTO tmp_NearCompletersWithMultiCredentials_MaxYearCleaning
+FROM tmp_NearCompletersWithMultiCredentials_MaxYear 
+INNER JOIN NearCompleters_in_STP_Credential_Step1 
+ON tmp_NearCompletersWithMultiCredentials_MaxYear.coci_STQU_ID = NearCompleters_in_STP_Credential_Step1.coci_STQU_ID;"
+
+# ---- qry_PickMaxYear_Step2 ----
+qry_PickMaxYear_Step2 <- "
+SELECT tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID, 
+Max(tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID) AS MaxOfID, 
+tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord 
+INTO tmp_MaxAwardYearCleaning_MaxID
+FROM tmp_NearCompletersWithMultiCredentials_MaxYearCleaning
+GROUP BY tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID, 
+tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord
+HAVING (((tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord)='Yes'));"
+
+# ---- qry_PickMaxYear_Step3 ----
+qry_PickMaxYear_Step3 <- "
+UPDATE tmp_NearCompletersWithMultiCredentials_MaxYearCleaning 
+SET tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use = 'Yes'
+FROM tmp_NearCompletersWithMultiCredentials_MaxYearCleaning
+INNER JOIN tmp_MaxAwardYearCleaning_MaxID 
+ON (tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord = tmp_MaxAwardYearCleaning_MaxID.Dup_STQUID_UseThisRecord) 
+AND (tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID = tmp_MaxAwardYearCleaning_MaxID.MaxOfID) 
+AND (tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID = tmp_MaxAwardYearCleaning_MaxID.coci_STQU_ID);"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step7 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step7 <- "
+UPDATE tmp_NearCompletersWithMultiCredentials_MaxYearCleaning
+SET tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use = 'Yes'
+FROM tmp_MaxAwardYearCleaning 
+INNER JOIN tmp_NearCompletersWithMultiCredentials_MaxYearCleaning 
+ON (tmp_MaxAwardYearCleaning.MaxOfPSI_AWARD_SCHOOL_YEAR = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.PSI_AWARD_SCHOOL_YEAR) 
+AND (tmp_MaxAwardYearCleaning.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID);"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step8 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step8 <-
+  "SELECT tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID, 
+Max(tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID) AS MaxOfID, 
+tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord 
+INTO tmp_MaxAwardYearCleaning_MaxID
+FROM tmp_NearCompletersWithMultiCredentials_MaxYearCleaning
+GROUP BY tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID, 
+tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord
+HAVING (((tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord)='Yes'));"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step10 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step10 <- "
+UPDATE NearCompleters_in_STP_Credential_Step1 
+SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = 'Yes'
+FROM NearCompleters_in_STP_Credential_Step1 
+INNER JOIN tmp_NearCompletersWithMultiCredentials_MaxYearCleaning 
+ON (NearCompleters_in_STP_Credential_Step1.ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID) 
+AND (NearCompleters_in_STP_Credential_Step1.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID) 
+WHERE (((tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use)='Yes'));"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step11 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step11 <-
+  "UPDATE tmp_MaxAwardYear
+  SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = 'Yes'
+FROM tmp_MaxAwardYear
+INNER JOIN NearCompleters_in_STP_Credential_Step1 
+ON (tmp_MaxAwardYear.MaxOfPSI_AWARD_SCHOOL_YEAR = NearCompleters_in_STP_Credential_Step1.PSI_AWARD_SCHOOL_YEAR) 
+AND (tmp_MaxAwardYear.coci_STQU_ID = NearCompleters_in_STP_Credential_Step1.coci_STQU_ID) 
+WHERE (((NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use) Is Null) 
+AND ((tmp_MaxAwardYear.Ignore) Is Null));"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step13 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step13 <- "
+UPDATE T_DACSO_NearCompleters 
+SET T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO = [NearCompleters_in_STP_Credential_Step1].[STP_Credential_Awarded_Before_DACSO], 
+    T_DACSO_NearCompleters.STP_Credential_Awarded_After_DACSO = [NearCompleters_in_STP_Credential_Step1].[STP_Credential_Awarded_After_DACSO]
+FROM T_DACSO_NearCompleters
+INNER JOIN NearCompleters_in_STP_Credential_Step1 
+ON T_DACSO_NearCompleters.coci_STQU_ID = NearCompleters_in_STP_Credential_Step1.coci_STQU_ID 
+WHERE (((NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use)='Yes'));"
+
+# ---- qry_PickMaxYear_step4 ----
+qry_PickMaxYear_step4 <- "
+UPDATE tmp_NearCompletersWithMultiCredentials_Cleaning 
+SET tmp_NearCompletersWithMultiCredentials_Cleaning.DupUseThisRecordMaxYear = 'Yes'
+FROM tmp_NearCompletersWithMultiCredentials_Cleaning 
+INNER JOIN tmp_MaxAwardYearCleaning_MaxID 
+ON (tmp_NearCompletersWithMultiCredentials_Cleaning.ID = tmp_MaxAwardYearCleaning_MaxID.MaxOfID) 
+AND (tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID = tmp_MaxAwardYearCleaning_MaxID.coci_STQU_ID);"
+
+
+# ---- qry_PickMaxYear_step5 ----
+qry_PickMaxYear_step5 <- "
+UPDATE tmp_NearCompletersWithMultiCredentials_Cleaning  
+SET tmp_NearCompletersWithMultiCredentials_Cleaning.Max_Award_School_Year = Null
+FROM tmp_NearCompletersWithMultiCredentials_Cleaning 
+INNER JOIN tmp_MaxAwardYearCleaning_MaxID 
+ON tmp_NearCompletersWithMultiCredentials_Cleaning.coci_STQU_ID = tmp_MaxAwardYearCleaning_MaxID.coci_STQU_ID
+WHERE (((tmp_NearCompletersWithMultiCredentials_Cleaning.Max_Award_School_Year)='Yes') 
+AND ((tmp_NearCompletersWithMultiCredentials_Cleaning.DupUseThisRecordMaxYear) Is Null));"
+
+
+# ---- qry_Update_DupStqu_ID_UseThisRecord2 ----
+qry_Update_DupStqu_ID_UseThisRecord2 <- "
+UPDATE DACSO_Matching_STP_Credential_PEN 
+SET DACSO_Matching_STP_Credential_PEN.Dup_STQUID_UseThisRecord = 'Yes'
+FROM DACSO_Matching_STP_Credential_PEN 
+INNER JOIN tmp_NearCompletersWithMultiCredentials_MaxYearCleaning 
+ON (tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID = DACSO_Matching_STP_Credential_PEN.ID) 
+AND (DACSO_Matching_STP_Credential_PEN.COCI_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.COCI_STQU_ID)
+WHERE (((tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use)='Yes'));"
+
+# ---- qry_Update_Final_Record_To_Use_NearCompletersDups ----
+qry_Update_Final_Record_To_Use_NearCompletersDups <- "
+UPDATE NearCompleters_in_STP_Credential_Step1 
+SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use
+FROM NearCompleters_in_STP_Credential_Step1 
+INNER JOIN tmp_NearCompletersWithMultiCredentials_MaxYearCleaning 
+ON (NearCompleters_in_STP_Credential_Step1.ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID) 
+AND (NearCompleters_in_STP_Credential_Step1.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID)"
+
+# ---- qry_NearCompleters_MultiCdtls_Cleaning_Step12 ----
+qry_NearCompleters_MultiCdtls_Cleaning_Step12 <-
+  "UPDATE NearCompleters_in_STP_Credential_Step1 
+SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = 'Yes'
+WHERE (((NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use) Is Null) 
+AND ((NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials) Is Null));"
+
+# ---- qry_Update_Final_STP_Cred_Before_or_After_Step1 ----
+qry_Update_Final_STP_Cred_Before_or_After_Step1 <- "
+UPDATE T_DACSO_NearCompleters 
+SET T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO_FINAL = NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_Before_DACSO, 
+    T_DACSO_NearCompleters.STP_Credential_Awarded_After_DACSO_FINAL  = NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_After_DACSO
+FRoM T_DACSO_NearCompleters 
+INNER JOIN NearCompleters_in_STP_Credential_Step1 
+ON T_DACSO_NearCompleters.coci_STQU_ID = NearCompleters_in_STP_Credential_Step1.coci_STQU_ID 
+WHERE (((NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use)='Yes'));"
+
+# ---- qry_update_Has_STP_Credential ----
+qry_update_Has_STP_Credential <- "
+UPDATE T_DACSO_DATA_Part_1_TempSelection 
+SET T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential = 'Yes'
+FROM T_DACSO_DATA_Part_1_TempSelection 
+INNER JOIN T_DACSO_NearCompleters 
+ON T_DACSO_DATA_Part_1_TempSelection.coci_STQU_ID = T_DACSO_NearCompleters.coci_STQU_ID 
+WHERE (((T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO)='Yes')) 
+OR (((T_DACSO_NearCompleters.STP_Credential_Awarded_After_DACSO)='Yes'));"
+
+# ---- qry_update_Grad_Status_Factoring_in_STP_step1 ----
+qry_update_Grad_Status_Factoring_in_STP_step1 <- "
+UPDATE T_DACSO_DATA_Part_1_TempSelection 
+SET T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP = T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group;"
+
+# ----  qry_update_Grad_Status_Factoring_in_STP_step2 ----
+qry_update_Grad_Status_Factoring_in_STP_step2 <- "
+UPDATE T_DACSO_DATA_Part_1_TempSelection 
+SET T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP = '1'
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP)='3') 
+AND ((T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential)='Yes'));"
+
+# ---- qry99_Investigate_Near_Completes_vs_Graduates_by_Year  ----
+qry99_Investigate_Near_Completes_vs_Graduates_by_Year <-
+  "select COSC_GRAD_STATUS_LGDS_CD_Group, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
+FROM
+(
+SELECT COSC_GRAD_STATUS_LGDS_CD_Group, COCI_STQU_ID , COCI_SUBM_CD 
+FROM T_DACSO_DATA_Part_1_TempSelection
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group) Is Not Null) 
+AND ((T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)>=17 
+And (T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)<=64))
+) As P
+PIVOT (
+  Count(COCI_STQU_ID) 
+  FOR COCI_SUBM_CD 
+    IN([C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23])
+  ) AS PT;"
+
+
+# ---- qry99_GradStatus_Factoring_in_STP_Credential_by_Year ----
+qry99_GradStatus_Factoring_in_STP_Credential_by_Year <- "
+select Grad_Status_Factoring_in_STP, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
+FROM
+(
+SELECT T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP, COCI_SUBM_CD
+FROM T_DACSO_DATA_Part_1_TempSelection
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP) Is Not Null) 
+AND ((T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)>=17 
+And (T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)<=64))
+) As P
+PIVOT (
+  Count(COCI_SUBM_CD) 
+  FOR COCI_SUBM_CD 
+    IN([C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23])
+) AS PT;"
+
+# ---- qry99_GradStatus_byCred_by_Year_Age_At_Grad ----
+qry99_GradStatus_byCred_by_Year_Age_At_Grad <- "
+select PSSM_Credential,PSSM_Credential_Name,COSC_GRAD_STATUS_LGDS_CD_Group, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
+FROM
+(
+SELECT T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, 
+T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, 
+T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group,
+COCI_SUBM_CD 
+FROM (tbl_Age INNER JOIN (T_DACSO_DATA_Part_1_TempSelection 
+INNER JOIN tmp_tbl_Age ON T_DACSO_DATA_Part_1_TempSelection.coci_STQU_ID = tmp_tbl_Age.COSC_STQU_ID) 
+  ON tbl_Age.Age = tmp_tbl_Age.Age_At_Grad) 
+--INNER JOIN agegrouplookup 
+--  ON tbl_Age.Age_Group = agegrouplookup.Age_Group
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group) Is Not Null)) 
+AND ((tmp_tbl_Age.Age_At_Grad)>=17 And (tmp_tbl_Age.Age_At_Grad)<=64)
+) As P
+PIVOT (
+  Count(COCI_SUBM_CD) 
+  FOR COCI_SUBM_CD 
+    IN([C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23])
+) AS PT;"
+
+# ---- qry99_GradStatus_Factoring_in_STP_byCred_by_Year_Age_At_Grad ----
+qry99_GradStatus_Factoring_in_STP_byCred_by_Year_Age_At_Grad <-
+  "select PSSM_Credential,PSSM_Credential_Name,Grad_Status_Factoring_in_STP, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
+FROM(
+SELECT T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, 
+T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, 
+T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP,
+COCI_SUBM_CD 
+FROM (tbl_Age INNER JOIN (T_DACSO_DATA_Part_1_TempSelection 
+INNER JOIN tmp_tbl_Age ON T_DACSO_DATA_Part_1_TempSelection.coci_STQU_ID = tmp_tbl_Age.COSC_STQU_ID) 
+  ON tbl_Age.Age = tmp_tbl_Age.Age_At_Grad) 
+--INNER JOIN agegrouplookup 
+--  ON tbl_Age.Age_Group = cast(agegrouplookup.Age_Group as float)
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP) Is Not Null)) 
+AND ((tmp_tbl_Age.Age_At_Grad)>=17 
+And (tmp_tbl_Age.Age_At_Grad)<=64)
+) As P
+PIVOT (
+  Count(COCI_SUBM_CD) 
+  FOR COCI_SUBM_CD 
+    IN([C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23])
+) AS PT;"
+
+# ---- qry_details_of_STP_Credential_Matching  ----
+qry_details_of_STP_Credential_Matching <-
+  "SELECT T_DACSO_DATA_Part_1_TempSelection.coci_SUBM_CD, 
+T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group, 
+T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP, Count(*) AS Expr1
+FROM T_DACSO_DATA_Part_1_TempSelection
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)>=17 
+And (T_DACSO_DATA_Part_1_TempSelection.Age_At_Grad)<=64))
+GROUP BY T_DACSO_DATA_Part_1_TempSelection.coci_SUBM_CD, 
+T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group, 
+T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP;"
+
+# ---- qry99_Near_completes_total_by_CIP4  ----
+qry99_Near_completes_total_by_CIP4 <- "
+SELECT     AgeGroupLookup.Age_Group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.LCIP4_CRED, 
+                         T_DACSO_DATA_Part_1.LCP4_CD, T_DACSO_DATA_Part_1.LCP4_CIP_4DIGITS_NAME, COUNT(*) AS Count
+INTO NearCompleters_CIP4
+FROM         T_DACSO_DATA_Part_1 
+INNER JOIN AgeGroupLookup 
+ON T_DACSO_DATA_Part_1.Age_At_Grad >= AgeGroupLookup.Lower_Bound 
+AND T_DACSO_DATA_Part_1.Age_At_Grad <= AgeGroupLookup.Upper_Bound 
+LEFT OUTER JOIN CredentialRank ON T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE (T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group = '3') 
+AND (T_DACSO_DATA_Part_1.COCI_SUBM_CD IN ('C_Outc19', 'C_Outc20'))
+GROUP BY AgeGroupLookup.Age_Group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.LCIP4_CRED, 
+                         T_DACSO_DATA_Part_1.LCP4_CD, T_DACSO_DATA_Part_1.LCP4_CIP_4DIGITS_NAME
+ORDER BY AgeGroupLookup.Age_Group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name"
+
+# ---- qry_Make_NearCompleters_CIP4_CombinedCred ----
+qry_Make_NearCompleters_CIP4_CombinedCred <- "
+SELECT nearcompleters_cip4.age_group,
+      combine_creds.combined_cred_name,
+      nearcompleters_cip4.lcip4_cred,
+      nearcompleters_cip4.lcp4_cd,
+      nearcompleters_cip4.lcp4_cip_4digits_name,
+      Sum(nearcompleters_cip4.count) AS CombinedCredCount
+INTO   nearcompleters_cip4_combinedcred
+FROM   nearcompleters_cip4
+INNER JOIN combine_creds
+ON nearcompleters_cip4.prgm_credential_awarded_name =
+  combine_creds.prgm_credential_awarded_name
+WHERE  (( ( combine_creds.use_in_pssm_2017_18 ) = 'Yes' ))
+GROUP  BY nearcompleters_cip4.age_group,
+    combine_creds.combined_cred_name,
+    nearcompleters_cip4.lcip4_cred,
+    nearcompleters_cip4.lcp4_cd,
+    nearcompleters_cip4.lcp4_cip_4digits_name;"
+
+# ---- qry99_Near_completes_total_with_STP_Credential_ByCIP4 ----
+qry99_Near_completes_total_with_STP_Credential_ByCIP4 <-
+  "SELECT     AgeGroupLookup.age_group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, COUNT(*) AS Count, 
+                      T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential, lcip4_cred,
+      lcp4_cd,
+     lcp4_cip_4digits_name
+INTO NearCompleters_CIP4_with_STP_Credential
+FROM         T_DACSO_DATA_Part_1 INNER JOIN
+                      AgeGroupLookup ON T_DACSO_DATA_Part_1.Age_At_Grad >= AgeGroupLookup.lower_bound AND 
+                      T_DACSO_DATA_Part_1.Age_At_Grad <= AgeGroupLookup.upper_bound INNER JOIN
+                      T_DACSO_DATA_Part_1_TempSelection ON T_DACSO_DATA_Part_1.COCI_STQU_ID = T_DACSO_DATA_Part_1_TempSelection.COCI_STQU_ID LEFT OUTER JOIN
+                      CredentialRank ON T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE     (T_DACSO_DATA_Part_1.COCI_SUBM_CD IN ('C_Outc19', 'C_Outc20'))
+GROUP BY AgeGroupLookup.age_group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential,  lcip4_cred,
+      lcp4_cd,
+     lcp4_cip_4digits_name
+HAVING      (T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential = 'Yes')
+ORDER BY AgeGroupLookup.age_group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name"
+
+# ---- qry_Make_NearCompleters_CIP4_With_STP_CombinedCred ----
+qry_Make_NearCompleters_CIP4_With_STP_CombinedCred <- "
+SELECT nearcompleters_cip4_with_stp_credential.age_group,
+combine_creds.combined_cred_name,
+nearcompleters_cip4_with_stp_credential.lcip4_cred,
+nearcompleters_cip4_with_stp_credential.lcp4_cd,
+nearcompleters_cip4_with_stp_credential.lcp4_cip_4digits_name,
+Sum(nearcompleters_cip4_with_stp_credential.count) AS CombinedCredCount,
+nearcompleters_cip4_with_stp_credential.has_stp_credential
+INTO NearCompleters_CIP4_With_STP_CombinedCred
+FROM   nearcompleters_cip4_with_stp_credential
+INNER JOIN combine_creds
+ON
+nearcompleters_cip4_with_stp_credential.prgm_credential_awarded_name
+= combine_creds.prgm_credential_awarded_name
+WHERE  (( ( combine_creds.use_in_pssm_2017_18) = 'Yes' ))
+GROUP  BY nearcompleters_cip4_with_stp_credential.age_group,
+combine_creds.combined_cred_name,
+nearcompleters_cip4_with_stp_credential.lcip4_cred,
+nearcompleters_cip4_with_stp_credential.lcp4_cd,
+nearcompleters_cip4_with_stp_credential.lcp4_cip_4digits_name,
+nearcompleters_cip4_with_stp_credential.has_stp_credential;"
+
+# ---- qry99_Completers_agg_factoring_in_STP_Credential_by_CIP4 ----
+qry99_Completers_agg_factoring_in_STP_Credential_by_CIP4 <-
+  "SELECT agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Expr1,
+       t_dacso_data_part_1.lcip4_cred,
+       t_dacso_data_part_1.lcp4_cd,
+       t_dacso_data_part_1.lcp4_cip_4digits_name
+INTO   completersfactoringinstp_cip4
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       LEFT OUTER JOIN credentialrank AS CredentialRank_1
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       CredentialRank_1.psi_credential_category
+WHERE  ( t_dacso_data_part_1.grad_status_factoring_in_stp = '1' )
+       AND ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+       AND ( t_dacso_data_part_1.age_at_grad >= 17 )
+       AND ( t_dacso_data_part_1.age_at_grad <= 64 )
+GROUP  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          agegrouplookup.age_group,
+          t_dacso_data_part_1.lcip4_cred,
+          t_dacso_data_part_1.lcp4_cd,
+          t_dacso_data_part_1.lcp4_cip_4digits_name
+ORDER  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name"
+
+# ---- qry_Make_CompletersFactoringInSTP_CIP4_CombinedCred  ----
+qry_Make_CompletersFactoringInSTP_CIP4_CombinedCred <- "
+SELECT completersfactoringinstp_cip4.age_group,
+        combine_creds.combined_cred_name,
+        completersfactoringinstp_cip4.lcip4_cred_cleaned,
+        completersfactoringinstp_cip4.lcp4_cd,
+        completersfactoringinstp_cip4.lcp4_cip_4digits_name,
+        Sum(completersfactoringinstp_cip4.expr1) AS CombinedCredCount
+INTO CompletersFactoringInSTP_CIP4_CombinedCred
+FROM   completersfactoringinstp_cip4
+INNER JOIN combine_creds
+ON completersfactoringinstp_cip4.prgm_credential_awarded_name = combine_creds.prgm_credential_awarded_name
+WHERE  (( ( combine_creds.use_in_pssm_2017_18) = 'Yes' ))
+GROUP  BY completersfactoringinstp_cip4.age_group,
+        combine_creds.combined_cred_name,
+        completersfactoringinstp_cip4.lcip4_cred_cleaned,
+        completersfactoringinstp_cip4.lcp4_cd,
+        completersfactoringinstp_cip4.lcp4_cip_4digits_name;"
+
+# ---- qry99_Completers_agg_by_gender ----
+qry99_Completers_agg_by_gender <-
+  "SELECT     T_DACSO_DATA_Part_1.tpid_lgnd_cd, agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.prgm_credential_awarded_name, COUNT(*)
+AS Count
+INTO Completers_agg_by_gender
+FROM         T_DACSO_DATA_Part_1 
+INNER JOIN agegrouplookup
+ON T_DACSO_DATA_Part_1.Age_At_Grad >= agegrouplookup.lower_bound 
+AND T_DACSO_DATA_Part_1.Age_At_Grad <= agegrouplookup.upper_bound 
+LEFT OUTER JOIN CredentialRank
+ON T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE     (T_DACSO_DATA_Part_1.COCI_SUBM_CD IN ('C_Outc19', 'C_Outc20')) 
+AND (T_DACSO_DATA_Part_1.Age_At_Grad >= 17) 
+AND (T_DACSO_DATA_Part_1.Age_At_Grad <= 64) 
+AND (T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group = '1')
+GROUP BY agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.TPID_LGND_CD
+HAVING      (T_DACSO_DATA_Part_1.TPID_LGND_CD <> '0')
+ORDER BY T_DACSO_DATA_Part_1.TPID_LGND_CD Desc, 
+agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name"
+
+# HISTORICAL ----
+# ---- qry99_Completers_agg_by_gender_age_year ----
+qry99_Completers_agg_by_gender_age_year <-
+  "SELECT     T_DACSO_DATA_Part_1.coci_subm_cd, T_DACSO_DATA_Part_1.tpid_lgnd_cd, agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.prgm_credential_awarded_name, COUNT(*)
+AS Count
+INTO Completers_agg_by_gender_age_year
+FROM         T_DACSO_DATA_Part_1 
+INNER JOIN agegrouplookup
+ON T_DACSO_DATA_Part_1.Age_At_Grad >= agegrouplookup.lower_bound 
+AND T_DACSO_DATA_Part_1.Age_At_Grad <= agegrouplookup.upper_bound 
+LEFT OUTER JOIN CredentialRank
+ON T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name = CredentialRank.PSI_CREDENTIAL_CATEGORY
+WHERE     
+    (T_DACSO_DATA_Part_1.Age_At_Grad >= 17) 
+AND (T_DACSO_DATA_Part_1.Age_At_Grad <= 64) 
+AND (T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group = '1')
+GROUP BY 
+T_DACSO_DATA_Part_1.COCI_SUBM_CD,
+agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, 
+agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.TPID_LGND_CD
+HAVING      (T_DACSO_DATA_Part_1.TPID_LGND_CD <> '0')
+ORDER BY T_DACSO_DATA_Part_1.TPID_LGND_CD Desc, 
+agegrouplookup.age_group, 
+T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name"
+
+# ---- qry99_Near_completes_total_byGender ----
+qry99_Near_completes_total_byGender_year <- "
+SELECT t_dacso_data_part_1.coci_subm_cd, 
+  t_dacso_data_part_1.tpid_lgnd_cd,
+       agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count
+INTO Near_completes_total_byGender_year
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.cosc_grad_status_lgds_cd_group = '3' )
+GROUP  BY agegrouplookup.age_group, t_dacso_data_part_1.coci_subm_cd,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1.tpid_lgnd_cd
+HAVING ( t_dacso_data_part_1.tpid_lgnd_cd <> '0' )
+ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
+          agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+# ---- qry99_Near_completes_total_with_STP_Credential_by_Gender ----
+qry99_Near_completes_total_with_STP_Credential_by_Gender_year <- "
+SELECT t_dacso_data_part_1.tpid_lgnd_cd,
+t_dacso_data_part_1.coci_subm_cd,
+       agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count,
+       t_dacso_data_part_1_tempselection.has_stp_credential
+INTO Near_completes_total_with_STP_Credential_by_Gender_year
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       INNER JOIN t_dacso_data_part_1_tempselection
+               ON t_dacso_data_part_1.coci_stqu_id =
+                  t_dacso_data_part_1_tempselection.coci_stqu_id
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+GROUP  BY agegrouplookup.age_group,
+t_dacso_data_part_1.coci_subm_cd,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1_tempselection.has_stp_credential,
+          t_dacso_data_part_1.tpid_lgnd_cd
+HAVING ( t_dacso_data_part_1_tempselection.has_stp_credential = 'Yes' )
+       AND ( t_dacso_data_part_1.tpid_lgnd_cd <> '0' )
+ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
+          agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+# END HISTORICAL ----
+
+# ---- qry99_Completers_agg_byCIP4----
+qry99_Completers_agg_byCIP4 <- "
+SELECT AgeGroupLookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Expr1,
+       t_dacso_data_part_1.lcp4_cd,
+       t_dacso_data_part_1.lcp4_cip_4digits_name,
+       t_dacso_data_part_1.lcip4_cred
+INTO   completerscip4
+FROM   t_dacso_data_part_1
+       INNER JOIN AgeGroupLookup
+               ON t_dacso_data_part_1.age_at_grad >= AgeGroupLookup.lower_bound
+              AND t_dacso_data_part_1.age_at_grad <= AgeGroupLookup.upper_bound
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name = CredentialRank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+       AND ( t_dacso_data_part_1.age_at_grad >= 17 )
+       AND ( t_dacso_data_part_1.age_at_grad <= 64 )
+       AND ( t_dacso_data_part_1.cosc_grad_status_lgds_cd_group = '1' )
+GROUP  BY AgeGroupLookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1.lcp4_cd,
+          t_dacso_data_part_1.lcp4_cip_4digits_name,
+          t_dacso_data_part_1.lcip4_cred
+ORDER  BY AgeGroupLookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+
+# ---- qry_Make_Completers_CIP4_CombinedCred ----
+qry_Make_Completers_CIP4_CombinedCred <-
+  "SELECT completerscip4.age_group,
+        combine_creds.combined_cred_name,
+        completerscip4.lcip4_cred_cleaned,
+        completerscip4.lcp4_cd,
+        completerscip4.lcp4_cip_4digits_name,
+        Sum(completerscip4.expr1) AS CombinedCredCount
+INTO Completers_CIP4_CombinedCred
+FROM completerscip4
+INNER JOIN combine_creds
+ON completerscip4.prgm_credential_awarded_name = combine_creds.prgm_credential_awarded_name
+WHERE  (( ( combine_creds.[use_in_pssm_2017_18] ) = 'Yes' ))
+GROUP  BY completerscip4.age_group,
+        combine_creds.combined_cred_name,
+        completerscip4.lcip4_cred_cleaned,
+        completerscip4.lcp4_cd,
+        completerscip4.lcp4_cip_4digits_name;"
+
+# ---- qry_NearCompletersByCIP4CombinedCred ----
+qry_NearCompletersByCIP4CombinedCred <-
+  "SELECT NearCompleters_CIP4_CombinedCred.age_group, 
+NearCompleters_CIP4_CombinedCred.Combined_Cred_Name, 
+NearCompleters_CIP4_CombinedCred.LCIP4_CRED, 
+NearCompleters_CIP4_CombinedCred.LCP4_CD, 
+NearCompleters_CIP4_CombinedCred.LCP4_CIP_4DIGITS_NAME, 
+NearCompleters_CIP4_CombinedCred.CombinedCredCount AS [Count], 
+NearCompleters_CIP4_CombinedCred_with_STP_Credential.CombinedCredCount AS NearCompWithSTPCred
+FROM NearCompleters_CIP4_CombinedCred 
+LEFT JOIN NearCompleters_CIP4_CombinedCred_with_STP_Credential 
+ON (NearCompleters_CIP4_CombinedCred.LCIP4_CRED = NearCompleters_CIP4_CombinedCred_with_STP_Credential.LCIP4_CRED) AND (NearCompleters_CIP4_CombinedCred.LCP4_CIP_4DIGITS_NAME = NearCompleters_CIP4_CombinedCred_with_STP_Credential.LCP4_CIP_4DIGITS_NAME) AND (NearCompleters_CIP4_CombinedCred.LCP4_CD = NearCompleters_CIP4_CombinedCred_with_STP_Credential.LCP4_CD) AND (NearCompleters_CIP4_CombinedCred.age_group = NearCompleters_CIP4_CombinedCred_with_STP_Credential.age_group)
+GROUP BY NearCompleters_CIP4_CombinedCred.age_group, NearCompleters_CIP4_CombinedCred.Combined_Cred_Name, NearCompleters_CIP4_CombinedCred.LCIP4_CRED, 
+NearCompleters_CIP4_CombinedCred.LCP4_CD, NearCompleters_CIP4_CombinedCred.LCP4_CIP_4DIGITS_NAME, NearCompleters_CIP4_CombinedCred.CombinedCredCount, NearCompleters_CIP4_CombinedCred_with_STP_Credential.CombinedCredCount;"
+
+
+# ---- qry99_Near_completes_total_by_Gender ----
+qry99_Near_completes_total_byGender <- "
+SELECT t_dacso_data_part_1.tpid_lgnd_cd,
+       agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count
+INTO Near_completes_total_byGender
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.cosc_grad_status_lgds_cd_group = '3' )
+       AND ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+GROUP  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1.tpid_lgnd_cd
+HAVING ( t_dacso_data_part_1.tpid_lgnd_cd <> '0' )
+ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
+          agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+# ---- qry99_Near_completes_total_with_STP_Credential_by_Gender ----
+qry99_Near_completes_total_with_STP_Credential_by_Gender <- "
+SELECT t_dacso_data_part_1.tpid_lgnd_cd,
+       agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count,
+       t_dacso_data_part_1_tempselection.has_stp_credential
+INTO Near_completes_total_with_STP_Credential_by_Gender
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       INNER JOIN t_dacso_data_part_1_tempselection
+               ON t_dacso_data_part_1.coci_stqu_id =
+                  t_dacso_data_part_1_tempselection.coci_stqu_id
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+GROUP  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1_tempselection.has_stp_credential,
+          t_dacso_data_part_1.tpid_lgnd_cd
+HAVING ( t_dacso_data_part_1_tempselection.has_stp_credential = 'Yes' )
+       AND ( t_dacso_data_part_1.tpid_lgnd_cd <> '0' )
+ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
+          agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+# ---- qry99_Near_completes_factoring_in_STP_total ----
+qry99_Near_completes_factoring_in_STP_total <- "
+SELECT agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.grad_status_factoring_in_stp = '3' )
+       AND ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+GROUP  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name
+ORDER  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+# ---- qry99_Completers_agg_factoring_in_STP_Credential ----
+qry99_Completers_agg_factoring_in_STP_Credential <- "
+SELECT agegrouplookup_1.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Expr1
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup AS agegrouplookup_1
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup_1.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup_1.upper_bound
+       LEFT OUTER JOIN credentialrank AS CredentialRank_1
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       CredentialRank_1.psi_credential_category
+WHERE  ( t_dacso_data_part_1.grad_status_factoring_in_stp = '1' )
+       AND ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20')
+           )
+       AND ( t_dacso_data_part_1.age_at_grad >= 17 )
+       AND ( t_dacso_data_part_1.age_at_grad <= 64 )
+GROUP  BY agegrouplookup_1.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          agegrouplookup_1.age_group
+ORDER  BY agegrouplookup_1.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name;"
+
+
+# ---- qry99_Near_completes_total_by_CIP4_TTRAIN ----
+qry99_Near_completes_total_by_CIP4_TTRAIN <- "
+SELECT agegrouplookup.age_group,
+t_dacso_data_part_1.prgm_credential_awarded_name,
+Count(*) AS Count,
+t_dacso_data_part_1.lcip4_cred,
+t_dacso_data_part_1.lcp4_cd,
+t_dacso_data_part_1.lcp4_cip_4digits_name,
+t_dacso_data_part_1.ttrain,
+t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+INTO Near_completes_total_by_CIP4_TTRAIN
+FROM   t_dacso_data_part_1
+INNER JOIN agegrouplookup
+ON t_dacso_data_part_1.age_at_grad >= agegrouplookup.lower_bound
+AND t_dacso_data_part_1.age_at_grad <= agegrouplookup.upper_bound
+LEFT OUTER JOIN credentialrank
+ON t_dacso_data_part_1.prgm_credential_awarded_name = credentialrank.psi_credential_category
+WHERE  (t_dacso_data_part_1.cosc_grad_status_lgds_cd_group = '3')
+AND (t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20'))
+GROUP  BY agegrouplookup.age_group,
+t_dacso_data_part_1.prgm_credential_awarded_name,
+t_dacso_data_part_1.lcip4_cred,
+t_dacso_data_part_1.lcp4_cd,
+t_dacso_data_part_1.lcp4_cip_4digits_name,
+t_dacso_data_part_1.ttrain,
+t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+ORDER  BY agegrouplookup.age_group,
+t_dacso_data_part_1.prgm_credential_awarded_name"
+
+# ---- qry99_Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN ----
+qry99_Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN <- "
+SELECT agegrouplookup.age_group,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count,
+       t_dacso_data_part_1_tempselection.has_stp_credential,
+       t_dacso_data_part_1.lcip4_cred,
+       t_dacso_data_part_1.lcp4_cd,
+       t_dacso_data_part_1.lcp4_cip_4digits_name,
+       t_dacso_data_part_1.ttrain,
+       t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+INTO Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       INNER JOIN t_dacso_data_part_1_tempselection
+               ON t_dacso_data_part_1.coci_stqu_id =
+                  t_dacso_data_part_1_tempselection.coci_stqu_id
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+WHERE  ( t_dacso_data_part_1.coci_subm_cd IN ('C_Outc19', 'C_Outc20') )
+GROUP  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1_tempselection.has_stp_credential,
+          t_dacso_data_part_1.lcip4_cred,
+          t_dacso_data_part_1.lcp4_cd,
+          t_dacso_data_part_1.lcp4_cip_4digits_name,
+          t_dacso_data_part_1.ttrain,
+          t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+HAVING ( t_dacso_data_part_1_tempselection.has_stp_credential = 'Yes' )
+ORDER  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name"
+
+# ---- qry99_Near_completes_program_dist_count ----
+qry99_Near_completes_program_dist_count <-
+  "SELECT t_pssm_projection_cred_grp.pssm_credential,
+       cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' +
+       t_pssm_projection_cred_grp.pssm_credential AS PSSM_CRED,
+       near_completes_total_by_cip4_ttrain.age_group,
+       near_completes_total_by_cip4_ttrain.lcip4_cred,
+       near_completes_total_by_cip4_ttrain.lcp4_cd,
+       near_completes_total_by_cip4_ttrain.lcp4_cip_4digits_name,
+       near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group,
+       near_completes_total_by_cip4_ttrain.ttrain,
+       Sum(near_completes_total_by_cip4_ttrain.count) AS Count,
+       Sum(Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0)) AS
+          Near_completers_from_C_Outc19_20_with_earlier_or_later_STP,
+       near_completes_total_by_cip4_ttrain.count - 
+          Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0) AS
+          Near_completers_STP_Credentials
+INTO T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN
+FROM   near_completes_total_by_cip4_ttrain
+INNER JOIN t_pssm_projection_cred_grp
+  ON   near_completes_total_by_cip4_ttrain.prgm_credential_awarded_name = t_pssm_projection_cred_grp.pssm_projection_credential
+LEFT OUTER JOIN  near_completes_total_with_stp_credential_bycip4_ttrain
+  ON   near_completes_total_by_cip4_ttrain.ttrain = near_completes_total_with_stp_credential_bycip4_ttrain.ttrain
+  AND  near_completes_total_by_cip4_ttrain.age_group = near_completes_total_with_stp_credential_bycip4_ttrain.age_group
+  AND  near_completes_total_by_cip4_ttrain.prgm_credential_awarded_name = near_completes_total_with_stp_credential_bycip4_ttrain.prgm_credential_awarded_name
+  AND  near_completes_total_by_cip4_ttrain.lcip4_cred = near_completes_total_with_stp_credential_bycip4_ttrain.lcip4_cred
+GROUP  BY near_completes_total_by_cip4_ttrain.age_group,
+      near_completes_total_by_cip4_ttrain.lcip4_cred,
+      near_completes_total_by_cip4_ttrain.lcp4_cd,
+      near_completes_total_by_cip4_ttrain.lcp4_cip_4digits_name,
+      near_completes_total_by_cip4_ttrain.ttrain,
+      t_pssm_projection_cred_grp.pssm_credential,
+      '3 - ' + t_pssm_projection_cred_grp.pssm_credential,
+      near_completes_total_by_cip4_ttrain.count - 
+      Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0),
+        near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group,
+      cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' + t_pssm_projection_cred_grp.pssm_credential;"
+
+
+# ---- HISTORICAL ttrain tables ----
+# ---- qry99_Near_completes_total_by_CIP4_TTRAIN_history ----
+qry99_Near_completes_total_by_CIP4_TTRAIN_history <- "
+SELECT agegrouplookup.age_group, t_dacso_data_part_1.coci_subm_cd,
+t_dacso_data_part_1.prgm_credential_awarded_name,
+Count(*) AS Count,
+t_dacso_data_part_1.lcip4_cred,
+t_dacso_data_part_1.lcp4_cd,
+t_dacso_data_part_1.lcp4_cip_4digits_name,
+t_dacso_data_part_1.ttrain,
+t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+INTO Near_completes_total_by_CIP4_TTRAIN
+FROM   t_dacso_data_part_1
+INNER JOIN agegrouplookup
+ON t_dacso_data_part_1.age_at_grad >= agegrouplookup.lower_bound
+AND t_dacso_data_part_1.age_at_grad <= agegrouplookup.upper_bound
+LEFT OUTER JOIN credentialrank
+ON t_dacso_data_part_1.prgm_credential_awarded_name = credentialrank.psi_credential_category
+WHERE  (t_dacso_data_part_1.cosc_grad_status_lgds_cd_group = '3')
+GROUP  BY agegrouplookup.age_group,
+t_dacso_data_part_1.coci_subm_cd,
+t_dacso_data_part_1.prgm_credential_awarded_name,
+t_dacso_data_part_1.lcip4_cred,
+t_dacso_data_part_1.lcp4_cd,
+t_dacso_data_part_1.lcp4_cip_4digits_name,
+t_dacso_data_part_1.ttrain,
+t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+ORDER  BY agegrouplookup.age_group,
+t_dacso_data_part_1.prgm_credential_awarded_name"
+
+# ---- qry99_Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN ----
+
+qry99_Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN_history <- "
+SELECT agegrouplookup.age_group, t_dacso_data_part_1.coci_subm_cd,
+       t_dacso_data_part_1.prgm_credential_awarded_name,
+       Count(*) AS Count,
+       t_dacso_data_part_1_tempselection.has_stp_credential,
+       t_dacso_data_part_1.lcip4_cred,
+       t_dacso_data_part_1.lcp4_cd,
+       t_dacso_data_part_1.lcp4_cip_4digits_name,
+       t_dacso_data_part_1.ttrain,
+       t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+INTO Near_completes_total_with_STP_Credential_ByCIP4_TTRAIN
+FROM   t_dacso_data_part_1
+       INNER JOIN agegrouplookup
+               ON t_dacso_data_part_1.age_at_grad >=
+                  agegrouplookup.lower_bound
+                  AND t_dacso_data_part_1.age_at_grad <=
+                      agegrouplookup.upper_bound
+       INNER JOIN t_dacso_data_part_1_tempselection
+               ON t_dacso_data_part_1.coci_stqu_id =
+                  t_dacso_data_part_1_tempselection.coci_stqu_id
+       LEFT OUTER JOIN credentialrank
+                    ON t_dacso_data_part_1.prgm_credential_awarded_name =
+                       credentialrank.psi_credential_category
+GROUP  BY agegrouplookup.age_group, t_dacso_data_part_1.coci_subm_cd,
+          t_dacso_data_part_1.prgm_credential_awarded_name,
+          t_dacso_data_part_1_tempselection.has_stp_credential,
+          t_dacso_data_part_1.lcip4_cred,
+          t_dacso_data_part_1.lcp4_cd,
+          t_dacso_data_part_1.lcp4_cip_4digits_name,
+          t_dacso_data_part_1.ttrain,
+          t_dacso_data_part_1.cosc_grad_status_lgds_cd_group
+HAVING ( t_dacso_data_part_1_tempselection.has_stp_credential = 'Yes' )
+ORDER  BY agegrouplookup.age_group,
+          t_dacso_data_part_1.prgm_credential_awarded_name"
+
+# ---- qry99_Near_completes_program_dist_count ----
+qry99_Near_completes_program_dist_count_history <-
+  "SELECT t_pssm_projection_cred_grp.pssm_credential,
+       cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' +
+       t_pssm_projection_cred_grp.pssm_credential AS PSSM_CRED,
+       near_completes_total_by_cip4_ttrain.age_group,
+       near_completes_total_by_cip4_ttrain.coci_subm_cd,
+       near_completes_total_by_cip4_ttrain.lcip4_cred,
+       near_completes_total_by_cip4_ttrain.lcp4_cd,
+       near_completes_total_by_cip4_ttrain.lcp4_cip_4digits_name,
+       near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group,
+       near_completes_total_by_cip4_ttrain.ttrain,
+       Sum(near_completes_total_by_cip4_ttrain.count) AS Count,
+       Sum(Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0)) AS
+          Near_completers_from_C_Outc19_20_with_earlier_or_later_STP,
+       near_completes_total_by_cip4_ttrain.count - 
+          Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0) AS
+          Near_completers_STP_Credentials
+INTO T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN_history
+FROM  Near_completes_total_by_CIP4_TTRAIN
+INNER JOIN t_pssm_projection_cred_grp
+  ON   near_completes_total_by_cip4_ttrain.prgm_credential_awarded_name = t_pssm_projection_cred_grp.pssm_projection_credential
+LEFT OUTER JOIN  near_completes_total_with_stp_credential_bycip4_ttrain
+  ON   near_completes_total_by_cip4_ttrain.ttrain = near_completes_total_with_stp_credential_bycip4_ttrain.ttrain
+  AND  near_completes_total_by_cip4_ttrain.age_group = near_completes_total_with_stp_credential_bycip4_ttrain.age_group
+  AND  near_completes_total_by_cip4_ttrain.prgm_credential_awarded_name = near_completes_total_with_stp_credential_bycip4_ttrain.prgm_credential_awarded_name
+  AND  near_completes_total_by_cip4_ttrain.lcip4_cred = near_completes_total_with_stp_credential_bycip4_ttrain.lcip4_cred
+  AND  near_completes_total_by_cip4_ttrain.coci_subm_cd = near_completes_total_with_stp_credential_bycip4_ttrain.coci_subm_cd
+GROUP  BY near_completes_total_by_cip4_ttrain.age_group,
+      near_completes_total_by_cip4_ttrain.coci_subm_cd,
+      near_completes_total_by_cip4_ttrain.lcip4_cred,
+      near_completes_total_by_cip4_ttrain.lcp4_cd,
+      near_completes_total_by_cip4_ttrain.lcp4_cip_4digits_name,
+      near_completes_total_by_cip4_ttrain.ttrain,
+      t_pssm_projection_cred_grp.pssm_credential,
+      '3 - ' + t_pssm_projection_cred_grp.pssm_credential,
+      near_completes_total_by_cip4_ttrain.count - 
+      Isnull(near_completes_total_with_stp_credential_bycip4_ttrain.count, 0),
+        near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group,
+      cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' + t_pssm_projection_cred_grp.pssm_credential;"
+
+
+# ---- END HISTORICAL ----
+
+# ----  NOT USED ----
+# ---- qry_Number_of_NearCompleters_With_STP_Credential_by_Year ----
+qry_Number_of_NearCompleters_With_STP_Credential_by_Year <-
+  "SELECT T_DACSO_NearCompleters.coci_SUBM_CD, Count(*) AS Expr1
+FROM T_DACSO_NearCompleters
+WHERE (((T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO)='Yes')) OR (((T_DACSO_NearCompleters.STP_Credential_Awarded_After_DACSO)='Yes'))
+GROUP BY T_DACSO_NearCompleters.coci_SUBM_CD;"
+
+
+# ---- qry_make_tmp_table_GradStat_step1 ----
+qry_make_tmp_table_GradStat_step1 <- "
+INSERT INTO tmp_tbl_Age_AppendNewYears ( COCI_STQU_ID, COCI_SUBM_CD, BTHDT, ENDDT, COCI_AGE_AT_SURVEY )
+SELECT INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_STQU_ID, INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_SUBM_CD, INFOWARE_CO_COHORT_SAMPLE_2016.BTHDT, INFOWARE_CO_COHORT_SAMPLE_2016.ENDDT, INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_AGE_AT_SURVEY
+FROM INFOWARE_CO_COHORT_SAMPLE_2016 INNER JOIN INFOWARE_SURV_COHORT_COLLECTION_INFO ON INFOWARE_CO_COHORT_SAMPLE_2016.STQU_ID = INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_STQU_ID
+WHERE (((INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_SUBM_CD)='C_Outc16'));"
+
+# ---- qry99_GradStatus_byCred_by_Year_Age_At_Survey ----
+qry99_GradStatus_byCred_by_Year_Age_At_Survey <-
+  "TRANSFORM Count(*) AS Expr1
+SELECT T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP
+FROM (tbl_Age INNER JOIN agegrouplookup ON tbl_Age.Age_Group = agegrouplookup.Age_Group) INNER JOIN (T_DACSO_DATA_Part_1_TempSelection INNER JOIN tmp_tbl_Age ON T_DACSO_DATA_Part_1_TempSelection.coci_STQU_ID = tmp_tbl_Age.COSC_STQU_ID) ON tbl_Age.Age = tmp_tbl_Age.COCI_AGE_AT_SURVEY
+WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP) Is Not Null) AND ((tmp_tbl_Age.COCI_AGE_AT_SURVEY)>=17 And (tmp_tbl_Age.COCI_AGE_AT_SURVEY)<=64))
+GROUP BY T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP
+ORDER BY T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP
+PIVOT T_DACSO_DATA_Part_1_TempSelection.coci_SUBM_CD;"
+
+
+# ---- qry99_Graduates_for_QI ----
+qry99_Graduates_for_QI <-
+  "SELECT T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD, Count(*) AS Expr1
+FROM T_DACSO_DATA_Part_1
+WHERE (((T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)>=17 And (T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)<=64))
+GROUP BY T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD
+HAVING (((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD) Is Not Null) AND ((T_DACSO_DATA_Part_1.coci_SUBM_CD)<>'C_Outc12' And (T_DACSO_DATA_Part_1.coci_SUBM_CD)<>'C_Outc06'))
+ORDER BY T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD;"
+
+
+# ---- qry99_Near_Completes_vs_Graduates_by_Year ----
+qry99_Near_Completes_vs_Graduates_by_Year <-
+  "TRANSFORM Count(*) AS Expr1
+SELECT agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.coci_SUBM_CD
+FROM (T_DACSO_DATA_Part_1 INNER JOIN tbl_Age ON T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY = tbl_Age.Age) INNER JOIN agegrouplookup ON tbl_Age.Age_Group = agegrouplookup.Age_Group
+WHERE (((T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc09' Or (T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc08' Or (T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc10') 
+AND ((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group) Is Not Null) AND ((T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)>=17 And (T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)<=64))
+GROUP BY agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.coci_SUBM_CD
+PIVOT T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group;"
+
+# ---- qry99_Near_Completes_vs_Graduates_by_Year_by_Age ----
+qry99_Near_Completes_vs_Graduates_by_Year_by_Age <-
+  "TRANSFORM Count(*) AS Expr1
+SELECT agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.PSSM_Credential_Name, T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD
+FROM T_DACSO_DATA_Part_1 INNER JOIN (agegrouplookup INNER JOIN tbl_Age ON agegrouplookup.Age_Group = tbl_Age.Age_Group) ON T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY = tbl_Age.Age
+WHERE (((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD) Is Not Null) AND ((T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)>=17 And (T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)<=64))
+GROUP BY agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PSSM_Credential, agegrouplookup.Age_Group, T_DACSO_DATA_Part_1.PSSM_Credential_Name, T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD
+ORDER BY agegrouplookup.Age_Group
+PIVOT T_DACSO_DATA_Part_1.coci_SUBM_CD;"
+
+# ---- qry9999_DACSO_Q006_Occ_by_completion ----
+qry9999_DACSO_Q006_Occ_by_completion <-
+  "SELECT 'DACSO' AS Survey, T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD, tbl_NOC_Skill_Level_Aged_17_34.MINOR_GROUP_CODE, T_Year_Survey_Year.Year_Code, Count(T_DACSO_DATA_Part_1.coci_STQU_ID) AS [Count]
+FROM tbl_NOC_Skill_Level_Aged_17_34 INNER JOIN (T_DACSO_DATA_Part_1 INNER JOIN T_Year_Survey_Year ON T_DACSO_DATA_Part_1.coci_SUBM_CD=T_Year_Survey_Year.SUBM_CD) ON tbl_NOC_Skill_Level_Aged_17_34.UNIT_GROUP_CODE=T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD
+WHERE (((T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD) Is Not Null And (T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD)<>'XXXX') AND ((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD)='1' Or (T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD)='2') AND ((T_DACSO_DATA_Part_1.Weight)<>0 And (T_DACSO_DATA_Part_1.Weight) Is Not Null))
+GROUP BY 'DACSO', T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD, tbl_NOC_Skill_Level_Aged_17_34.MINOR_GROUP_CODE, T_Year_Survey_Year.Year_Code;"
+
+###############################################################################################
+# ---- qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
+qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "SELECT        tblCredential_HighestRank.psi_gender_cleaned, AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+                         tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup + tblCredential_HighestRank.psi_gender_cleaned AS Expr1, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) 
+                         AS Count
+INTO Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs
+FROM            tblCredential_HighestRank INNER JOIN
+                         AgeGroupLookup ON tblCredential_HighestRank.AGE_GROUP_AT_GRAD = AgeGroupLookup.AgeIndex INNER JOIN
+                         Credential_Non_Dup ON tblCredential_HighestRank.id = Credential_Non_Dup.id
+WHERE        (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY = 1) AND (Credential_Non_Dup.OUTCOMES_CRED <> 'DACSO') OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL) OR
+                         (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') AND (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') AND 
+                         (Credential_Non_Dup.RESEARCH_UNIVERSITY IS NULL)
+GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, tblCredential_HighestRank.psi_gender_cleaned
+HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
+ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, tblCredential_HighestRank.psi_gender_cleaned DESC;"
+
+# ---- qry09c_MinEnrolment ----
+qry09c_MinEnrolment <- "
+SELECT     MinEnrolment.PSI_GENDER, MinEnrolment.PSI_GENDER + AgeGroupLookup.AgeGroup As Groups, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
+INTO    qry09c_MinEnrolment
+FROM       MinEnrolment 
+INNER JOIN  AgeGroupLookup 
+ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
+GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
+HAVING      (MinEnrolment.PSI_SCHOOL_YEAR <> '2023/2024')
+ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
+
+###############################################################################################
+# ******************************************************************************
+# Part 1 ----
+
+## qry_Private_Credentials_00a_Append ----
+# grab PSSM_Credential and add to PTIB data; drop other and none credential
+qry_Private_Credentials_00a_Append <-
+  "SELECT intYear = T_Private_Institutions_Credentials_Raw.Year, 
+Credential = T_PSSM_Credential_Grouping.PSSM_Credential, 
+LCIP_CD = T_Private_Institutions_Credentials_Raw.CIP, 
+Age_Group = T_Private_Institutions_Credentials_Raw.Age_Group,
+Immigration_Status = T_Private_Institutions_Credentials_Raw.Immigration_Status,
+Graduates = T_Private_Institutions_Credentials_Raw.Sum_of_Graduates,
+Enrolled_Not_Graduated = T_Private_Institutions_Credentials_Raw.Sum_of_Enrolments,
+Enrolment = T_Private_Institutions_Credentials_Raw.Sum_of_Total_Enrolments
+INTO T_Private_Institutions_Credentials
+FROM T_PSSM_Credential_Grouping INNER JOIN T_Private_Institutions_Credentials_Raw
+ON T_PSSM_Credential_Grouping.PRGM_Credential_Awarded_Name = T_Private_Institutions_Credentials_Raw.Credential
+WHERE (((T_PSSM_Credential_Grouping.PSSM_Credential) Is Not Null) 
+AND ((T_Private_Institutions_Credentials_Raw.Credential)<>'None'))"
+
+## qry_Private_Credentials_00b_Check_CIP_Length ----
+# Check that all CIPs are 7 digits
+qry_Private_Credentials_00b_Check_CIP_Length <-
+  "SELECT T_Private_Institutions_Credentials.LCIP_CD, Len([LCIP_CD]) AS Expr1
+FROM T_Private_Institutions_Credentials
+WHERE (((Len([LCIP_CD]))<>7))"
+
+## qry_Private_Credentials_00c_Clean_CIP_Period ----
+# remove periods from LCIP_CD
+qry_Private_Credentials_00c_Clean_CIP_Period <-
+  "UPDATE T_Private_Institutions_Credentials 
+SET T_Private_Institutions_Credentials.LCIP_CD = Replace([LCIP_CD],'.','')"
+
+## qry_Private_Credentials_00d_Check_CIPs ----
+# Check CIPs valid; compared to the Infoware table
+qry_Private_Credentials_00d_Check_CIPs <-
+  "SELECT T_Private_Institutions_Credentials.LCIP_CD, 
+INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD
+FROM INFOWARE_L_CIP_6DIGITS_CIP2016 RIGHT JOIN T_Private_Institutions_Credentials 
+ON INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD = T_Private_Institutions_Credentials.LCIP_CD
+WHERE (((INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD) Is Null));"
+
+## qry_Private_Credentials_00f_Recode_Age_Group ----
+## recode dashes in age group
+qry_Private_Credentials_00f_Recode_Age_Group <-
+  "UPDATE T_Private_Institutions_Credentials 
+SET T_Private_Institutions_Credentials.Age_Group = Replace([Age_Group],'-',' to ');"
+
+## qry_Private_Credentials_00g_Avg ----
+## Get averages of enrolments/graduates by credential/LCIP_CD/Age/Immigration by # years; remove excluded
+qry_Private_Credentials_00g_Avg <-
+  "INSERT INTO T_Private_Institutions_Credentials ( intYear, Credential, LCIP_CD, Age_Group, Immigration_Status, Enrolment, Enrolled_Not_Graduated, Graduates, Exclude )
+SELECT 'Avg 2021 & 2022' AS intYear, 
+T_Private_Institutions_Credentials_Clean.Credential, 
+T_Private_Institutions_Credentials_Clean.LCIP_CD, 
+T_Private_Institutions_Credentials_Clean.Age_Group, 
+T_Private_Institutions_Credentials_Clean.Immigration_Status, 
+Sum([Enrolment])/2 AS AvgOfEnrolment, 
+Sum([Enrolled_Not_Graduated])/2 AS AvgOfEnrolment_Not_Graduated, 
+Sum([Graduates])/2 AS AvgOfGraduates, 
+T_Private_Institutions_Credentials_Clean.Exclude
+FROM T_Private_Institutions_Credentials_Clean
+GROUP BY T_Private_Institutions_Credentials_Clean.Credential, 
+T_Private_Institutions_Credentials_Clean.LCIP_CD, 
+T_Private_Institutions_Credentials_Clean.Age_Group, 
+T_Private_Institutions_Credentials_Clean.Immigration_Status, 
+T_Private_Institutions_Credentials_Clean.Exclude
+HAVING (((T_Private_Institutions_Credentials_Clean.Exclude) Is Null));"
+# ******************************************************************************
+
+# Part 2 ----
+## qry_Private_Credentials_01a_Domestic ----
+# count domestic grads for each combination of age group, CIP and Credential
+qry_Private_Credentials_01a_Domestic <-
+  "SELECT '2023/2024' AS [Year],
+T_Private_Institutions_Credentials.Credential,
+T_Private_Institutions_Credentials.LCIP_CD,
+T_Private_Institutions_Credentials.Age_Group,
+Sum(IIf([Immigration_Status]='Domestic',[Graduates],0)) AS Domestic
+INTO qry_Private_Credentials_01a_Domestic
+FROM T_Private_Institutions_Credentials
+WHERE (((T_Private_Institutions_Credentials.Exclude) Is Null) 
+AND ((T_Private_Institutions_Credentials.Graduates) Is Not Null))
+GROUP BY T_Private_Institutions_Credentials.Credential,
+T_Private_Institutions_Credentials.LCIP_CD, 
+T_Private_Institutions_Credentials.Age_Group
+HAVING (((T_Private_Institutions_Credentials.Credential)='CERT' 
+Or (T_Private_Institutions_Credentials.Credential)='DIPL'));"
+
+## qry_Private_Credentials_01b_Domestic_International ----
+# count domenstic and international grads for each combination of age group, CIP and Credential
+qry_Private_Credentials_01b_Domestic_International <-
+  "SELECT '2023/2024' AS [Year],
+T_Private_Institutions_Credentials.Credential,
+T_Private_Institutions_Credentials.LCIP_CD,
+T_Private_Institutions_Credentials.Age_Group,
+Sum(T_Private_Institutions_Credentials.Graduates) AS Domestic_International
+INTO qry_Private_Credentials_01b_Domestic_International
+FROM T_Private_Institutions_Credentials
+WHERE (((T_Private_Institutions_Credentials.Exclude) Is Null) 
+AND ((T_Private_Institutions_Credentials.Immigration_Status)='Domestic' 
+Or (T_Private_Institutions_Credentials.Immigration_Status)='International' 
+Or (T_Private_Institutions_Credentials.Immigration_Status)='#N/A') 
+AND ((T_Private_Institutions_Credentials.Graduates) Is Not Null))
+GROUP BY T_Private_Institutions_Credentials.Credential,
+T_Private_Institutions_Credentials.LCIP_CD, T_Private_Institutions_Credentials.Age_Group
+HAVING (((T_Private_Institutions_Credentials.Credential)='CERT' 
+Or (T_Private_Institutions_Credentials.Credential)='DIPL'));"
+
+## qry_Private_Credentials_01c_Percent_Domestic ----
+# Compute percent of domestic and international grads that are domestic
+qry_Private_Credentials_01c_Percent_Domestic <-
+  "SELECT qry_Private_Credentials_01a_Domestic.Year, 
+qry_Private_Credentials_01a_Domestic.Credential, 
+qry_Private_Credentials_01a_Domestic.LCIP_CD, 
+qry_Private_Credentials_01a_Domestic.Age_Group, 
+qry_Private_Credentials_01a_Domestic.Domestic, 
+qry_Private_Credentials_01b_Domestic_International.Domestic_International, 
+IIf([Domestic]=0,0,[Domestic]/[Domestic_International]) AS [Percent_Domestic]
+INTO qry_Private_Credentials_01c_Percent_Domestic
+FROM qry_Private_Credentials_01a_Domestic INNER JOIN qry_Private_Credentials_01b_Domestic_International 
+ON (qry_Private_Credentials_01a_Domestic.Age_Group = qry_Private_Credentials_01b_Domestic_International.Age_Group) 
+AND (qry_Private_Credentials_01a_Domestic.LCIP_CD = qry_Private_Credentials_01b_Domestic_International.LCIP_CD) 
+AND (qry_Private_Credentials_01a_Domestic.Credential = qry_Private_Credentials_01b_Domestic_International.Credential) 
+AND (qry_Private_Credentials_01a_Domestic.Year = qry_Private_Credentials_01b_Domestic_International.Year);"
+
+## qry_Private_Credentials_01d_Grads_Blank ----
+qry_Private_Credentials_01d_Grads_Blank <-
+  "SELECT [qry_Private_Credentials_01c_Percent_Domestic].Year, 
+T_Private_Institutions_Credentials.Credential, 
+T_Private_Institutions_Credentials.LCIP_CD, 
+T_Private_Institutions_Credentials.Age_Group, 
+[Graduates]*[Percent_Domestic] AS Graduates_Blank
+INTO qry_Private_Credentials_01d_Grads_Blank
+FROM T_Private_Institutions_Credentials INNER JOIN [qry_Private_Credentials_01c_Percent_Domestic] 
+ON (T_Private_Institutions_Credentials.Age_Group = [qry_Private_Credentials_01c_Percent_Domestic].Age_Group) 
+AND (T_Private_Institutions_Credentials.LCIP_CD = [qry_Private_Credentials_01c_Percent_Domestic].LCIP_CD) 
+AND (T_Private_Institutions_Credentials.Credential = [qry_Private_Credentials_01c_Percent_Domestic].Credential)
+WHERE (((T_Private_Institutions_Credentials.Immigration_Status)='(blank)' 
+Or (T_Private_Institutions_Credentials.Immigration_Status)='Unknown') 
+AND ((T_Private_Institutions_Credentials.Exclude) Is Null));"
+
+## qry_Private_Credentials_01e_Grads_Union ----
+qry_Private_Credentials_01e_Grads_Union <- "
+SELECT qry_Private_Credentials_01a_Domestic.Year, 
+qry_Private_Credentials_01a_Domestic.Credential, 
+qry_Private_Credentials_01a_Domestic.LCIP_CD, 
+qry_Private_Credentials_01a_Domestic.Age_Group, 
+qry_Private_Credentials_01a_Domestic.Domestic
+INTO qry_Private_Credentials_01e_Grads_Union
+FROM qry_Private_Credentials_01a_Domestic
+UNION ALL SELECT qry_Private_Credentials_01d_Grads_Blank.Year, 
+qry_Private_Credentials_01d_Grads_Blank.Credential, 
+qry_Private_Credentials_01d_Grads_Blank.LCIP_CD, 
+qry_Private_Credentials_01d_Grads_Blank.Age_Group, 
+qry_Private_Credentials_01d_Grads_Blank.Graduates_Blank
+FROM qry_Private_Credentials_01d_Grads_Blank;"
+
+## qry_Private_Credentials_01f_Grads ----
+# Sum of union query
+qry_Private_Credentials_01f_Grads <- "
+SELECT qry_Private_Credentials_01e_Grads_Union.Year, 
+qry_Private_Credentials_01e_Grads_Union.Credential, 
+qry_Private_Credentials_01e_Grads_Union.LCIP_CD, 
+qry_Private_Credentials_01e_Grads_Union.Age_Group, 
+Sum(qry_Private_Credentials_01e_Grads_Union.Domestic) AS Grads
+INTO qry_Private_Credentials_01f_Grads
+FROM qry_Private_Credentials_01e_Grads_Union
+GROUP BY qry_Private_Credentials_01e_Grads_Union.Year, 
+qry_Private_Credentials_01e_Grads_Union.Credential, 
+qry_Private_Credentials_01e_Grads_Union.LCIP_CD, 
+qry_Private_Credentials_01e_Grads_Union.Age_Group;"
+
+## qry_Private_Credentials_05i_Grads ----
+# Summarize the Grads by Credential/Age
+qry_Private_Credentials_05i_Grads <-
+  "SELECT qry_Private_Credentials_01f_Grads.Year, 
+qry_Private_Credentials_01f_Grads.Credential, 
+qry_Private_Credentials_01f_Grads.Age_Group, 
+Sum(qry_Private_Credentials_01f_Grads.Grads) AS SumOfGrads
+INTO qry_Private_Credentials_05i_Grads
+FROM qry_Private_Credentials_01f_Grads
+GROUP BY qry_Private_Credentials_01f_Grads.Year, 
+qry_Private_Credentials_01f_Grads.Credential, 
+qry_Private_Credentials_01f_Grads.Age_Group;"
+
+## qry_Private_Credentials_05i1_Grads_by_Year ----
+# add Grads for all years to new table for import into Graduate_Projections later
+qry_Private_Credentials_05i1_Grads_by_Year <-
+  "SELECT 'PTIB' AS Survey, 
+'P - ' + [Credential] AS PSSM_CRED, 
+qry_Private_Credentials_05i_Grads.Age_Group, 
+T_PTIB_Y1_to_Y10.Y1_to_Y10 AS [Year], 
+qry_Private_Credentials_05i_Grads.SumOfGrads AS Graduates
+INTO qry_Private_Credentials_05i1_Grads_by_Year
+FROM qry_Private_Credentials_05i_Grads INNER JOIN T_PTIB_Y1_to_Y10 
+ON qry_Private_Credentials_05i_Grads.Year = T_PTIB_Y1_to_Y10.Y1;"
+
+## qry_Private_Credentials_05i2_Delete_AgeGrps ----
+# remove excess age groups
+qry_Private_Credentials_05i2_Delete_AgeGrps <-
+  "DELETE FROM qry_Private_Credentials_05i1_Grads_by_Year
+WHERE (((qry_Private_Credentials_05i1_Grads_by_Year.Survey)='PTIB') AND
+((qry_Private_Credentials_05i1_Grads_by_Year.Age_Group)='(blank)') OR
+((qry_Private_Credentials_05i1_Grads_by_Year.Age_Group)='Unknown') OR
+((qry_Private_Credentials_05i1_Grads_by_Year.Age_Group)='65+') OR
+((qry_Private_Credentials_05i1_Grads_by_Year.Age_Group)='16 or less'))"
+
+# ******************************************************************************
+
+# Part 3 ----
+## qry_Private_Credentials_06b_Cohort_Dist ----
+# count grads by CIP
+qry_Private_Credentials_06b_Cohort_Dist <-
+  "SELECT qry_Private_Credentials_01f_Grads.Year, 
+qry_Private_Credentials_01f_Grads.Credential, 
+'P - ' + [Credential] AS PSSM_CRED, 
+Left([LCIP_CD],4) AS LCP4_CD, 
+'P - ' + Left([LCIP_CD],4) + ' - ' + [Credential] AS LCIP4_CRED, 
+'P - ' + Left([LCIP_CD],2) + ' - ' + [Credential] AS LCIP2_CRED, 
+qry_Private_Credentials_01f_Grads.Age_Group, 
+Sum(qry_Private_Credentials_01f_Grads.Grads) AS [Count]
+INTO qry_Private_Credentials_06b_Cohort_Dist
+FROM qry_Private_Credentials_01f_Grads
+GROUP BY qry_Private_Credentials_01f_Grads.Year,
+qry_Private_Credentials_01f_Grads.Credential, 
+'P - ' + [Credential], Left([LCIP_CD],4),
+'P - ' + Left([LCIP_CD],4) + ' - ' + [Credential],
+'P - ' + Left([LCIP_CD],2) + ' - ' + [Credential], 
+qry_Private_Credentials_01f_Grads.Age_Group;"
+
+## qry_Private_Credentials_06c_Cohort_Dist_Total ----
+# sum totals by age group
+qry_Private_Credentials_06c_Cohort_Dist_Total <-
+  "SELECT qry_Private_Credentials_06b_Cohort_Dist.Year, 
+qry_Private_Credentials_06b_Cohort_Dist.Credential, 
+qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED, 
+qry_Private_Credentials_06b_Cohort_Dist.Age_Group, 
+Sum(qry_Private_Credentials_06b_Cohort_Dist.Count) AS Total
+INTO qry_Private_Credentials_06c_Cohort_Dist_Total
+FROM qry_Private_Credentials_06b_Cohort_Dist
+GROUP BY qry_Private_Credentials_06b_Cohort_Dist.Year, 
+qry_Private_Credentials_06b_Cohort_Dist.Credential, 
+qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED, 
+qry_Private_Credentials_06b_Cohort_Dist.Age_Group;"
+
+## qry_Private_Credentials_06d0_Cohort_Dist_Delete_Projected ----
+qry_Private_Credentials_06d0_Cohort_Dist_Delete_Projected <-
+  "DELETE FROM Cohort_Program_Distributions_Projected
+WHERE (((Cohort_Program_Distributions_Projected.Survey)='PTIB'));"
+
+## qry_Private_Credentials_06d0_Cohort_Dist_Delete_Static ----
+qry_Private_Credentials_06d0_Cohort_Dist_Delete_Static <-
+  "DELETE FROM Cohort_Program_Distributions_Static
+WHERE (((Cohort_Program_Distributions_Static.Survey)='PTIB'));"
+
+## qry_Private_Credentials_06d1_Cohort_Dist ----
+qry_Private_Credentials_06d1_Cohort_Dist <-
+  "SELECT 'PTIB' AS Survey, 
+qry_Private_Credentials_06b_Cohort_Dist.Credential, 
+qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED, 
+qry_Private_Credentials_06b_Cohort_Dist.LCP4_CD, 
+qry_Private_Credentials_06b_Cohort_Dist.LCIP4_CRED, 
+qry_Private_Credentials_06b_Cohort_Dist.LCIP2_CRED, 
+qry_Private_Credentials_06b_Cohort_Dist.Age_Group, 
+qry_Private_Credentials_06b_Cohort_Dist.Year, 
+qry_Private_Credentials_06b_Cohort_Dist.Count, 
+qry_Private_Credentials_06c_Cohort_Dist_Total.Total, 
+IIf(([Total]=0),0,[Count]/[Total]) AS [Percent]
+INTO qry_Private_Credentials_06d1_Cohort_Dist
+FROM qry_Private_Credentials_06c_Cohort_Dist_Total INNER JOIN qry_Private_Credentials_06b_Cohort_Dist 
+ON (qry_Private_Credentials_06c_Cohort_Dist_Total.PSSM_CRED = qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED) 
+AND (qry_Private_Credentials_06c_Cohort_Dist_Total.Age_Group = qry_Private_Credentials_06b_Cohort_Dist.Age_Group);"
+
+
+## qry_Private_Credentials_06d2_Delete_AgeGrps ----
+# remove excess age groups
+qry_Private_Credentials_06d2_Delete_AgeGrps <-
+  "DELETE FROM qry_Private_Credentials_06d1_Cohort_Dist
+WHERE (((qry_Private_Credentials_06d1_Cohort_Dist.Survey)='PTIB') AND
+((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='(blank)') OR
+((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='Unknown') OR
+((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='65+') OR
+((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='16 or less'))"
+
+# ******************************************************************************
+
+###############################################################################################
+# ---- qry_Build_Program_Projection_Input ----
+qry_Build_Program_Projection_Input <- "
+--CREATE VIEW tbl_Program_Projection_Input AS 
+SELECT  A.AgeGroup, 
+        tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+        tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + A.AgeGroup AS Expr1,
+        Credential_Non_Dup.FINAL_CIP_CODE_4, 
+        tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, 
+COUNT(*) AS Count 
+FROM    tblCredential_HighestRank 
+INNER JOIN AgeGroupLookup A
+  ON    tblCredential_HighestRank.AGE_GROUP_AT_GRAD = A.AgeIndex 
+INNER JOIN Credential_Non_Dup 
+  ON    tblCredential_HighestRank.id = Credential_Non_Dup.id 
+WHERE   (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') 
+  AND   (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) 
+  AND   (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') 
+  OR    (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) 
+  AND   (tblCredential_HighestRank.RESEARCH_UNIVERSITY = 1) 
+  AND   (tblCredential_HighestRank.OUTCOMES_CRED <> 'DACSO') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') 
+  OR    (tblCredential_HighestRank.PSI_VISA_STATUS = 'DOMESTIC') 
+  AND   (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') 
+  OR    (tblCredential_HighestRank.PSI_VISA_STATUS IS NULL) 
+  AND   (tblCredential_HighestRank.RESEARCH_UNIVERSITY IS NULL) 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '09') 
+  AND   (Credential_Non_Dup.FINAL_CIP_CLUSTER_CODE <> '10') 
+GROUP BY A.AgeGroup, 
+        tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
+        tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED,  
+        Credential_Non_Dup.FINAL_CIP_CODE_4 
+HAVING  (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP');"
+
+# ---- Q012a_Check_Total_for_Invalid_CIPs ----
+Q012a_Check_Total_for_Invalid_CIPs <-
+  "SELECT tbl_Program_Projection_Input.FINAL_CIP_CODE_4, 
+        tbl_Program_Projection_Input.Count
+FROM    tbl_Program_Projection_Input INNER JOIN INFOWARE_L_CIP_4DIGITS_CIP2016 
+ON      tbl_Program_Projection_Input.FINAL_CIP_CODE_4 = INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD
+WHERE   (((INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD) Is Null))
+GROUP BY tbl_Program_Projection_Input.FINAL_CIP_CODE_4, tbl_Program_Projection_Input.Count;"
+
+# ---- Q012b_Weight_Cohort_Dist ----
+Q012b_Weight_Cohort_Dist <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
+        tbl_Program_Projection_Input.FINAL_CIP_CODE_4 AS LCP4_CD, T_PSSM_Projection_Cred_Grp.COSC_GRAD_STATUS_LGDS_CD, 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [FINAL_CIP_CODE_4], ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIP4_CRED, 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, Left([FINAL_CIP_CODE_4],2), ' - ' , [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIP2_CRED, 
+        tbl_Program_Projection_Input.AgeGroup, 
+        Sum(tbl_Program_Projection_Input.Count) AS Counts, 
+        T_Weights_STP.Weight, 
+        Sum([Count])*([Weight]) AS Weighted
+INTO Q012b_Weight_Cohort_Dist
+FROM    T_PSSM_Projection_Cred_Grp 
+INNER JOIN (tbl_Program_Projection_Input 
+  INNER JOIN T_Weights_STP 
+    ON tbl_Program_Projection_Input.PSI_AWARD_SCHOOL_YEAR_DELAYED = T_Weights_STP.Year_Code) 
+  ON T_PSSM_Projection_Cred_Grp.PSSM_Projection_Credential = tbl_Program_Projection_Input.PSI_CREDENTIAL_CATEGORY
+WHERE   (((T_Weights_STP.Model)='2023-2024') AND ((T_PSSM_Projection_Cred_Grp.PSSM_Credential) Not In ('APPRAPPR','APPRCERT','GRCT or GRDP','PDEG','MAST','DOCT')))
+GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [PSSM_Credential]), 
+        tbl_Program_Projection_Input.FINAL_CIP_CODE_4, 
+        T_PSSM_Projection_Cred_Grp.COSC_GRAD_STATUS_LGDS_CD, 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [FINAL_CIP_CODE_4], ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+        CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, Left([FINAL_CIP_CODE_4],2), ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+        tbl_Program_Projection_Input.AgeGroup, 
+        T_Weights_STP.Weight
+HAVING (((T_Weights_STP.Weight)>0));"
+
+# ---- Q012c_Weighted_Cohort_Dist ----
+Q012c_Weighted_Cohort_Dist <-
+  "SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+      Q012b_Weight_Cohort_Dist.PSSM_CRED, 
+      Q012b_Weight_Cohort_Dist.LCP4_CD, 
+      Q012b_Weight_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD, 
+      Q012b_Weight_Cohort_Dist.LCIP4_CRED, 
+      Q012b_Weight_Cohort_Dist.LCIP2_CRED, 
+      Q012b_Weight_Cohort_Dist.AgeGroup, 
+      Sum(Q012b_Weight_Cohort_Dist.Weighted) AS [Count]
+INTO Q012c_Weighted_Cohort_Dist
+FROM Q012b_Weight_Cohort_Dist
+GROUP BY Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+      Q012b_Weight_Cohort_Dist.PSSM_CRED, 
+      Q012b_Weight_Cohort_Dist.LCP4_CD, 
+      Q012b_Weight_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD, 
+      Q012b_Weight_Cohort_Dist.LCIP4_CRED, 
+      Q012b_Weight_Cohort_Dist.LCIP2_CRED, 
+      Q012b_Weight_Cohort_Dist.AgeGroup;"
+
+# ---- Q012c1_Weighted_Cohort_Dist_TTRAIN ----
+Q012c1_Weighted_Cohort_Dist_TTRAIN <-
+  "SELECT T_Cohorts_Recoded.PSSM_Credential, 
+        T_Cohorts_Recoded.PSSM_Credential AS PSSM_CRED, 
+        T_Cohorts_Recoded.LCP4_CD, 
+        T_Cohorts_Recoded.GRAD_STATUS, 
+        T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, 
+        T_Cohorts_Recoded.LCIP2_CRED, tbl_Age_Groups.Age_Group_Label AS Age_Group, 
+        Count(*) AS Counts, 
+        T_Cohorts_Recoded.Weight, 
+        Count(*)*([Weight]) AS Weighted
+INTO Q012c1_Weighted_Cohort_Dist_TTRAIN
+FROM T_Cohorts_Recoded 
+INNER JOIN tbl_Age_Groups 
+  ON T_Cohorts_Recoded.Age_Group = tbl_Age_Groups.Age_Group
+WHERE (((T_Cohorts_Recoded.GRAD_STATUS)<>'3'))
+GROUP BY T_Cohorts_Recoded.PSSM_Credential, T_Cohorts_Recoded.LCP4_CD, 
+        T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, 
+        T_Cohorts_Recoded.LCIP4_CRED, T_Cohorts_Recoded.LCIP2_CRED, 
+        tbl_Age_Groups.Age_Group_Label, T_Cohorts_Recoded.Weight, 
+        T_Cohorts_Recoded.PSSM_Credential
+HAVING (((T_Cohorts_Recoded.TTRAIN) Is Not Null) 
+AND ((T_Cohorts_Recoded.Weight)>0));"
+
+# ---- Q012c2_Weighted_Cohort_Dist ----
+Q012c2_Weighted_Cohort_Dist <-
+  "SELECT Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCP4_CD, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.GRAD_STATUS, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.TTRAIN, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCIP4_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCIP2_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.Age_Group, 
+         Sum(Q012c1_Weighted_Cohort_Dist_TTRAIN.Weighted) AS [Count]
+INTO Q012c2_Weighted_Cohort_Dist
+FROM Q012c1_Weighted_Cohort_Dist_TTRAIN
+GROUP BY Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCP4_CD, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.GRAD_STATUS, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.TTRAIN, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCIP4_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.LCIP2_CRED, 
+         Q012c1_Weighted_Cohort_Dist_TTRAIN.Age_Group;"
+
+# ---- Q012c3_Weighted_Cohort_Dist_Total ----
+Q012c3_Weighted_Cohort_Dist_Total <-
+  "SELECT Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q012c2_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q012c2_Weighted_Cohort_Dist.LCP4_CD, 
+        Q012c2_Weighted_Cohort_Dist.GRAD_STATUS, 
+        Q012c2_Weighted_Cohort_Dist.Age_Group, 
+        Sum(Q012c2_Weighted_Cohort_Dist.Count) AS Totals
+INTO    Q012c3_Weighted_Cohort_Dist_Total
+FROM    Q012c2_Weighted_Cohort_Dist
+GROUP BY Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q012c2_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q012c2_Weighted_Cohort_Dist.LCP4_CD, 
+        Q012c2_Weighted_Cohort_Dist.GRAD_STATUS, 
+        Q012c2_Weighted_Cohort_Dist.Age_Group;"
+
+# ---- Q012c4_Weighted_Cohort_Distribution_Projected ----
+Q012c4_Weighted_Cohort_Distribution_Projected <-
+  "SELECT 'Program_Projections_2023-2024_Q015e' AS Survey, 
+        Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q012c2_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q012c2_Weighted_Cohort_Dist.LCP4_CD, 
+        Q012c2_Weighted_Cohort_Dist.GRAD_STATUS, 
+        Q012c2_Weighted_Cohort_Dist.TTRAIN, 
+        Q012c2_Weighted_Cohort_Dist.Age_Group, 
+        '2023/2024' AS Projection_Year, 
+        Q012c2_Weighted_Cohort_Dist.Count, 
+        Q012c3_Weighted_Cohort_Dist_Total.Totals, 
+        IIf((Totals=0), 0 , CAST(Count AS float)/CAST(Totals as FLOAT)) AS [%]
+INTO    Q012c4_Weighted_Cohort_Distribution_Projected
+FROM    Q012c2_Weighted_Cohort_Dist 
+INNER JOIN Q012c3_Weighted_Cohort_Dist_Total 
+  ON    (Q012c2_Weighted_Cohort_Dist.Age_Group = Q012c3_Weighted_Cohort_Dist_Total.Age_Group)
+  AND   (Q012c2_Weighted_Cohort_Dist.PSSM_CRED = Q012c3_Weighted_Cohort_Dist_Total.PSSM_CRED) 
+  AND   (Q012c2_Weighted_Cohort_Dist.GRAD_STATUS = Q012c3_Weighted_Cohort_Dist_Total.GRAD_STATUS) 
+  AND   (Q012c2_Weighted_Cohort_Dist.LCP4_CD = Q012c3_Weighted_Cohort_Dist_Total.LCP4_CD);"
+
+# ---- Q012c5_Weighted_Cohort_Dist_TTRAIN ----
+Q012c5_Weighted_Cohort_Dist_TTRAIN <-
+  "SELECT Q012c_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q012c_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q012c_Weighted_Cohort_Dist.LCP4_CD, 
+        Q012c_Weighted_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD, 
+        Q012c4_Weighted_Cohort_Distribution_Projected.TTRAIN, 
+        CONCAT(
+          (CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END),
+			    [Q012c_Weighted_Cohort_Dist].[LCP4_CD], ' - ',
+			    (CASE WHEN [TTRAIN] IS NULL THEN Null ELSE CAST([TTRAIN] AS NVARCHAR(50)) + ' - ' END),
+			    [Q012c_Weighted_Cohort_Dist].[PSSM_Credential]
+			   ) AS LCIP4_CRED, 
+        CONCAT(
+          (CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END), 
+			    Left([Q012c_Weighted_Cohort_Dist].[LCP4_CD],2) , ' - ',  
+			    (CASE WHEN [TTRAIN] IS NULL THEN Null ELSE CAST([TTRAIN] AS NVARCHAR(50)) + ' - ' END), 
+			    [Q012c_Weighted_Cohort_Dist].[PSSM_Credential]
+			  ) AS LCIP2_CRED, 
+        Q012c_Weighted_Cohort_Dist.AgeGroup, Q012c_Weighted_Cohort_Dist.Count, Q012c4_Weighted_Cohort_Distribution_Projected.[%], 
+        CASE WHEN [Q012c4_Weighted_Cohort_Distribution_Projected].[%] IS NULL THEN [Q012c_Weighted_Cohort_Dist].[Count] ELSE [Q012c_Weighted_Cohort_Dist].[Count]*[Q012c4_Weighted_Cohort_Distribution_Projected].[%] END AS Count_Distributed
+INTO    Q012c5_Weighted_Cohort_Dist_TTRAIN
+FROM    Q012c_Weighted_Cohort_Dist 
+LEFT JOIN Q012c4_Weighted_Cohort_Distribution_Projected 
+  ON    (Q012c_Weighted_Cohort_Dist.AgeGroup = Q012c4_Weighted_Cohort_Distribution_Projected.Age_Group) 
+  AND   (Q012c_Weighted_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD = Q012c4_Weighted_Cohort_Distribution_Projected.GRAD_STATUS) 
+  AND   (Q012c_Weighted_Cohort_Dist.LCP4_CD = Q012c4_Weighted_Cohort_Distribution_Projected.LCP4_CD) 
+  AND   (Q012c_Weighted_Cohort_Dist.PSSM_Credential = Q012c4_Weighted_Cohort_Distribution_Projected.PSSM_Credential);"
+
+# ---- Q012d_Weighted_Cohort_Dist_Total ----
+Q012d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+        Q012b_Weight_Cohort_Dist.PSSM_CRED, 
+        Q012b_Weight_Cohort_Dist.AgeGroup, 
+        Sum(Q012b_Weight_Cohort_Dist.Weighted) AS Totals
+INTO    Q012d_Weighted_Cohort_Dist_Total
+FROM    Q012b_Weight_Cohort_Dist
+GROUP BY Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+        Q012b_Weight_Cohort_Dist.PSSM_CRED, 
+        Q012b_Weight_Cohort_Dist.AgeGroup;"
+
+# ---- Q012e_Delete_Weighted_Cohort_Distribution ----
+Q012e_Delete_Weighted_Cohort_Distribution <-
+  "DELETE 
+FROM Cohort_Program_Distributions_Static
+WHERE (((Cohort_Program_Distributions_Static.Survey) Like '%Q012e'));"
+
+# ---- Q012e_Weighted_Cohort_Distribution ----
+Q012e_Weighted_Cohort_Distribution <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_Q012e' AS Survey, 
+Q012c5_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential,
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.LCP4_CD, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.COSC_GRAD_STATUS_LGDS_CD, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.TTRAIN, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.LCIP4_CRED, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.LCIP2_CRED, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.AgeGroup, 
+        '2023/2024' AS Projection_Year, 
+        Q012c5_Weighted_Cohort_Dist_TTRAIN.Count_Distributed, 
+        Q012d_Weighted_Cohort_Dist_Total.Totals, 
+        CASE WHEN Totals = 0 THEN 0 ELSE CAST(Count_Distributed AS FLOAT)/CAST(Totals AS FLOAT) END AS [Percent]
+FROM    Q012c5_Weighted_Cohort_Dist_TTRAIN 
+INNER JOIN Q012d_Weighted_Cohort_Dist_Total 
+  ON    (Q012c5_Weighted_Cohort_Dist_TTRAIN.AgeGroup = Q012d_Weighted_Cohort_Dist_Total.AgeGroup) 
+  AND   (Q012c5_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED = Q012d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
+
+# ---- Q013a_Check_PDEG_CLP_07_Only_CIP_22 ----
+Q013a_Check_PDEG_CLP_07_Only_CIP_22 <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT
+        (CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
+        tbl_Program_Projection_Input.FINAL_CIP_CODE_4, qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD AS LCIPPC_CD, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ',
+           [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIPPC_CRED, 
+        tbl_Program_Projection_Input.AgeGroup, 
+        Sum(tbl_Program_Projection_Input.Count) AS Counts, 
+        T_Weights_STP.Weight, 
+        Sum([Count])*([Weight]) AS Weighted
+FROM (T_PSSM_Projection_Cred_Grp 
+INNER JOIN (tbl_Program_Projection_Input 
+    INNER JOIN T_Weights_STP 
+      ON tbl_Program_Projection_Input.PSI_AWARD_SCHOOL_YEAR_DELAYED = T_Weights_STP.Year_Code) 
+  ON T_PSSM_Projection_Cred_Grp.PSSM_Projection_Credential = tbl_Program_Projection_Input.PSI_CREDENTIAL_CATEGORY) 
+INNER JOIN qry_12_LCP4_LCIPPC_Recode_9999 
+  ON tbl_Program_Projection_Input.FINAL_CIP_CODE_4 = qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCP4_CD
+WHERE (((T_Weights_STP.Model)='2023-2024') 
+AND ((T_PSSM_Projection_Cred_Grp.PSSM_Credential) In ('PDEG')))
+GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+		    CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]),
+		    tbl_Program_Projection_Input.FINAL_CIP_CODE_4, 
+		    qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD, 
+		    CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD],
+		        ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+		tbl_Program_Projection_Input.AgeGroup, T_Weights_STP.Weight
+HAVING (((T_Weights_STP.Weight)>0));"
+
+# ---- Q013b_Weight_Cohort_Dist_MAST_DOCT_Others ----
+Q013b_Weight_Cohort_Dist_MAST_DOCT_Others <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+		    CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
+        qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD AS LCIPPC_CD, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ',
+             [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIPPC_CRED, 
+        tbl_Program_Projection_Input.AgeGroup, 
+        Sum(tbl_Program_Projection_Input.Count) AS Counts, 
+        T_Weights_STP.Weight, 
+        Sum([Count])*([Weight]) AS Weighted
+INTO Q013b_Weight_Cohort_Dist_MAST_DOCT_Others
+FROM    (T_PSSM_Projection_Cred_Grp 
+INNER JOIN (tbl_Program_Projection_Input   
+    INNER JOIN T_Weights_STP 
+      ON tbl_Program_Projection_Input.PSI_AWARD_SCHOOL_YEAR_DELAYED = T_Weights_STP.Year_Code) 
+  ON T_PSSM_Projection_Cred_Grp.PSSM_Projection_Credential = tbl_Program_Projection_Input.PSI_CREDENTIAL_CATEGORY) 
+INNER JOIN qry_12_LCP4_LCIPPC_Recode_9999 
+  ON tbl_Program_Projection_Input.FINAL_CIP_CODE_4 = qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCP4_CD
+WHERE (((T_Weights_STP.Model)='2023-2024') 
+AND   ((T_PSSM_Projection_Cred_Grp.PSSM_Credential) In ('GRCT or GRDP','PDEG','MAST','DOCT')))
+GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+	    CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]), 
+      qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD, 
+      CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ',
+      [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+      tbl_Program_Projection_Input.AgeGroup, T_Weights_STP.Weight
+HAVING (((T_Weights_STP.Weight)>0));"
+
+# ---- Q013c_Weighted_Cohort_Dist ----
+Q013c_Weighted_Cohort_Dist <-
+  "SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED,
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CD, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CRED, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup, 
+        Sum(Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.Weighted) AS [Count]
+INTO    Q013c_Weighted_Cohort_Dist
+FROM    Q013b_Weight_Cohort_Dist_MAST_DOCT_Others
+GROUP BY Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CD, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CRED, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup;"
+
+# ---- Q013d_Weighted_Cohort_Dist_Total ----
+Q013d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup, 
+        Sum(Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.Weighted) AS Totals
+INTO    Q013d_Weighted_Cohort_Dist_Total
+FROM    Q013b_Weight_Cohort_Dist_MAST_DOCT_Others
+GROUP BY Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED, 
+        Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup;"
+
+# ---- Q013e_Weighted_Cohort_Distribution ----
+Q013e_Weighted_Cohort_Distribution <- "
+INSERT INTO Cohort_Program_Distributions_Static (Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Age_Group, [Year], [Count], [Total], [Percent] )
+SELECT 'Program_Projections_2023-2024_Q013e' AS Survey, 
+        Q013c_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q013c_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q013c_Weighted_Cohort_Dist.LCIPPC_CD, 
+        Q013c_Weighted_Cohort_Dist.LCIPPC_CRED, 
+        Q013c_Weighted_Cohort_Dist.AgeGroup, 
+        '2023/2024' AS Year, 
+        Q013c_Weighted_Cohort_Dist.Count, 
+        Q013d_Weighted_Cohort_Dist_Total.Totals, 
+        CASE WHEN Totals = 0 THEN 0 ELSE CAST([Count] AS FLOAT)/CAST([Totals] AS FLOAT) END AS [Percent]
+FROM    Q013c_Weighted_Cohort_Dist 
+INNER JOIN Q013d_Weighted_Cohort_Dist_Total 
+  ON    (Q013c_Weighted_Cohort_Dist.AgeGroup = Q013d_Weighted_Cohort_Dist_Total.AgeGroup) 
+  AND   (Q013c_Weighted_Cohort_Dist.PSSM_CRED = Q013d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
+
+# ---- Q014b_Weighted_Cohort_Dist_APPR ----
+Q014b_Weighted_Cohort_Dist_APPR <-
+  "SELECT T_Cohorts_Recoded.PSSM_Credential, 
+        T_Cohorts_Recoded.PSSM_Credential AS PSSM_CRED, 
+        T_Cohorts_Recoded.LCP4_CD, 
+        T_Cohorts_Recoded.TTRAIN, 
+        T_Cohorts_Recoded.LCIP4_CRED, 
+        T_Cohorts_Recoded.LCIP2_CRED, 
+        tbl_Age_Groups.Age_Group_Label AS Age_Group, 
+        Count(*) AS Counts, 
+        T_Cohorts_Recoded.Weight, 
+        Count(*)*([Weight]) AS Weighted
+INTO    Q014b_Weighted_Cohort_Dist_APPR
+FROM    T_Cohorts_Recoded INNER JOIN tbl_Age_Groups 
+ON      T_Cohorts_Recoded.Age_Group = tbl_Age_Groups.Age_Group
+WHERE   (((T_Cohorts_Recoded.PSSM_Credential) In ('APPRAPPR','APPRCERT')))
+GROUP BY T_Cohorts_Recoded.PSSM_Credential, 
+        T_Cohorts_Recoded.LCP4_CD, 
+        T_Cohorts_Recoded.TTRAIN, 
+        T_Cohorts_Recoded.LCIP4_CRED, 
+        T_Cohorts_Recoded.LCIP2_CRED, tbl_Age_Groups.Age_Group_Label, 
+        T_Cohorts_Recoded.Weight, 
+        T_Cohorts_Recoded.PSSM_Credential
+HAVING (((T_Cohorts_Recoded.Weight)>0));"
+
+# ---- Q014c_Weighted_Cohort_Dist ----
+Q014c_Weighted_Cohort_Dist <-
+  "SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+        Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCP4_CD, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCIP4_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCIP2_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.Age_Group, 
+        Sum(Q014b_Weighted_Cohort_Dist_APPR.Weighted) AS [Count]
+INTO    Q014c_Weighted_Cohort_Dist
+FROM    Q014b_Weighted_Cohort_Dist_APPR
+GROUP BY Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+        Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCP4_CD, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCIP4_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.LCIP2_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.Age_Group;"
+
+# ---- Q014d_Weighted_Cohort_Dist_Total ----
+Q014d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+        Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.Age_Group, 
+        Sum(Q014b_Weighted_Cohort_Dist_APPR.Weighted) AS Totals
+INTO    Q014d_Weighted_Cohort_Dist_Total
+FROM    Q014b_Weighted_Cohort_Dist_APPR
+GROUP BY Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+        Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
+        Q014b_Weighted_Cohort_Dist_APPR.Age_Group;"
+
+# Q014e_Weighted_Cohort_Distribution_Projected ----
+Q014e_Weighted_Cohort_Distribution_Projected <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_Q014e' AS Survey, 
+        Q014c_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q014c_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q014c_Weighted_Cohort_Dist.LCP4_CD, 
+        Q014c_Weighted_Cohort_Dist.LCIP4_CRED, 
+        Q014c_Weighted_Cohort_Dist.LCIP2_CRED, 
+        Q014c_Weighted_Cohort_Dist.Age_Group, 
+        '2023/2024' AS Projection_Year, 
+        Q014c_Weighted_Cohort_Dist.Count, Q014d_Weighted_Cohort_Dist_Total.Totals, 
+        CASE WHEN Totals = 0 THEN 0 ELSE Count/Totals END AS [Percent]
+FROM    Q014c_Weighted_Cohort_Dist 
+INNER JOIN Q014d_Weighted_Cohort_Dist_Total 
+  ON   (Q014c_Weighted_Cohort_Dist.Age_Group = Q014d_Weighted_Cohort_Dist_Total.Age_Group) 
+  AND  (Q014c_Weighted_Cohort_Dist.PSSM_CRED = Q014d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
+
+# ---- Q014e_Weighted_Cohort_Distribution_Static ----
+Q014e_Weighted_Cohort_Distribution_Static <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_Q014e' AS Survey, 
+        Q014c_Weighted_Cohort_Dist.PSSM_Credential, 
+        Q014c_Weighted_Cohort_Dist.PSSM_CRED, 
+        Q014c_Weighted_Cohort_Dist.LCP4_CD, 
+        Q014c_Weighted_Cohort_Dist.LCIP4_CRED, 
+        Q014c_Weighted_Cohort_Dist.LCIP2_CRED, 
+        Q014c_Weighted_Cohort_Dist.Age_Group, '2023/2024' AS Projection_Year, 
+        Q014c_Weighted_Cohort_Dist.Count, Q014d_Weighted_Cohort_Dist_Total.Totals, 
+        CASE WHEN Totals = 0 THEN 0 ELSE Count/Totals END AS [Percent]
+FROM    Q014c_Weighted_Cohort_Dist
+INNER JOIN Q014d_Weighted_Cohort_Dist_Total 
+  ON    (Q014c_Weighted_Cohort_Dist.Age_Group = Q014d_Weighted_Cohort_Dist_Total.Age_Group) 
+  AND   (Q014c_Weighted_Cohort_Dist.PSSM_CRED = Q014d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
+
+# ---- Q014f_APPSO_Grads_Y2_to_Y10 ----
+Q014f_APPSO_Grads_Y2_to_Y10 <-
+  "INSERT INTO Graduate_Projections ( Survey, PSSM_Credential, PSSM_CRED, Age_Group, [Year], Graduates )
+SELECT  Graduate_Projections.Survey, 
+        Graduate_Projections.PSSM_Credential, 
+        Graduate_Projections.PSSM_CRED, 
+        Graduate_Projections.Age_Group, 
+        T_APPR_Y2_to_Y10.Y2_to_Y10, 
+        Graduate_Projections.Graduates
+FROM    Graduate_Projections INNER JOIN T_APPR_Y2_to_Y10 
+ON      Graduate_Projections.Year = T_APPR_Y2_to_Y10.Y1
+WHERE   (((Graduate_Projections.Survey)='APPSO'));"
+
+# ---- Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected ----
+Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], [Total], [Percent] )
+SELECT 'Program_Projections_2023-2024_Q015e21' AS Survey, 
+        Cohort_Program_Distributions_Static.PSSM_Credential, 
+        Cohort_Program_Distributions_Static.PSSM_CRED, 
+        Cohort_Program_Distributions_Static.LCP4_CD, 
+        Cohort_Program_Distributions_Static.GRAD_STATUS, 
+        Cohort_Program_Distributions_Static.TTRAIN, 
+        Cohort_Program_Distributions_Static.LCIP4_CRED, 
+        Cohort_Program_Distributions_Static.LCIP2_CRED, 
+        Cohort_Program_Distributions_Static.Age_Group, 
+        T_Cohort_Program_Distributions_Y2_to_Y12.Y2_to_Y10 as Year, 
+        Cohort_Program_Distributions_Static.Count, 
+        Cohort_Program_Distributions_Static.Total, 
+        Cohort_Program_Distributions_Static.[Percent]
+FROM    Cohort_Program_Distributions_Static 
+INNER JOIN T_Cohort_Program_Distributions_Y2_to_Y12 
+ON      Cohort_Program_Distributions_Static.Year = T_Cohort_Program_Distributions_Y2_to_Y12.Y1
+WHERE   (((Cohort_Program_Distributions_Static.PSSM_CRED) In ('APPRAPPR','APPRCERT') 
+    Or (Cohort_Program_Distributions_Static.PSSM_CRED) Like '3 - %'));"
+
+# ---- Q015e22_Append_Distribution_Y2_to_Y12_Static ----
+Q015e22_Append_Distribution_Y2_to_Y12_Static <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+        SELECT 'Program_Projections_2023-2024_Q015e22' AS Survey, 
+        Cohort_Program_Distributions_Static.PSSM_Credential, 
+        Cohort_Program_Distributions_Static.PSSM_CRED, 
+        Cohort_Program_Distributions_Static.LCP4_CD, 
+        Cohort_Program_Distributions_Static.GRAD_STATUS, 
+        Cohort_Program_Distributions_Static.TTRAIN, 
+        Cohort_Program_Distributions_Static.LCIP4_CRED, 
+        Cohort_Program_Distributions_Static.LCIP2_CRED, 
+        Cohort_Program_Distributions_Static.Age_Group, 
+        T_Cohort_Program_Distributions_Y2_to_Y12.Y2_to_Y10, 
+        Cohort_Program_Distributions_Static.Count, 
+        Cohort_Program_Distributions_Static.Total, 
+        Cohort_Program_Distributions_Static.[Percent]
+FROM Cohort_Program_Distributions_Static 
+INNER JOIN T_Cohort_Program_Distributions_Y2_to_Y12 
+ON Cohort_Program_Distributions_Static.Year = T_Cohort_Program_Distributions_Y2_to_Y12.Y1;"
+
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_1 ----
+qry_05_Flip_T_Predict_CIP_CRED_AGE_1 <-
+  "SELECT T_Predict_CIP_CRED_AGE.CIP,
+T_Predict_CIP_CRED_AGE.CRED, 
+T_Predict_CIP_CRED_AGE.AGE, 
+T_Predict_CIP_CRED_AGE.[2023/2024] AS [Count], 
+'2023/2024' AS [Year] 
+INTO T_Predict_CIP_CRED_AGE_Flipped
+FROM T_Predict_CIP_CRED_AGE;"
+
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2 ----
+qry_05_Flip_T_Predict_CIP_CRED_AGE_2 <-
+  "INSERT INTO T_Predict_CIP_CRED_AGE_Flipped ( CIP, CRED, AGE, [Year], [Count] )
+SELECT T_Predict_CIP_CRED_AGE.CIP, 
+T_Predict_CIP_CRED_AGE.CRED, 
+T_Predict_CIP_CRED_AGE.AGE, 
+'2020/2021' AS [Year], 
+T_Predict_CIP_CRED_AGE.[2020/2021]
+FROM T_Predict_CIP_CRED_AGE;"
+
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2_Check ----
+qry_05_Flip_T_Predict_CIP_CRED_AGE_2_Check <-
+  "SELECT T_Predict_CIP_CRED_AGE_Flipped.Year, 
+Sum(T_Predict_CIP_CRED_AGE_Flipped.Count) AS SumOfCount
+FROM T_Predict_CIP_CRED_AGE_Flipped
+GROUP BY T_Predict_CIP_CRED_AGE_Flipped.Year;"
+
+# ---- qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected ----
+qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected <- "
+DELETE 
+FROM    Cohort_Program_Distributions_Projected
+WHERE   (((Cohort_Program_Distributions_Projected.PSSM_CRED) Not In ('APPRAPPR','APPRCERT') 
+  AND   (Cohort_Program_Distributions_Projected.PSSM_CRED) Not Like '3 -%' 
+  AND   (Cohort_Program_Distributions_Projected.PSSM_CRED) Not Like 'P -%'));"
+
+# ---- qry_10a_Program_Dist_Count ----
+qry_10a_Program_Dist_Count <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS PSSM_CRED, 
+        T_Predict_CIP_CRED_AGE_Flipped.CIP, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [CIP], ' - ' 
+			, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIP4_CRED, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, Left([CIP],2), ' - ' 
+			, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIP2_CRED, 
+        T_Predict_CIP_CRED_AGE_Flipped.AGE, 
+        T_Predict_CIP_CRED_AGE_Flipped.Year, 
+       Sum(T_Predict_CIP_CRED_AGE_Flipped.Count) AS [Count]
+INTO qry_10a_Program_Dist_Count 
+FROM    T_Predict_CIP_CRED_AGE_Flipped 
+INNER JOIN T_PSSM_Projection_Cred_Grp 
+  ON T_Predict_CIP_CRED_AGE_Flipped.CRED = T_PSSM_Projection_Cred_Grp.PSSM_Projection_Credential
+WHERE   (((T_PSSM_Projection_Cred_Grp.PSSM_Credential) Not In ('APPRAPPR','APPRCERT','GRCT or GRDP','PDEG','MAST','DOCT')))
+GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+         CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+		    T_Predict_CIP_CRED_AGE_Flipped.CIP, 
+         CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [CIP], ' - ' 
+			, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) , 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, Left([CIP],2), ' - ' 
+			, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+        T_Predict_CIP_CRED_AGE_Flipped.AGE, 
+        T_Predict_CIP_CRED_AGE_Flipped.Year;"
+
+# ---- qry_10b_Program_Dist_Total ----
+qry_10b_Program_Dist_Total <-
+  "SELECT qry_10a_Program_Dist_Count.PSSM_Credential, 
+        qry_10a_Program_Dist_Count.PSSM_CRED, 
+        qry_10a_Program_Dist_Count.AGE, 
+        qry_10a_Program_Dist_Count.Year, 
+        Sum(qry_10a_Program_Dist_Count.Count) AS Totals
+INTO    qry_10b_Program_Dist_Total
+FROM    qry_10a_Program_Dist_Count
+GROUP BY qry_10a_Program_Dist_Count.PSSM_Credential, 
+        qry_10a_Program_Dist_Count.PSSM_CRED, 
+        qry_10a_Program_Dist_Count.AGE, 
+        qry_10a_Program_Dist_Count.Year;"
+
+# ---- qry_10c_Program_Dist_Distribution ----
+qry_10c_Program_Dist_Distribution <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_qry10c' AS Survey, 
+        qry_10a_Program_Dist_Count.PSSM_Credential, 
+        qry_10a_Program_Dist_Count.PSSM_CRED, 
+        qry_10a_Program_Dist_Count.CIP AS LCP4_CD, 
+        qry_10a_Program_Dist_Count.LCIP4_CRED, 
+        qry_10a_Program_Dist_Count.LCIP2_CRED, 
+        qry_10a_Program_Dist_Count.AGE AS Age_Group, 
+        qry_10a_Program_Dist_Count.Year, 
+        qry_10a_Program_Dist_Count.Count, 
+        qry_10b_Program_Dist_Total.Totals, 
+        CASE WHEN Totals = 0 THEN 0 ELSE CAST([Count] AS FLOAT)/CAST([Totals] AS FLOAT) END AS [Percent]
+FROM    qry_10a_Program_Dist_Count 
+INNER JOIN qry_10b_Program_Dist_Total 
+  ON    (qry_10a_Program_Dist_Count.Year = qry_10b_Program_Dist_Total.Year) 
+  AND   (qry_10a_Program_Dist_Count.AGE = qry_10b_Program_Dist_Total.AGE) 
+  AND   (qry_10a_Program_Dist_Count.PSSM_CRED = qry_10b_Program_Dist_Total.PSSM_CRED);"
+
+# ---- qry_12_LCP4_LCIPPC_Recode_9999 ----
+qry_12_LCP4_LCIPPC_Recode_9999 <-
+  "SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD, 
+        IIf([LCIP_LCP4_CD]='9999','99',[INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCIPPC_CD]) AS LCIP_LCIPPC_CD
+INTO    qry_12_LCP4_LCIPPC_Recode_9999
+FROM    INFOWARE_L_CIP_6DIGITS_CIP2016
+GROUP BY INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD, 
+        IIf([LCIP_LCP4_CD]='9999','99',[INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCIPPC_CD]);"
+
+# ---- qry_12a_Program_Dist_Count ----
+qry_12a_Program_Dist_Count <- "
+SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS PSSM_CRED, 
+        qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD AS LCIPPC_CD, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIPPC_CRED, 
+        T_Predict_CIP_CRED_AGE_Flipped.AGE AS Age_Group, 
+        T_Predict_CIP_CRED_AGE_Flipped.Year, 
+        Sum(T_Predict_CIP_CRED_AGE_Flipped.Count) AS [Count]
+INTO    qry_12a_Program_Dist_Count
+FROM    (T_Predict_CIP_CRED_AGE_Flipped INNER JOIN T_PSSM_Projection_Cred_Grp ON T_Predict_CIP_CRED_AGE_Flipped.CRED = T_PSSM_Projection_Cred_Grp.PSSM_Projection_Credential) 
+INNER JOIN qry_12_LCP4_LCIPPC_Recode_9999
+ON      T_Predict_CIP_CRED_AGE_Flipped.CIP = qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCP4_CD
+WHERE   (((T_PSSM_Projection_Cred_Grp.PSSM_Credential) In ('GRCT or GRDP','PDEG','MAST','DOCT')))
+GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+        CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+        qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD, 
+		CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]), 
+        T_Predict_CIP_CRED_AGE_Flipped.AGE, 
+		T_Predict_CIP_CRED_AGE_Flipped.Year;"
+
+# ---- qry_12b_Program_Dist_Total ----
+qry_12b_Program_Dist_Total <-
+  "SELECT qry_12a_Program_Dist_Count.PSSM_Credential, 
+        qry_12a_Program_Dist_Count.PSSM_CRED, 
+        qry_12a_Program_Dist_Count.Age_Group, 
+        qry_12a_Program_Dist_Count.Year, 
+        Sum(qry_12a_Program_Dist_Count.Count) AS Totals
+INTO qry_12b_Program_Dist_Total
+FROM qry_12a_Program_Dist_Count
+GROUP BY qry_12a_Program_Dist_Count.PSSM_Credential, 
+         qry_12a_Program_Dist_Count.PSSM_CRED, 
+         qry_12a_Program_Dist_Count.Age_Group, 
+         qry_12a_Program_Dist_Count.Year;"
+
+# ---- qry_12c_Program_Dist_Distribution ----
+qry_12c_Program_Dist_Distribution <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_qry12c' AS Survey, 
+        qry_12a_Program_Dist_Count.PSSM_Credential, 
+        qry_12a_Program_Dist_Count.PSSM_CRED, 
+        qry_12a_Program_Dist_Count.LCIPPC_CD, 
+        qry_12a_Program_Dist_Count.LCIPPC_CRED, 
+        qry_12a_Program_Dist_Count.Age_Group, 
+        qry_12a_Program_Dist_Count.Year, 
+        qry_12a_Program_Dist_Count.Count, 
+        qry_12b_Program_Dist_Total.Totals, 
+        IIf(([Totals]=0),0,[Count]/[Totals]) AS [%]
+FROM    qry_12a_Program_Dist_Count 
+INNER JOIN qry_12b_Program_Dist_Total 
+  ON    (qry_12a_Program_Dist_Count.PSSM_CRED = qry_12b_Program_Dist_Total.PSSM_CRED) 
+  AND   (qry_12a_Program_Dist_Count.Age_Group = qry_12b_Program_Dist_Total.Age_Group) 
+  AND   (qry_12a_Program_Dist_Count.Year = qry_12b_Program_Dist_Total.Year);"
+
+# ---- qry_12d_Check_Missing ----
+qry_12d_Check_Missing <-
+  "SELECT Cohort_Program_Distributions_Static.PSSM_Credential, 
+        Cohort_Program_Distributions_Static.PSSM_CRED, 
+        Cohort_Program_Distributions_Static.LCP4_CD, 
+        Cohort_Program_Distributions_Static.LCIP4_CRED, 
+        Cohort_Program_Distributions_Static.Age_Group, 
+        Cohort_Program_Distributions_Static.Year, 
+        Cohort_Program_Distributions_Projected.PSSM_Credential, 
+        Cohort_Program_Distributions_Projected.PSSM_CRED, 
+        Cohort_Program_Distributions_Projected.LCP4_CD, 
+        Cohort_Program_Distributions_Projected.Age_Group, 
+        Cohort_Program_Distributions_Projected.Year, 
+        Cohort_Program_Distributions_Static.Count
+FROM    Cohort_Program_Distributions_Static 
+LEFT JOIN Cohort_Program_Distributions_Projected 
+  ON    (Cohort_Program_Distributions_Static.Year = Cohort_Program_Distributions_Projected.Year) 
+  AND   (Cohort_Program_Distributions_Static.Age_Group = Cohort_Program_Distributions_Projected.Age_Group) 
+  AND   (Cohort_Program_Distributions_Static.LCP4_CD = Cohort_Program_Distributions_Projected.LCP4_CD) 
+  AND   (Cohort_Program_Distributions_Static.PSSM_CRED = Cohort_Program_Distributions_Projected.PSSM_CRED) 
+  AND   (Cohort_Program_Distributions_Static.PSSM_Credential = Cohort_Program_Distributions_Projected.PSSM_Credential)
+WHERE (((Cohort_Program_Distributions_Static.Age_Group) 
+      Not In ('15 to 16','65 to 89')) 
+      AND ((Cohort_Program_Distributions_Projected.PSSM_Credential) Is Null) 
+      AND ((Cohort_Program_Distributions_Projected.PSSM_CRED) Is Null) 
+      AND ((Cohort_Program_Distributions_Projected.LCP4_CD) Is Null) 
+      AND ((Cohort_Program_Distributions_Projected.Age_Group) Is Null) 
+      AND ((Cohort_Program_Distributions_Projected.Year) Is Null));"
+
+# ---- qry_13a0_Delete_Near_Completers_Projected ----
+qry_13a0_Delete_Near_Completers_Projected <-
+  "DELETE 
+FROM Cohort_Program_Distributions_Projected
+WHERE (((Cohort_Program_Distributions_Projected.PSSM_CRED) Like '3 - %'));"
+
+# ---- qry_13a0_Delete_Near_Completers_Static ----
+qry_13a0_Delete_Near_Completers_Static <-
+  "DELETE 
+FROM Cohort_Program_Distributions_Static
+WHERE (((Cohort_Program_Distributions_Static.PSSM_CRED) Like '3 - %'));"
+
+# ---- qry_13a_Near_completers ----
+qry_13a_Near_completers <-
+  "SELECT T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_Credential, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_CRED, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.LCP4_CD, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.COSC_GRAD_STATUS_LGDS_CD_Group, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.TTRAIN AS COSC_TTRAIN, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.LCIP4_CRED, 
+        CAST([COSC_GRAD_STATUS_LGDS_CD_Group] as NVARCHAR(50)) + ' - ' + Left([LCP4_CD],2) + ' - ' + CAST([TTRAIN] as NVARCHAR(50)) + ' - ' + [PSSM_Credential] AS LCIP2_CRED, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.Age_Group as AgeGroup, 
+        Sum(T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.[Near_completers_STP_Credentials]) AS [Count]
+INTO    qry_13a_Near_completers
+FROM    T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN
+GROUP BY T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_Credential, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_CRED, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.LCP4_CD, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.COSC_GRAD_STATUS_LGDS_CD_Group, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.TTRAIN, 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.LCIP4_CRED, 
+        CAST([COSC_GRAD_STATUS_LGDS_CD_Group] as NVARCHAR(50)) + ' - ' + Left([LCP4_CD],2) + ' - ' + CAST([TTRAIN] as NVARCHAR(50)) + ' - ' + [PSSM_Credential], 
+        T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.Age_Group;"
+
+# ---- qry_13b_Near_Completers_Total ----
+qry_13b_Near_Completers_Total <-
+  "SELECT qry_13a_Near_completers.PSSM_Credential, 
+        qry_13a_Near_completers.PSSM_CRED, 
+        qry_13a_Near_completers.AgeGroup, 
+        Sum(qry_13a_Near_completers.Count) AS Totals
+INTO    qry_13b_Near_Completers_Total
+FROM    qry_13a_Near_completers
+GROUP BY qry_13a_Near_completers.PSSM_Credential, 
+        qry_13a_Near_completers.PSSM_CRED, 
+        qry_13a_Near_completers.AgeGroup;"
+
+# ---- qry_13c_Near_Completers_Program_Dist ----
+qry_13c_Near_Completers_Program_Dist <-
+  "SELECT qry_13a_Near_completers.PSSM_Credential, 
+        qry_13a_Near_completers.PSSM_CRED, 
+        qry_13a_Near_completers.LCP4_CD, 
+        qry_13a_Near_completers.COSC_GRAD_STATUS_LGDS_CD_Group, 
+        qry_13a_Near_completers.COSC_TTRAIN, 
+        qry_13a_Near_completers.LCIP4_CRED, 
+        qry_13a_Near_completers.LCIP2_CRED, 
+        qry_13a_Near_completers.AgeGroup, 
+        qry_13a_Near_completers.Count, 
+        qry_13b_Near_Completers_Total.Totals, 
+        IIf([Totals]=0,0, cast(Count AS float)/cast(Totals as float)) AS [%]
+INTO    qry_13c_Near_Completers_Program_Dist
+FROM    qry_13b_Near_Completers_Total 
+INNER JOIN qry_13a_Near_completers 
+  ON    (qry_13b_Near_Completers_Total.AgeGroup = qry_13a_Near_completers.AgeGroup) 
+  AND   (qry_13b_Near_Completers_Total.PSSM_CRED = qry_13a_Near_completers.PSSM_CRED);"
+
+
+# ---- qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN ----
+qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN <-
+  "INSERT INTO  Cohort_Program_Distributions_Projected 
+        (Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_qry_13d' AS Survey, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCP4_CD, 
+        qry_13c_Near_Completers_Program_Dist.COSC_GRAD_STATUS_LGDS_CD_Group, 
+        qry_13c_Near_Completers_Program_Dist.COSC_TTRAIN, 
+        qry_13c_Near_Completers_Program_Dist.LCIP4_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCIP2_CRED, 
+        tbl_Age_Groups_Near_Completers.Age_Group_Label_Graduate_Projection AS AgeGroup, '2023/2024' AS Projection_Year, 
+        qry_13c_Near_Completers_Program_Dist.Count, qry_13c_Near_Completers_Program_Dist.Totals, 
+        qry_13c_Near_Completers_Program_Dist.[%]
+FROM    qry_13c_Near_Completers_Program_Dist 
+INNER JOIN tbl_Age_Groups_Near_Completers 
+  ON    qry_13c_Near_Completers_Program_Dist.AgeGroup = tbl_Age_Groups_Near_Completers.Age_Group_Label_Near_Completer_Projection;"
+
+
+# ---- qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN ----
+qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
+        ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
+SELECT 'Program_Projections_2023-2024_qry_13d' AS Survey, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCP4_CD, 
+        qry_13c_Near_Completers_Program_Dist.COSC_GRAD_STATUS_LGDS_CD_Group, 
+        qry_13c_Near_Completers_Program_Dist.COSC_TTRAIN, 
+        qry_13c_Near_Completers_Program_Dist.LCIP4_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCIP2_CRED, 
+        tbl_Age_Groups_Near_Completers.Age_Group_Label_Graduate_Projection AS AgeGroup, '2023/2024' AS Projection_Year, 
+        qry_13c_Near_Completers_Program_Dist.Count, 
+        qry_13c_Near_Completers_Program_Dist.Totals, 
+        qry_13c_Near_Completers_Program_Dist.[%]
+FROM    qry_13c_Near_Completers_Program_Dist 
+INNER JOIN tbl_Age_Groups_Near_Completers 
+  ON    qry_13c_Near_Completers_Program_Dist.AgeGroup = tbl_Age_Groups_Near_Completers.Age_Group_Label_Near_Completer_Projection;"
+
+# ---- NOT USED ----
+
+# ---- qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used ----
+qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used <-
+  "SELECT qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCP4_CD,'3' AS GRADSTAT, '0' AS TTRAIN, '3 - ' + [LCP4_CD] + ' - 0 - ' + [PSSM_Credential] AS LCIP4_CRED, 
+        qry_13c_Near_Completers_Program_Dist.AgeGroup, qry_13c_Near_Completers_Program_Dist.Count, qry_13c_Near_Completers_Program_Dist.Totals, 
+        qry_13c_Near_Completers_Program_Dist.[%]
+FROM    qry_13c_Near_Completers_Program_Dist
+UNION ALL 
+SELECT  qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCP4_CD,'3' AS GRADSTAT, '1' AS TTRAIN, '3 - ' + [LCP4_CD] + ' - 1 - ' + [PSSM_Credential] AS LCIP4_CRED, 
+        qry_13c_Near_Completers_Program_Dist.AgeGroup, qry_13c_Near_Completers_Program_Dist.Count, qry_13c_Near_Completers_Program_Dist.Totals, 
+        qry_13c_Near_Completers_Program_Dist.[%]
+FROM    qry_13c_Near_Completers_Program_Dist
+UNION ALL 
+SELECT  qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
+        qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
+        qry_13c_Near_Completers_Program_Dist.LCP4_CD, '3' AS GRADSTAT, '2' AS TTRAIN, '3 - ' + [LCP4_CD] + ' - 2 - ' + [PSSM_Credential] AS LCIP4_CRED, 
+        qry_13c_Near_Completers_Program_Dist.AgeGroup, qry_13c_Near_Completers_Program_Dist.Count, qry_13c_Near_Completers_Program_Dist.Totals, 
+        qry_13c_Near_Completers_Program_Dist.[%]
+FROM    qry_13c_Near_Completers_Program_Dist;"
+###############################################################################################
+
+# ---- Count_Cohort_Program_Distributions ----
+Count_Cohort_Program_Distributions <-
+  "SELECT Cohort_Program_Distributions.Survey,
+Count(*) AS Expr1
+FROM Cohort_Program_Distributions
+GROUP BY Cohort_Program_Distributions.Survey;"
+
+# ---- Count_Labour_Supply_Distribution ----
+Count_Labour_Supply_Distribution1 <-
+  "SELECT Labour_Supply_Distribution.Survey, LCIP4_CRED,
+Count(*) AS Expr1
+FROM Labour_Supply_Distribution
+GROUP BY Labour_Supply_Distribution.Survey, LCIP4_CRED;"
+
+# ---- Count_Labour_Supply_Distribution ----
+Count_Labour_Supply_Distribution2 <-
+  "SELECT Labour_Supply_Distribution.Survey, PSSM_CREDENTIAL,
+Count(*) AS Expr1
+FROM Labour_Supply_Distribution
+GROUP BY Labour_Supply_Distribution.Survey, PSSM_CREDENTIAL;"
+
+# ---- Count_Occupation_Distributions ----
+Count_Occupation_Distributions1 <-
+  "SELECT Occupation_Distributions.Survey, 
+Occupation_Distributions.PSSM_CREDENTIAL,
+Count(*) AS Expr1
+FROM Occupation_Distributions
+GROUP BY Occupation_Distributions.Survey, 
+Occupation_Distributions.PSSM_CREDENTIAL;"
+
+# ---- Count_Occupation_Distributions ----
+Count_Occupation_Distributions2 <-
+  "SELECT Occupation_Distributions.Survey, 
+Occupation_Distributions.LCIP4_CRED, 
+Count(*) AS Expr1
+FROM Occupation_Distributions
+GROUP BY Occupation_Distributions.Survey, 
+Occupation_Distributions.LCIP4_CRED"
+
+
+# ---- Occupation_Unknown ----
+Occupation_Unknown <-
+  "SELECT Cohort_Program_Distributions.LCIP4_CRED, 
+Labour_Supply_Distribution.LCIP4_CRED, 
+Cohort_Program_Distributions.Age_Group, 
+Occupation_Distributions.LCIP4_CRED, 
+Occupation_Distributions.Age_Group_Rollup, 
+Labour_Supply_Distribution.New_Labour_Supply, 
+Cohort_Program_Distributions.Year, 
+Cohort_Program_Distributions.Count, 
+Labour_Supply_Distribution.Count, 
+Occupation_Distributions.Count, 
+Cohort_Program_Distributions.[percent]
+FROM (Cohort_Program_Distributions 
+INNER JOIN (Labour_Supply_Distribution 
+	LEFT JOIN Occupation_Distributions 
+	ON (Labour_Supply_Distribution.Age_Group_Rollup = Occupation_Distributions.Age_Group_Rollup) 
+	AND (Labour_Supply_Distribution.LCIP4_CRED = Occupation_Distributions.LCIP4_CRED)
+) 
+ON Cohort_Program_Distributions.LCIP4_CRED = Labour_Supply_Distribution.LCIP4_CRED) 
+INNER JOIN tbl_Age_Groups 
+	ON (Labour_Supply_Distribution.Age_Group_Rollup = tbl_Age_Groups.Age_Group_Rollup) 
+	AND (Cohort_Program_Distributions.Age_Group = tbl_Age_Groups.Age_Group_Label)
+WHERE (((Occupation_Distributions.LCIP4_CRED) Is Null) 
+AND ((Occupation_Distributions.Age_Group_Rollup) Is Null) 
+AND ((Cohort_Program_Distributions.Year)='2023/2024'));"
+
+
+# ---- Q_0_LCP2_LCP4 ----
+Q_0_LCP2_LCP4 <-
+  "SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP2_CD, 
+INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD INTO T_LCP2_LCP4
+FROM INFOWARE_L_CIP_6DIGITS_CIP2016
+GROUP BY INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP2_CD, 
+INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD;"
+
+
+# ---- Q_0a_Delete_Private_Inst_Labour_Supply_Distribution ----
+Q_0a_Delete_Private_Inst_Labour_Supply_Distribution <-
+  "DELETE 
+FROM Labour_Supply_Distribution_No_TT
+WHERE (((Labour_Supply_Distribution_No_TT.PSSM_CRED) Like 'P - %'));"
+
+
+# ---- Q_0a_Delete_Private_Inst_Labour_Supply_Distribution_LCP2 ----
+Q_0a_Delete_Private_Inst_Labour_Supply_Distribution_LCP2 <-
+  "DELETE 
+FROM Labour_Supply_Distribution_LCP2_No_TT
+WHERE (((Labour_Supply_Distribution_LCP2_No_TT.PSSM_CRED) Like 'P - %'));"
+
+
+# ---- Q_0a_Delete_Private_Inst_Occupation_Distribution ----
+Q_0a_Delete_Private_Inst_Occupation_Distribution <-
+  "DELETE 
+FROM Occupation_Distributions_No_TT
+WHERE (((Occupation_Distributions_No_TT.PSSM_CRED) Like 'P - %'));"
+
+# ---- Q_0a_Delete_Private_Inst_Occupation_Distribution_LCP2 ----
+Q_0a_Delete_Private_Inst_Occupation_Distribution_LCP2 <-
+  "DELETE 
+FROM Occupation_Distributions_LCP2_No_TT
+WHERE (((Occupation_Distributions_LCP2_No_TT.PSSM_CRED) Like 'P - %'));"
+
+# ---- Q_0b_Append_Private_Institution_Labour_Supply_Distribution ----
+Q_0b_Append_Private_Institution_Labour_Supply_Distribution <-
+  "INSERT INTO Labour_Supply_Distribution_No_TT 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, [Count], Total, New_Labour_Supply )
+SELECT 'PTIB' AS Survey, 
+Labour_Supply_Distribution_No_TT.PSSM_Credential, 
+'P - ' + [Labour_Supply_Distribution_No_TT].[PSSM_Credential] AS PSSM_CRED, 
+Labour_Supply_Distribution_No_TT.LCP4_CD, 'P - ' + [Labour_Supply_Distribution_No_TT].[LCP4_CD] + ' - ' + [Labour_Supply_Distribution_No_TT].[PSSM_Credential] AS LCIP4_CRED, 
+Labour_Supply_Distribution_No_TT.Current_Region_PSSM_Code_Rollup, 
+Labour_Supply_Distribution_No_TT.Age_Group_Rollup, Labour_Supply_Distribution_No_TT.Count, Labour_Supply_Distribution_No_TT.Total, 
+Labour_Supply_Distribution_No_TT.New_Labour_Supply
+FROM Labour_Supply_Distribution_No_TT
+WHERE (((Labour_Supply_Distribution_No_TT.PSSM_Credential) In ('CERT','DIPL','ADGR or UT','BACH','MAST','DOCT')) 
+AND ((Labour_Supply_Distribution_No_TT.LCIP4_CRED) Not Like '3 - %'));"
+
+
+# ---- Q_0b_Append_Private_Institution_Labour_Supply_Distribution_2D ----
+Q_0b_Append_Private_Institution_Labour_Supply_Distribution_2D <-
+  "INSERT INTO Labour_Supply_Distribution_LCP2_No_TT 
+( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCP2_CRED, 
+Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, [Count], Total, New_Labour_Supply )
+SELECT 'PTIB' AS Survey, Labour_Supply_Distribution_LCP2_No_TT.PSSM_Credential, 
+'P - ' + [Labour_Supply_Distribution_LCP2_No_TT].[PSSM_Credential] AS PSSM_CRED, 
+Labour_Supply_Distribution_LCP2_No_TT.LCP2_CD, 'P - ' + [Labour_Supply_Distribution_LCP2_No_TT].[LCP2_CD] + ' - ' + [Labour_Supply_Distribution_LCP2_No_TT].[PSSM_Credential] AS LCIP2_CRED, 
+Labour_Supply_Distribution_LCP2_No_TT.Current_Region_PSSM_Code_Rollup, 
+Labour_Supply_Distribution_LCP2_No_TT.Age_Group_Rollup, 
+Labour_Supply_Distribution_LCP2_No_TT.Count, 
+Labour_Supply_Distribution_LCP2_No_TT.Total, 
+Labour_Supply_Distribution_LCP2_No_TT.New_Labour_Supply
+FROM Labour_Supply_Distribution_LCP2_No_TT
+WHERE (((Labour_Supply_Distribution_LCP2_No_TT.PSSM_Credential) In ('CERT','DIPL','ADGR or UT','BACH','MAST','DOCT')) 
+AND ((Labour_Supply_Distribution_LCP2_No_TT.LCP2_CRED) Not Like '3 - %'));"
+
+
+# ---- Q_0c_Append_Private_Institution_Occupation_Distribution ----
+Q_0c_Append_Private_Institution_Occupation_Distribution <-
+  "INSERT INTO Occupation_Distributions_No_TT 
+( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, NOC, [Count], Total, [Percent] )
+SELECT 'PTIB' AS Survey, 
+Occupation_Distributions_No_TT.PSSM_Credential, 
+'P - ' + [Occupation_Distributions_No_TT].[PSSM_Credential] AS PSSM_CRED, 
+Occupation_Distributions_No_TT.LCP4_CD, 'P - ' + [Occupation_Distributions_No_TT].[LCP4_CD] + ' - ' + [Occupation_Distributions_No_TT].[PSSM_Credential] AS LCIP4_CRED, 
+Occupation_Distributions_No_TT.LCIP2_CRED, 
+Occupation_Distributions_No_TT.Current_Region_PSSM_Code_Rollup, 
+Occupation_Distributions_No_TT.Age_Group_Rollup, 
+Occupation_Distributions_No_TT.NOC, 
+Occupation_Distributions_No_TT.[Count], 
+Occupation_Distributions_No_TT.[Total], 
+Occupation_Distributions_No_TT.[Percent]
+FROM Occupation_Distributions_No_TT
+WHERE (((Occupation_Distributions_No_TT.PSSM_Credential) In ('CERT','DIPL','ADGR or UT','BACH','MAST','DOCT')) 
+AND ((Occupation_Distributions_No_TT.LCIP4_CRED) Not Like '3 - %'));"
+
+
+# ---- Q_0c_Append_Private_Institution_Occupation_Distribution_2D ----
+Q_0c_Append_Private_Institution_Occupation_Distribution_2D <-
+  "INSERT INTO Occupation_Distributions_LCP2_No_TT 
+( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCIP2_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, NOC, [Count], Total, [Percent] )
+SELECT 'PTIB' AS Survey, 
+Occupation_Distributions_LCP2_No_TT.PSSM_Credential, 
+'P - ' + [Occupation_Distributions_LCP2_No_TT].[PSSM_Credential] AS PSSM_CRED, 
+Occupation_Distributions_LCP2_No_TT.LCP2_CD, 'P - ' + [Occupation_Distributions_LCP2_No_TT].[LCP2_CD] + ' - ' + [Occupation_Distributions_LCP2_No_TT].[PSSM_Credential] AS LCIP2_CRED, 
+Occupation_Distributions_LCP2_No_TT.Current_Region_PSSM_Code_Rollup, 
+Occupation_Distributions_LCP2_No_TT.Age_Group_Rollup, 
+Occupation_Distributions_LCP2_No_TT.NOC, 
+Occupation_Distributions_LCP2_No_TT.[Count], 
+Occupation_Distributions_LCP2_No_TT.[Total], 
+Occupation_Distributions_LCP2_No_TT.[Percent]
+FROM Occupation_Distributions_LCP2_No_TT
+WHERE (((Occupation_Distributions_LCP2_No_TT.PSSM_Credential) In ('CERT','DIPL','ADGR or UT','BACH','MAST','DOCT')) 
+AND ((Occupation_Distributions_LCP2_No_TT.LCIP2_CRED) Not Like '3 - %'));"
+
+
+# ---- Q_1_Grad_Projections_by_Age_by_Program ----
+Q_1_Grad_Projections_by_Age_by_Program <-
+  "SELECT Cohort_Program_Distributions.PSSM_Credential AS PSSM_Credential, 
+        Graduate_Projections.PSSM_CRED, 
+        Graduate_Projections.Age_Group, 
+        Graduate_Projections.Year, 
+        Cohort_Program_Distributions.LCP4_CD, 
+        Cohort_Program_Distributions.GRAD_STATUS, 
+        Cohort_Program_Distributions.TTRAIN, 
+        Cohort_Program_Distributions.LCIP4_CRED, 
+        [Graduate_Projections].[Graduates]*[Cohort_Program_Distributions].[Percent] AS Grads
+INTO Q_1_Grad_Projections_by_Age_by_Program
+FROM    ((T_Exclude_from_Projections_LCP4_CD 
+RIGHT JOIN (Graduate_Projections 
+  INNER JOIN Cohort_Program_Distributions 
+    ON  (Graduate_Projections.Year = Cohort_Program_Distributions.Year) 
+    AND (Graduate_Projections.Age_Group = Cohort_Program_Distributions.Age_Group) 
+    AND (Graduate_Projections.PSSM_CRED = Cohort_Program_Distributions.PSSM_CRED)) 
+  ON    T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD = Cohort_Program_Distributions.LCP4_CD) 
+LEFT JOIN T_Exclude_from_Projections_PSSM_Credential 
+  ON    Cohort_Program_Distributions.PSSM_Credential = T_Exclude_from_Projections_PSSM_Credential.PSSM_Credential) 
+LEFT JOIN T_Exclude_from_Projections_LCIP4_CRED 
+  ON    Cohort_Program_Distributions.LCIP4_CRED = T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED
+WHERE   (((T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD) Is Null) 
+  AND   ((T_Exclude_from_Projections_PSSM_Credential.PSSM_Credential) Is Null) 
+  AND   ((T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED) Is Null));"
+
+
+# ---- Q_1_Grad_Projections_by_Age_by_Program_Static ----
+Q_1_Grad_Projections_by_Age_by_Program_Static <- "
+SELECT Cohort_Program_Distributions_Static.PSSM_Credential, 
+       Graduate_Projections.PSSM_CRED, 
+       Graduate_Projections.Age_Group, 
+       Graduate_Projections.Year, 
+       Cohort_Program_Distributions_Static.LCP4_CD, 
+       Cohort_Program_Distributions_Static.GRAD_STATUS, 
+       Cohort_Program_Distributions_Static.TTRAIN, 
+       --Cohort_Program_Distributions_Static.LCIP4_CRED, 
+       [Graduate_Projections].[Graduates]*[Cohort_Program_Distributions_Static].[Percent] AS Grads, 
+       T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED
+INTO Q_1_Grad_Projections_by_Age_by_Program_Static
+FROM  (((Graduate_Projections 
+INNER JOIN Cohort_Program_Distributions_Static 
+  ON  (Cohort_Program_Distributions_Static.Year = Graduate_Projections.Year) 
+  AND (Graduate_Projections.Age_Group = Cohort_Program_Distributions_Static.Age_Group) 
+  AND (Graduate_Projections.PSSM_CRED = Cohort_Program_Distributions_Static.PSSM_CRED)) 
+LEFT JOIN T_Exclude_from_Projections_PSSM_Credential 
+  ON  Cohort_Program_Distributions_Static.PSSM_Credential = T_Exclude_from_Projections_PSSM_Credential.PSSM_Credential) 
+LEFT JOIN T_Exclude_from_Projections_LCP4_CD 
+  ON  Cohort_Program_Distributions_Static.LCP4_CD = T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD) 
+LEFT JOIN T_Exclude_from_Projections_LCIP4_CRED 
+  ON  Cohort_Program_Distributions_Static.LCIP4_CRED = T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED
+WHERE (((T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED) Is Null) 
+  AND ((T_Exclude_from_Projections_PSSM_Credential.PSSM_Credential) Is Null) 
+  AND ((T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD) Is Null));"
+
+
+# ---- Q_1b_Checking_Grads_by_Year_Excludes_CIPs ----
+Q_1b_Checking_Grads_by_Year_Excludes_CIPs <- "
+SELECT PSSM_Credential, PSSM_CRED, Age_Group, [2022/2023], [2023/2024], [2024/2025], 
+[2025/2026], [2026/2027], [2027/2028], [2028/2029], [2029/2030], [2030/2031], [2031/2032], 
+[2032/2033], [2033/2034],[2034/2035]
+FROM (
+    SELECT PSSM_Credential, PSSM_CRED, Age_Group, Year, Grads
+	FROM Q_1_Grad_Projections_by_Age_by_Program
+) AS SourceTable
+PIVOT (
+    Sum(Grads) 
+	FOR Year IN
+    ([2022/2023], [2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], 
+    [2028/2029], [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+order by PSSM_Credential, PSSM_CRED, Age_Group"
+
+
+# ---- Q_1c_Grad_Projections_by_Program ----
+Q_1c_Grad_Projections_by_Program <-
+  "SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+        Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
+        tbl_Age_Groups_Rollup.Age_Group_Rollup, 
+        tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
+        Q_1_Grad_Projections_by_Age_by_Program.Year, 
+        Q_1_Grad_Projections_by_Age_by_Program.GRAD_STATUS, 
+        Q_1_Grad_Projections_by_Age_by_Program.TTRAIN, 
+        Q_1_Grad_Projections_by_Age_by_Program.LCP4_CD, 
+        Q_1_Grad_Projections_by_Age_by_Program.LCIP4_CRED, 
+        Sum(Q_1_Grad_Projections_by_Age_by_Program.Grads) AS Grads
+INTO Q_1c_Grad_Projections_by_Program
+FROM    (Q_1_Grad_Projections_by_Age_by_Program 
+INNER JOIN tbl_Age_Groups 
+  ON    Q_1_Grad_Projections_by_Age_by_Program.Age_Group = tbl_Age_Groups.Age_Group_Label) 
+INNER JOIN tbl_Age_Groups_Rollup 
+  ON    tbl_Age_Groups.Age_Group_Rollup = tbl_Age_Groups_Rollup.Age_Group_Rollup
+GROUP BY Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+        Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
+        tbl_Age_Groups_Rollup.Age_Group_Rollup, 
+        tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
+        Q_1_Grad_Projections_by_Age_by_Program.Year, 
+        Q_1_Grad_Projections_by_Age_by_Program.GRAD_STATUS, 
+        Q_1_Grad_Projections_by_Age_by_Program.TTRAIN, 
+        Q_1_Grad_Projections_by_Age_by_Program.LCP4_CD, 
+        Q_1_Grad_Projections_by_Age_by_Program.LCIP4_CRED;"
+
+
+# ---- Q_1c_Grad_Projections_by_Program_LCP2 ----
+Q_1c_Grad_Projections_by_Program_LCP2 <-
+  " SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
+tbl_Age_Groups_Rollup.Age_Group_Rollup, 
+tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
+Q_1_Grad_Projections_by_Age_by_Program.Year, 
+Left(LCP4_CD,2) AS LCP2_CD, 
+Q_1_Grad_Projections_by_Age_by_Program.GRAD_STATUS, 
+Q_1_Grad_Projections_by_Age_by_Program.TTRAIN, 
+CONCAT(
+  (CASE WHEN (Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3' Or Left(PSSM_CRED,1)='P') THEN Left(PSSM_CRED,1) + ' - ' ELSE '' END)
+  , Left(LCP4_CD,2) 
+  , ' - ' 
+  , CASE WHEN TTRAIN IS NULL THEN Null ELSE CAST(TTRAIN AS NVARCHAR(50)) + ' - ' END 
+  , PSSM_Credential) AS LCIP2_CRED, 
+Sum(Q_1_Grad_Projections_by_Age_by_Program.Grads) AS Grads
+INTO Q_1c_Grad_Projections_by_Program_LCP2
+FROM    (Q_1_Grad_Projections_by_Age_by_Program 
+         INNER JOIN tbl_Age_Groups 
+         ON    Q_1_Grad_Projections_by_Age_by_Program.Age_Group = tbl_Age_Groups.Age_Group_Label) 
+INNER JOIN tbl_Age_Groups_Rollup 
+ON    tbl_Age_Groups.Age_Group_Rollup = tbl_Age_Groups_Rollup.Age_Group_Rollup
+GROUP BY Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
+tbl_Age_Groups_Rollup.Age_Group_Rollup, 
+tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
+Q_1_Grad_Projections_by_Age_by_Program.Year, 
+Left([LCP4_CD],2), 
+Q_1_Grad_Projections_by_Age_by_Program.GRAD_STATUS, 
+Q_1_Grad_Projections_by_Age_by_Program.TTRAIN,
+CONCAT(
+  (CASE WHEN (Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3' Or Left(PSSM_CRED,1)='P') THEN Left(PSSM_CRED,1) + ' - ' ELSE '' END)
+  , Left(LCP4_CD,2) 
+  , ' - ' 
+  , CASE WHEN TTRAIN IS NULL THEN Null ELSE CAST(TTRAIN AS NVARCHAR(50)) + ' - ' END 
+  , PSSM_Credential);"
+
+
+# ---- Q_2_Labour_Supply_by_LCIP4_CRED ----
+Q_2_Labour_Supply_by_LCIP4_CRED <- "
+SELECT Q_1c_Grad_Projections_by_Program.PSSM_Credential, 
+Q_1c_Grad_Projections_by_Program.PSSM_CRED, 
+Q_1c_Grad_Projections_by_Program.Age_Group_Rollup, 
+Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, 
+Q_1c_Grad_Projections_by_Program.Year, 
+Q_1c_Grad_Projections_by_Program.TTRAIN, 
+Q_1c_Grad_Projections_by_Program.LCP4_CD AS LCP4_CD, 
+Q_1c_Grad_Projections_by_Program.LCIP4_CRED, 
+Labour_Supply_Distribution.Current_Region_PSSM_Code_Rollup, 
+Labour_Supply_Distribution.New_Labour_Supply, [Grads]*[New_Labour_Supply] AS NLS
+INTO Q_2_Labour_Supply_by_LCIP4_CRED 
+FROM Q_1c_Grad_Projections_by_Program 
+INNER JOIN Labour_Supply_Distribution 
+ON (Q_1c_Grad_Projections_by_Program.LCIP4_CRED = Labour_Supply_Distribution.LCIP4_CRED) 
+AND (Q_1c_Grad_Projections_by_Program.Age_Group_Rollup = Labour_Supply_Distribution.Age_Group_Rollup);"
+
+
+# ---- Q_2a_Labour_Supply_Unknown ----
+Q_2a_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads)       AS Grads
+INTO Q_2a_Labour_Supply_Unknown
+FROM   q_1c_grad_projections_by_program
+       LEFT JOIN labour_supply_distribution
+              ON ( q_1c_grad_projections_by_program.age_group_rollup =
+                             labour_supply_distribution.age_group_rollup )
+                 AND ( q_1c_grad_projections_by_program.lcip4_cred =
+                           labour_supply_distribution.lcip4_cred )
+WHERE  ( ( ( labour_supply_distribution.lcip4_cred ) IS NULL )
+         AND ( ( labour_supply_distribution.age_group_rollup ) IS NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.ttrain,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+# ---- Q_2a2_Labour_Supply_Unknown_No_TT_Proxy ----
+Q_2a2_Labour_Supply_Unknown_No_TT_Proxy <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.year,
+       q_2a_labour_supply_unknown.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd                         AS
+       LCP4_CD,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       labour_supply_distribution_no_tt.current_region_pssm_code_rollup,
+       labour_supply_distribution_no_tt.new_labour_supply,
+       [q_1c_grad_projections_by_program].[grads] * [new_labour_supply] AS NLS
+INTO Q_2a2_Labour_Supply_Unknown_No_TT_Proxy
+FROM   labour_supply_distribution_no_tt
+       INNER JOIN (q_2a_labour_supply_unknown
+                   INNER JOIN q_1c_grad_projections_by_program
+                           ON ( q_2a_labour_supply_unknown.year =
+                                q_1c_grad_projections_by_program.year )
+                              AND ( q_2a_labour_supply_unknown.lcip4_cred =
+q_1c_grad_projections_by_program.lcip4_cred )
+AND ( q_2a_labour_supply_unknown.age_group_rollup =
+q_1c_grad_projections_by_program.age_group_rollup )
+AND ( q_2a_labour_supply_unknown.pssm_cred =
+q_1c_grad_projections_by_program.pssm_cred ))
+ON ( labour_supply_distribution_no_tt.age_group_rollup =
+q_1c_grad_projections_by_program.age_group_rollup )
+AND ( labour_supply_distribution_no_tt.lcip4_cred =
+q_1c_grad_projections_by_program.lcip4_cred );"
+
+
+# ---- Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union ----
+Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union <-
+  "SELECT Q_2_Labour_Supply_by_LCIP4_CRED.*
+INTO Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union
+FROM Q_2_Labour_Supply_by_LCIP4_CRED
+UNION ALL SELECT Q_2a2_Labour_Supply_Unknown_No_TT_Proxy.*
+FROM Q_2a2_Labour_Supply_Unknown_No_TT_Proxy;"
+
+
+# ---- Q_2a4_Labour_Supply ----
+Q_2a4_Labour_Supply <-
+  "SELECT Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union.* 
+INTO tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp
+FROM Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union;"
+
+
+# ---- Q_2b_Labour_Supply_Unknown ----
+Q_2b_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads)       AS Grads
+INTO Q_2b_Labour_Supply_Unknown
+FROM   tmp_tbl_q_2a4_labour_supply_by_lcip4_cred_no_tt_union_tmp
+       RIGHT JOIN q_1c_grad_projections_by_program
+               ON
+       (
+tmp_tbl_q_2a4_labour_supply_by_lcip4_cred_no_tt_union_tmp.age_group_rollup =
+           q_1c_grad_projections_by_program.age_group_rollup )
+           AND (
+tmp_tbl_q_2a4_labour_supply_by_lcip4_cred_no_tt_union_tmp.lcip4_cred =
+    q_1c_grad_projections_by_program.lcip4_cred )
+WHERE  ( ( (
+tmp_tbl_q_2a4_labour_supply_by_lcip4_cred_no_tt_union_tmp.lcip4_cred ) IS
+       NULL )
+         AND ( (
+tmp_tbl_q_2a4_labour_supply_by_lcip4_cred_no_tt_union_tmp.age_group_rollup )
+  IS NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.ttrain,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+# ---- Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy ----
+Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.year,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd                         AS
+       LCP4_CD,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       labour_supply_distribution_no_tt.current_region_pssm_code_rollup,
+       labour_supply_distribution_no_tt.new_labour_supply,
+       [q_1c_grad_projections_by_program].[grads] * [new_labour_supply] AS NLS
+INTO Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy 
+FROM   (q_2b_labour_supply_unknown
+        INNER JOIN q_1c_grad_projections_by_program
+                ON ( q_2b_labour_supply_unknown.pssm_cred =
+                                q_1c_grad_projections_by_program.pssm_cred )
+                   AND ( q_2b_labour_supply_unknown.age_group_rollup =
+                             q_1c_grad_projections_by_program.age_group_rollup )
+                   AND ( q_2b_labour_supply_unknown.lcip4_cred =
+                             q_1c_grad_projections_by_program.lcip4_cred )
+                   AND ( q_2b_labour_supply_unknown.year =
+                         q_1c_grad_projections_by_program.year ))
+       INNER JOIN labour_supply_distribution_no_tt
+               ON ( q_1c_grad_projections_by_program.age_group_rollup =
+labour_supply_distribution_no_tt.age_group_rollup )
+AND ( q_1c_grad_projections_by_program.lcp4_cd =
+labour_supply_distribution_no_tt.lcp4_cd )
+WHERE  ( ( ( q_1c_grad_projections_by_program.pssm_cred ) LIKE 'P - CERT' )
+         AND ( ( labour_supply_distribution_no_tt.pssm_cred ) LIKE 'P - DIPL' )
+       )
+        OR ( ( ( q_1c_grad_projections_by_program.pssm_cred ) LIKE 'P - DIPL' )
+             AND ( ( labour_supply_distribution_no_tt.pssm_cred ) LIKE
+                   'P - CERT' ) );"
+
+
+# ---- Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union ----
+Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union <-
+  "SELECT tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp.*
+INTO Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union
+FROM tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp
+UNION ALL SELECT Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy.*
+FROM Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy;"
+
+
+# ---- Q_2b4_Labour_Supply_Unknown ----
+Q_2b4_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred       AS LCIP4_CRED,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads)       AS Grads
+INTO Q_2b4_Labour_Supply_Unknown
+FROM   q_1c_grad_projections_by_program
+       LEFT JOIN q_2b3_labour_supply_by_lcip4_cred_private_cred_proxy_union
+              ON ( q_1c_grad_projections_by_program.age_group_rollup =
+q_2b3_labour_supply_by_lcip4_cred_private_cred_proxy_union.age_group_rollup )
+AND ( q_1c_grad_projections_by_program.lcip4_cred =
+q_2b3_labour_supply_by_lcip4_cred_private_cred_proxy_union.lcip4_cred )
+WHERE  ( ( (
+q_2b3_labour_supply_by_lcip4_cred_private_cred_proxy_union.lcip4_cred ) IS
+       NULL )
+         AND
+         (
+         (
+q_2b3_labour_supply_by_lcip4_cred_private_cred_proxy_union.age_group_rollup )
+  IS NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.ttrain,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+
+# ---- Q_2c_Labour_Supply_Unknown_LCP2_Proxy ----
+Q_2c_Labour_Supply_Unknown_LCP2_Proxy <-
+  "SELECT Q_2b4_Labour_Supply_Unknown.PSSM_Credential, 
+        Q_2b4_Labour_Supply_Unknown.PSSM_CRED, 
+        Q_2b4_Labour_Supply_Unknown.Age_Group_Rollup, 
+        Q_2b4_Labour_Supply_Unknown.Age_Group_Rollup_Label, 
+        Q_2b4_Labour_Supply_Unknown.Year, 
+        Q_2b4_Labour_Supply_Unknown.TTRAIN, Q_2b4_Labour_Supply_Unknown.LCP4_CD, 
+        Q_2b4_Labour_Supply_Unknown.LCIP4_CRED, 
+        Labour_Supply_Distribution_LCP2.Current_Region_PSSM_Code_Rollup, 
+        Labour_Supply_Distribution_LCP2.New_Labour_Supply, 
+        [Grads]*[New_Labour_Supply] AS NLS
+INTO Q_2c_Labour_Supply_Unknown_LCP2_Proxy
+FROM Labour_Supply_Distribution_LCP2 
+INNER JOIN ((Q_2b4_Labour_Supply_Unknown 
+    LEFT JOIN T_Exclude_from_Labour_Supply_Unknown_LCP2_Proxy 
+    ON Q_2b4_Labour_Supply_Unknown.LCP4_CD = T_Exclude_from_Labour_Supply_Unknown_LCP2_Proxy.LCIP_LCP4_CD) 
+  INNER JOIN T_LCP2_LCP4 ON Q_2b4_Labour_Supply_Unknown.LCP4_CD = T_LCP2_LCP4.LCIP_LCP4_CD) 
+  ON (Labour_Supply_Distribution_LCP2.Age_Group_Rollup = Q_2b4_Labour_Supply_Unknown.Age_Group_Rollup) 
+  AND (Labour_Supply_Distribution_LCP2.LCP2_CD = T_LCP2_LCP4.LCIP_LCP2_CD) 
+  AND (Labour_Supply_Distribution_LCP2.PSSM_CRED = Q_2b4_Labour_Supply_Unknown.PSSM_CRED)
+WHERE (((T_Exclude_from_Labour_Supply_Unknown_LCP2_Proxy.LCIP_LCP4_CD) Is Null)) 
+OR (((Left([LCIP4_CRED],1))='P - '));"
+
+
+# ---- Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union ----
+Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union <-
+  "SELECT Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union.*
+INTO Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union
+FROM Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union
+UNION ALL SELECT Q_2c_Labour_Supply_Unknown_LCP2_Proxy.*
+FROM Q_2c_Labour_Supply_Unknown_LCP2_Proxy;"
+
+
+# ---- Q_2c3_Labour_Supply_Unknown ----
+Q_2c3_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads)       AS Grads
+INTO Q_2c3_Labour_Supply_Unknown
+FROM   q_1c_grad_projections_by_program
+       LEFT JOIN q_2c2_labour_supply_unknown_lcp2_proxy_union
+              ON ( q_1c_grad_projections_by_program.age_group_rollup =
+       q_2c2_labour_supply_unknown_lcp2_proxy_union.age_group_rollup )
+       AND ( q_1c_grad_projections_by_program.lcip4_cred =
+       q_2c2_labour_supply_unknown_lcp2_proxy_union.lcip4_cred )
+WHERE  ( ( ( q_2c2_labour_supply_unknown_lcp2_proxy_union.lcip4_cred ) IS NULL )
+         AND ( ( q_2c2_labour_supply_unknown_lcp2_proxy_union.age_group_rollup )
+               IS
+               NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.ttrain,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+
+# ---- Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT ----
+Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT <-
+  "SELECT q_2c3_labour_supply_unknown.pssm_credential,
+       q_2c3_labour_supply_unknown.pssm_cred,
+       q_2c3_labour_supply_unknown.age_group_rollup,
+       q_2c3_labour_supply_unknown.age_group_rollup_label,
+       q_2c3_labour_supply_unknown.year,
+       q_2c3_labour_supply_unknown.ttrain,
+       q_2c3_labour_supply_unknown.lcp4_cd,
+       q_2c3_labour_supply_unknown.lcip4_cred,
+       labour_supply_distribution_lcp2_no_tt.current_region_pssm_code_rollup,
+       labour_supply_distribution_lcp2_no_tt.new_labour_supply,
+       [grads] * [new_labour_supply] AS NLS
+INTO   Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT
+FROM   labour_supply_distribution_lcp2_no_tt
+       INNER JOIN ((t_exclude_from_labour_supply_unknown_lcp2_proxy
+                    RIGHT JOIN q_2c3_labour_supply_unknown
+                            ON
+       t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd =
+       q_2c3_labour_supply_unknown.lcp4_cd)
+                   INNER JOIN t_lcp2_lcp4
+                           ON q_2c3_labour_supply_unknown.lcp4_cd =
+                              t_lcp2_lcp4.lcip_lcp4_cd)
+               ON ( t_lcp2_lcp4.lcip_lcp2_cd =
+       labour_supply_distribution_lcp2_no_tt.lcp2_cd )
+                  AND ( labour_supply_distribution_lcp2_no_tt.age_group_rollup =
+                            q_2c3_labour_supply_unknown.age_group_rollup )
+                  AND ( labour_supply_distribution_lcp2_no_tt.pssm_cred =
+                            q_2c3_labour_supply_unknown.pssm_cred )
+WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS
+          NULL ))
+        OR (( ( LEFT([lcip4_cred], 1) ) = 'P - ' ));"
+
+
+# ---- Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union ----
+Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union.*
+INTO Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
+FROM Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union
+UNION ALL Select Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT.*
+FROM Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT;"
+
+
+# ---- Q_2d2_Labour_Supply ----
+Q_2d2_Labour_Supply <-
+  "SELECT Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.* 
+INTO tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp
+FROM Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union;"
+
+
+# ---- Q_2d2_Labour_Supply_Unknown ----
+Q_2d2_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.ttrain,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred       AS LCIP4_CRED,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads)       AS Grads
+INTO   Q_2d2_Labour_Supply_Unknown 
+FROM   q_1c_grad_projections_by_program
+       LEFT JOIN tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union_tmp
+              ON ( q_1c_grad_projections_by_program.age_group_rollup =
+tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union_tmp.age_group_rollup )
+AND ( q_1c_grad_projections_by_program.lcip4_cred =
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union_tmp.lcip4_cred )
+WHERE  ( (
+( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union_tmp.lcip4_cred ) IS
+NULL
+         )
+         AND
+(
+(
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union_tmp.age_group_rollup )
+               IS
+                   NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.ttrain,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+# ---- Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy ----
+Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy <-
+  "SELECT q_2d2_labour_supply_unknown.pssm_credential,
+       q_2d2_labour_supply_unknown.pssm_cred,
+       q_2d2_labour_supply_unknown.age_group_rollup,
+       q_2d2_labour_supply_unknown.age_group_rollup_label,
+       q_2d2_labour_supply_unknown.year,
+       q_2d2_labour_supply_unknown.ttrain,
+       q_2d2_labour_supply_unknown.lcp4_cd AS LCP4_CD,
+       q_2d2_labour_supply_unknown.lcip4_cred,
+       labour_supply_distribution_lcp2_no_tt.current_region_pssm_code_rollup,
+       labour_supply_distribution_lcp2_no_tt.new_labour_supply,
+       [grads] * [new_labour_supply]       AS NLS
+INTO Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy
+FROM   labour_supply_distribution_lcp2_no_tt
+       INNER JOIN (t_lcp2_lcp4
+                   INNER JOIN q_2d2_labour_supply_unknown
+                           ON t_lcp2_lcp4.lcip_lcp4_cd =
+                              q_2d2_labour_supply_unknown.lcp4_cd)
+               ON ( labour_supply_distribution_lcp2_no_tt.age_group_rollup =
+                               q_2d2_labour_supply_unknown.age_group_rollup )
+                  AND ( labour_supply_distribution_lcp2_no_tt.lcp2_cd =
+                        t_lcp2_lcp4.lcip_lcp2_cd )
+WHERE  ( ( ( q_2d2_labour_supply_unknown.pssm_cred ) LIKE 'P - CERT' )
+         AND ( ( labour_supply_distribution_lcp2_no_tt.pssm_cred ) LIKE
+               'P - DIPL' ) )
+        OR ( ( ( q_2d2_labour_supply_unknown.pssm_cred ) LIKE 'P - DIPL' )
+             AND ( ( labour_supply_distribution_lcp2_no_tt.pssm_cred ) LIKE
+                   'P - CERT'
+                 ) );"
+
+
+# ---- Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union ----
+Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp.*
+INTO Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union
+FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp
+UNION ALL SELECT Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy.*
+FROM Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy;"
+
+
+# ---- Q_2f_Labour_Supply ----
+Q_2f_Labour_Supply <-
+  "SELECT Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union.* 
+INTO tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
+FROM Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union;"
+
+
+# ---- Q_2f2_Labour_Supply_Unknown ----
+Q_2f2_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
+       q_1c_grad_projections_by_program.pssm_cred,
+       q_1c_grad_projections_by_program.age_group_rollup,
+       q_1c_grad_projections_by_program.age_group_rollup_label,
+       q_1c_grad_projections_by_program.lcp4_cd,
+       q_1c_grad_projections_by_program.lcip4_cred,
+       q_1c_grad_projections_by_program.year,
+       Sum(q_1c_grad_projections_by_program.grads) AS Grads
+INTO   Q_2f_Labour_Supply
+FROM   q_1c_grad_projections_by_program
+       LEFT JOIN tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+              ON ( q_1c_grad_projections_by_program.age_group_rollup =
+tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup )
+AND ( q_1c_grad_projections_by_program.lcip4_cred =
+tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred )
+WHERE  ( ( ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred ) IS
+           NULL )
+         AND ( (
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup )
+               IS
+               NULL ) )
+GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
+          q_1c_grad_projections_by_program.pssm_cred,
+          q_1c_grad_projections_by_program.age_group_rollup,
+          q_1c_grad_projections_by_program.age_group_rollup_label,
+          q_1c_grad_projections_by_program.lcp4_cd,
+          q_1c_grad_projections_by_program.lcip4_cred,
+          q_1c_grad_projections_by_program.year;"
+
+
+# ---- Q_3_Occupations_by_LCIP4_CRED ----
+Q_3_Occupations_by_LCIP4_CRED <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.TTRAIN, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, 
+        tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup, 
+        Occupation_Distributions.NOC, Occupation_Distributions.[Percent], 
+        [tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union].[NLS]*[Occupation_Distributions].[Percent] AS OccsN
+INTO Q_3_Occupations_by_LCIP4_CRED
+FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union 
+INNER JOIN Occupation_Distributions 
+ON (tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED = Occupation_Distributions.LCIP4_CRED) 
+AND (tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = Occupation_Distributions.Current_Region_PSSM_Code_Rollup) 
+AND (tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup = Occupation_Distributions.Age_Group_Rollup);"
+
+
+# ---- Q_3b_Occupations_Unknown ----
+Q_3b_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.new_labour_supply,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls
+INTO Q_3b_Occupations_Unknown
+FROM   tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN occupation_distributions
+  ON( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup = occupation_distributions.age_group_rollup )
+  AND(tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup = occupation_distributions.current_region_pssm_code_rollup )
+  AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred = occupation_distributions.lcip4_cred )
+WHERE  ( ( ( occupation_distributions.lcip4_cred ) IS NULL )
+  AND ( ( occupation_distributions.current_region_pssm_code_rollup ) IS NULL )
+  AND ( ( occupation_distributions.age_group_rollup ) IS NULL ) );"
+
+
+# ---- Q_3b11_Ocupations_Unknown_No_TT_Proxy ----
+Q_3b11_Ocupations_Unknown_No_TT_Proxy <-
+  "SELECT q_3b_occupations_unknown.pssm_credential,
+        q_3b_occupations_unknown.pssm_cred,
+        q_3b_occupations_unknown.age_group_rollup,
+        q_3b_occupations_unknown.age_group_rollup_label,
+        q_3b_occupations_unknown.year,
+        q_3b_occupations_unknown.ttrain,
+        q_3b_occupations_unknown.lcp4_cd,
+        q_3b_occupations_unknown.lcip4_cred,
+        q_3b_occupations_unknown.current_region_pssm_code_rollup,
+        occupation_distributions_no_tt.noc,
+        occupation_distributions_no_tt.[percent],
+        [nls] * [percent] AS OccsN
+INTO Q_3b11_Ocupations_Unknown_No_TT_Proxy
+FROM   q_3b_occupations_unknown
+  INNER JOIN occupation_distributions_no_tt
+    ON ( q_3b_occupations_unknown.current_region_pssm_code_rollup =  occupation_distributions_no_tt.current_region_pssm_code_rollup )
+    AND ( q_3b_occupations_unknown.lcp4_cd = occupation_distributions_no_tt.lcp4_cd )
+    AND ( q_3b_occupations_unknown.age_group_rollup = occupation_distributions_no_tt.age_group_rollup )
+    AND ( q_3b_occupations_unknown.pssm_cred = occupation_distributions_no_tt.pssm_cred );"
+
+
+# ---- q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union ----
+q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union <-
+  "SELECT Q_3_Occupations_by_LCIP4_CRED.*
+INTO q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union
+FROM Q_3_Occupations_by_LCIP4_CRED
+UNION ALL SELECT Q_3b11_Ocupations_Unknown_No_TT_Proxy.*
+FROM Q_3b11_Ocupations_Unknown_No_TT_Proxy;"
+
+
+# ---- Q_3b13_Occupations ----
+Q_3b13_Occupations <-
+  "SELECT q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union.* 
+INTO tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
+FROM q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union;"
+
+
+# ---- Q_3b14_Occupations_Unknown ----
+Q_3b14_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.new_labour_supply,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls
+INTO Q_3b14_Occupations_Unknown
+FROM   tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp
+    ON  (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year = tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.year )
+    AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup = tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.current_region_pssm_code_rollup )
+    AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred = tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.lcip4_cred )
+    AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup = tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.age_group_rollup )
+WHERE  (((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.year ) IS NULL ) 
+    AND ((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.age_group_rollup ) IS NULL )
+    AND ((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.lcip4_cred ) IS NULL)
+    AND ((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.current_region_pssm_code_rollup ) IS NULL ) );"
+
+
+# ---- Q_3b2_Occupations_Unknown_Private_Cred_Proxy ----
+Q_3b2_Occupations_Unknown_Private_Cred_Proxy <-
+  "SELECT q_3b14_occupations_unknown.pssm_credential,
+       q_3b14_occupations_unknown.pssm_cred,
+       q_3b14_occupations_unknown.age_group_rollup,
+       q_3b14_occupations_unknown.age_group_rollup_label,
+       q_3b14_occupations_unknown.year,
+       q_3b14_occupations_unknown.ttrain,
+       q_3b14_occupations_unknown.lcp4_cd,
+       q_3b14_occupations_unknown.lcip4_cred,
+       q_3b14_occupations_unknown.current_region_pssm_code_rollup,
+       occupation_distributions_no_tt.noc,
+       occupation_distributions_no_tt.[percent],
+       q_3b14_occupations_unknown.nls*occupation_distributions_no_tt.[percent] AS OccsN
+INTO Q_3b2_Occupations_Unknown_Private_Cred_Proxy
+FROM   (q_3b14_occupations_unknown
+INNER JOIN tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+  ON (q_3b14_occupations_unknown.lcip4_cred = tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred )
+  AND  (q_3b14_occupations_unknown.year =  tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year )
+  AND  (q_3b14_occupations_unknown.age_group_rollup =  tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup )
+  AND  (q_3b14_occupations_unknown.pssm_cred = tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred ))
+INNER JOIN occupation_distributions_no_tt
+  ON (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd = occupation_distributions_no_tt.lcp4_cd )
+AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup = occupation_distributions_no_tt.age_group_rollup )
+AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup = occupation_distributions_no_tt.current_region_pssm_code_rollup )
+WHERE  ( ( ( q_3b14_occupations_unknown.pssm_cred ) LIKE 'P - CERT')
+  AND ( ( occupation_distributions_no_tt.pssm_cred ) LIKE 'P - DIPL'))
+  OR ( ( ( q_3b14_occupations_unknown.pssm_cred ) LIKE 'P - DIPL')
+  AND ( ( occupation_distributions_no_tt.pssm_cred ) LIKE 'P - CERT'));"
+
+
+# ---- Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union ----
+Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union <-
+  "SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
+INTO Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union
+FROM tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
+UNION ALL SELECT Q_3b2_Occupations_Unknown_Private_Cred_Proxy.*
+FROM Q_3b2_Occupations_Unknown_Private_Cred_Proxy;"
+
+
+# ---- Q_3b4_Occupations_Unknown ----
+Q_3b4_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.new_labour_supply,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls
+INTO    Q_3b4_Occupations_Unknown
+FROM    tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union
+ON ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred = q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.lcip4_cred )
+AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup = q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.age_group_rollup )
+AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup = q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.current_region_pssm_code_rollup )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year = q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.year )
+WHERE  (((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.age_group_rollup ) IS NULL)
+ AND ((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.year ) IS  NULL)
+ AND ((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.lcip4_cred )  IS NULL)
+ AND ((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.current_region_pssm_code_rollup ) IS NULL));"
+
+# ---- Q_3c_Occupations_Unknown_LCP2_Proxy ----
+Q_3c_Occupations_Unknown_LCP2_Proxy <-
+  "SELECT q_3b4_occupations_unknown.pssm_credential,
+        q_3b4_occupations_unknown.pssm_cred,
+        q_3b4_occupations_unknown.age_group_rollup,
+        q_3b4_occupations_unknown.age_group_rollup_label,
+        q_3b4_occupations_unknown.year,
+        q_3b4_occupations_unknown.ttrain,
+        q_3b4_occupations_unknown.lcp4_cd,
+        q_3b4_occupations_unknown.lcip4_cred,
+        q_3b4_occupations_unknown.current_region_pssm_code_rollup,
+        occupation_distributions_lcp2.noc,
+        occupation_distributions_lcp2.[percent],
+        q_3b4_occupations_unknown.nls*occupation_distributions_lcp2.[percent] AS OccsN
+INTO Q_3c_Occupations_Unknown_LCP2_Proxy
+FROM   (q_3b4_occupations_unknown
+INNER JOIN (t_lcp2_lcp4
+INNER JOIN occupation_distributions_lcp2 ON t_lcp2_lcp4.lcip_lcp2_cd = occupation_distributions_lcp2.lcp2_cd)
+ON (q_3b4_occupations_unknown.age_group_rollup = occupation_distributions_lcp2.age_group_rollup )
+AND (q_3b4_occupations_unknown.current_region_pssm_code_rollup = occupation_distributions_lcp2.current_region_pssm_code_rollup )
+AND ( q_3b4_occupations_unknown.pssm_cred =  occupation_distributions_lcp2.pssm_cred )
+AND ( q_3b4_occupations_unknown.lcp4_cd = t_lcp2_lcp4.lcip_lcp4_cd ))
+LEFT JOIN t_exclude_from_labour_supply_unknown_lcp2_proxy
+ ON q_3b4_occupations_unknown.lcp4_cd = t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd
+WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS  NULL ))
+ OR (( ( LEFT([lcip4_cred], 1) ) = 'P - ' ));"
+
+
+# ---- Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union ----
+Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
+INTO Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union
+FROM tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
+UNION ALL SELECT Q_3b2_Occupations_Unknown_Private_Cred_Proxy.*
+FROM Q_3b2_Occupations_Unknown_Private_Cred_Proxy
+UNION ALL SELECT Q_3c_Occupations_Unknown_LCP2_Proxy.*
+FROM Q_3c_Occupations_Unknown_LCP2_Proxy;"
+
+
+# ---- Q_3d2_Occupations ----
+Q_3d2_Occupations <-
+  "SELECT Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.* 
+INTO tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
+FROM Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union;"
+
+
+# ---- Q_3d2_Occupations_Unknown ----
+Q_3d2_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.new_labour_supply,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls
+INTO Q_3d2_Occupations_Unknown
+FROM   tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp
+ON (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred =tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.lcip4_cred )
+AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup =tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.current_region_pssm_code_rollup )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year =tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.year )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup =tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.age_group_rollup )
+WHERE  ( ( (tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.age_group_rollup ) IS NULL )
+AND ( ( tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.year ) IS NULL )
+AND ( ( tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.lcip4_cred ) IS NULL)
+AND ((tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.current_region_pssm_code_rollup ) IS NULL ) );"
+
+
+# ---- Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT ----
+Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT <-
+  "SELECT q_3d2_occupations_unknown.pssm_credential,
+       q_3d2_occupations_unknown.pssm_cred,
+       q_3d2_occupations_unknown.age_group_rollup,
+       q_3d2_occupations_unknown.age_group_rollup_label,
+       q_3d2_occupations_unknown.year,
+       q_3d2_occupations_unknown.ttrain,
+       q_3d2_occupations_unknown.lcp4_cd,
+       q_3d2_occupations_unknown.lcip4_cred,
+       q_3d2_occupations_unknown.current_region_pssm_code_rollup,
+       occupation_distributions_lcp2_no_tt.noc,
+       occupation_distributions_lcp2_no_tt.[percent],
+       nls*[percent] AS OccsN
+INTO Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT
+FROM   (t_lcp2_lcp4
+INNER JOIN occupation_distributions_lcp2_no_tt
+ON t_lcp2_lcp4.lcip_lcp2_cd =occupation_distributions_lcp2_no_tt.lcp2_cd)
+INNER JOIN (q_3d2_occupations_unknown
+LEFT JOIN t_exclude_from_labour_supply_unknown_lcp2_proxy
+ON q_3d2_occupations_unknown.lcp4_cd =t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd)
+ON ( t_lcp2_lcp4.lcip_lcp4_cd =q_3d2_occupations_unknown.lcp4_cd )
+AND ( occupation_distributions_lcp2_no_tt.pssm_cred = q_3d2_occupations_unknown.pssm_cred )
+AND (occupation_distributions_lcp2_no_tt.current_region_pssm_code_rollup = q_3d2_occupations_unknown.current_region_pssm_code_rollup )
+AND ( occupation_distributions_lcp2_no_tt.age_group_rollup = q_3d2_occupations_unknown.age_group_rollup )
+WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS NULL ))
+ OR (( ( LEFT([lcip4_cred], 1) ) = 'P - ' ));"
+
+
+# ---- Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union ----
+Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
+INTO Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union
+FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
+UNION ALL SELECT Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT.*
+FROM Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT;"
+
+
+# ---- Q_3d24_Occupations_Unknown ----
+Q_3d24_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.new_labour_supply,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls
+INTO Q_3d24_Occupations_Unknown
+FROM    tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union
+       ON (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup =q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.current_region_pssm_code_rollup )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred = q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.lcip4_cred )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year = q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.year )
+AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup =q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.age_group_rollup )
+WHERE  ( ( (q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.age_group_rollup )IS NULL )
+AND ( ( q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.year )IS NULL)
+AND ( ( q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.lcip4_cred ) IS NULL)
+AND ((q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.current_region_pssm_code_rollup ) IS NULL ) );"
+
+# ---- Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy ----
+Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy <-
+  "SELECT q_3d24_occupations_unknown.pssm_credential,
+       q_3d24_occupations_unknown.pssm_cred,
+       q_3d24_occupations_unknown.age_group_rollup,
+       q_3d24_occupations_unknown.age_group_rollup_label,
+       q_3d24_occupations_unknown.year,
+       q_3d24_occupations_unknown.ttrain,
+       q_3d24_occupations_unknown.lcp4_cd,
+       q_3d24_occupations_unknown.lcip4_cred,
+       q_3d24_occupations_unknown.current_region_pssm_code_rollup,
+       occupation_distributions_lcp2_no_tt.noc,
+       occupation_distributions_lcp2_no_tt.[percent],
+       nls*[percent] AS OccsN
+INTO Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy
+FROM   (q_3d24_occupations_unknown
+        INNER JOIN t_lcp2_lcp4
+                ON q_3d24_occupations_unknown.lcp4_cd =
+       t_lcp2_lcp4.lcip_lcp4_cd)
+       INNER JOIN occupation_distributions_lcp2_no_tt
+               ON ( q_3d24_occupations_unknown.current_region_pssm_code_rollup =occupation_distributions_lcp2_no_tt.current_region_pssm_code_rollup )
+AND ( q_3d24_occupations_unknown.age_group_rollup =occupation_distributions_lcp2_no_tt.age_group_rollup )
+AND ( t_lcp2_lcp4.lcip_lcp2_cd =occupation_distributions_lcp2_no_tt.lcp2_cd )
+WHERE  ( ( ( q_3d24_occupations_unknown.pssm_cred ) LIKE 'P - CERT' )
+AND ( ( occupation_distributions_lcp2_no_tt.pssm_cred ) LIKE 'P - DIPL') )
+OR ( ( ( q_3d24_occupations_unknown.pssm_cred ) LIKE 'P - DIPL' )
+AND ( ( occupation_distributions_lcp2_no_tt.pssm_cred ) LIKE'P - CERT' ) );"
+
+# ---- Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union ----
+Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
+INTO Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union
+FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
+UNION ALL SELECT Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT.*
+FROM Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT
+UNION ALL SELECT Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy.*
+FROM Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy;"
+
+
+# ---- Q_3e_Occupations_Unknown ----
+Q_3e_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+        Sum(tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls) AS NLS
+INTO Q_3e_Occupations_Unknown 
+FROM    tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union
+  ON ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred = q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.lcip4_cred )
+  AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.current_region_pssm_code_rollup )
+  AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.age_group_rollup )
+  AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.year )
+WHERE  ( ( (q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.age_group_rollup ) IS NULL )
+  AND ( ( q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.year ) IS NULL )
+  AND ( (q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.lcip4_cred ) IS NULL)
+ AND ((q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.current_region_pssm_code_rollup ) IS NULL ) )
+GROUP BY tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup;"
+
+# ---- Q_3e2_Occupations_Unknown ----
+Q_3e2_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+       tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup,
+       99999  AS NOC,
+       1 AS [Percent],
+       Sum(tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls) AS OccsN
+INTO Q_3e2_Occupations_Unknown 
+FROM   tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union
+LEFT JOIN q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union
+   ON ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.lcip4_cred )
+  AND (tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.current_region_pssm_code_rollup )
+  AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.age_group_rollup )
+  AND ( tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year =q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.year )
+WHERE  ( ( (q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.age_group_rollup )IS NULL )
+  AND ( ( q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.year )IS NULL)
+  AND ( (q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.lcip4_cred ) IS NULL)
+  AND ((q_3d4_occupations_by_lcip4_cred_lcp2_lcp2_private_union.current_region_pssm_code_rollup ) IS NULL ) )
+GROUP  BY tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.year,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.ttrain,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcp4_cd,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.lcip4_cred,
+          tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup
+HAVING  (( ( Sum(tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls) ) > 0 ));"
+
+
+# ---- Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union ----
+Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union.*
+INTO Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union
+FROM Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union
+UNION ALL SELECT Q_3e2_Occupations_Unknown.*
+FROM Q_3e2_Occupations_Unknown;"
+
+
+# ---- Q_3f_Occupations ----
+Q_3f_Occupations <-
+  "SELECT Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Year, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.TTRAIN, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.NOC, 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.[percent], 
+        Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN 
+INTO    tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union
+FROM    Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union
+WHERE (((Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN)>0));"
+
+
+# ---- Q_4_NOC_1D_Totals_by_PSSM_CRED ----
+Q_4_NOC_1D_Totals_by_PSSM_CRED <- "
+SELECT NOC_Level, NOC, ENGLISH_NAME,
+	 [1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],
+	 [3 - ADCT or ADIP],[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],
+	 [APPRAPPR],[APPRCERT],[BACH],[DOCT],[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
+	 
+INTO Q_4_NOC_1D_Totals_by_PSSM_CRED
+
+FROM (
+	SELECT 
+	  tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN, 
+		Len(T_NOC_Broad_Categories.BROAD_CATEGORY_CODE) AS NOC_Level, 
+		 T_NOC_Broad_Categories.BROAD_CATEGORY_CODE AS NOC, 
+		 T_NOC_Broad_Categories.BROAD_CATEGORY_ENGLISH_NAME AS ENGLISH_NAME, 
+		PSSM_CRED
+	FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	INNER JOIN T_NOC_Broad_Categories 
+	  ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC =  T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+    ([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],
+	 [3 - ADCT or ADIP],[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],
+	 [APPRAPPR],[APPRCERT],[BACH],[DOCT],[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
+) AS PivotTable
+ORDER BY NOC;"
+
+
+# ---- Q_4_NOC_1D_Totals_by_Year ----
+Q_4_NOC_1D_Totals_by_Year <- "
+SELECT Expr1, Age_Group_Rollup_Label, NOC_Level, NOC,  ENGLISH_NAME,  
+Current_Region_PSSM_Code_Rollup,  Current_Region_PSSM_Name_Rollup,
+	 [2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+	 [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
+	 
+INTO Q_4_NOC_1D_Totals_by_Year
+
+FROM (
+		SELECT 
+		  Year, 
+			OccsN,
+			CONCAT([Age_Group_Rollup_Label], '-' , BROAD_CATEGORY_CODE , '-'
+				, CAST([T_Current_Region_PSSM_Rollup_Codes].[Current_Region_PSSM_Code_Rollup] AS NVARCHAR(50))) AS Expr1, 
+			tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+			Len(T_NOC_Broad_Categories.BROAD_CATEGORY_CODE) AS NOC_Level, 
+			CAST(T_NOC_Broad_Categories.BROAD_CATEGORY_CODE AS NVARCHAR(50)) AS NOC, 
+			 T_NOC_Broad_Categories.BROAD_CATEGORY_ENGLISH_NAME AS ENGLISH_NAME, 
+			T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, 
+			T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup
+		FROM T_Current_Region_PSSM_Rollup_Codes 
+		INNER JOIN tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+			ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup
+		INNER JOIN T_NOC_Broad_Categories 
+		ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC =  T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR Year IN
+    ([2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], [2029/2030], 
+    [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+
+ORDER BY  Expr1, Age_Group_Rollup_Label, NOC_Level,  NOC,  ENGLISH_NAME,  Current_Region_PSSM_Code_Rollup;"
+
+# ---- Q_4_NOC_2D_Totals_by_PSSM_CRED ----
+Q_4_NOC_2D_Totals_by_PSSM_CRED <- "
+SELECT NOC_Level, NOC, ENGLISH_NAME,
+	[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+	[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],
+	[DOCT],[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
+	
+INTO Q_4_NOC_2D_Totals_by_PSSM_CRED
+
+FROM (
+SELECT	PSSM_CRED,
+		tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+		Len(MAJOR_GROUP_CODE) AS NOC_Level, 
+		T_NOC_Broad_Categories.MAJOR_GROUP_CODE AS NOC, 
+		T_NOC_Broad_Categories.MAJOR_GROUP_ENGLISH_NAME AS ENGLISH_NAME
+	FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	INNER JOIN T_NOC_Broad_Categories 
+	ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+    ([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+	[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],
+	[DOCT],[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
+) AS PivotTable
+
+ORDER BY NOC;"
+
+
+# ---- Q_4_NOC_2D_Totals_by_PSSM_CRED_Appendix ----
+Q_4_NOC_2D_Totals_by_PSSM_CRED_Appendix <- "
+SELECT NOC_Level, NOC, Expr1, 
+[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],
+[3 - ADCT or ADIP],[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - GRCT or GRDP],
+[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],[GRCT or GRDP],[MAST],[PDEG]
+
+INTO Q_4_NOC_2D_Totals_by_PSSM_CRED_Appendix
+
+FROM (
+	SELECT T_PSSM_CRED_RECODE.PSSM_CRED, 
+	  tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+	  Len(MAJOR_GROUP_CODE) AS NOC_Level, 
+	  T_NOC_Broad_Categories.MAJOR_GROUP_CODE AS NOC, 
+	  CONCAT(MAJOR_GROUP_CODE , ' ' , MAJOR_GROUP_ENGLISH_NAME) AS Expr1
+	FROM T_PSSM_CRED_RECODE 
+	INNER JOIN (tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	INNER JOIN  T_NOC_Broad_Categories 
+	  ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC =  T_NOC_Broad_Categories.UNIT_GROUP_CODE) 
+	  ON T_PSSM_CRED_RECODE.PSSM_CRED = tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED
+	WHERE T_PSSM_CRED_RECODE.PSSM_CRED_Group In ('APPRAPPR','APPRCERT','CERT','DIPL','ADGR Or UT','ADCT or ADIP','BACH','PDCT or PDDP','MAST','DOCT')
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+    ([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],
+	[3 - ADCT or ADIP],[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - GRCT or GRDP],
+	[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],[GRCT or GRDP],[MAST],[PDEG])
+) AS PivotTable
+
+ORDER BY  NOC_LEVEL, NOC;"
+
+
+# ---- Q_4_NOC_2D_Totals_by_Year ----
+Q_4_NOC_2D_Totals_by_Year <-
+  "SELECT 	Expr1, Age_Group_Rollup_Label, NOC_Level, NOC, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
+	 [2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+	 [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
+	 
+INTO Q_4_NOC_2D_Totals_by_Year
+
+FROM (
+	SELECT Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN, 
+	CONCAT([Age_Group_Rollup_Label] , '-' , [T_NOC_Broad_Categories].[MAJOR_GROUP_CODE] , '-' 
+		 , CAST([T_Current_Region_PSSM_Rollup_Codes].[Current_Region_PSSM_Code_Rollup] AS NVARCHAR(50))) AS Expr1, 
+	tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+	Len(MAJOR_GROUP_CODE) AS NOC_Level, 
+	 T_NOC_Broad_Categories.MAJOR_GROUP_CODE AS NOC, 
+	 T_NOC_Broad_Categories.MAJOR_GROUP_ENGLISH_NAME AS ENGLISH_NAME, 
+	T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, 
+	T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup
+	FROM (T_Current_Region_PSSM_Rollup_Codes 
+		INNER JOIN tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+			ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup) 
+		INNER JOIN  T_NOC_Broad_Categories 
+		ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC =  T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR Year IN
+    ([2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+    [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+
+ORDER BY Age_Group_Rollup_Label,  ENGLISH_NAME,  Current_Region_PSSM_Name_Rollup;"
+
+
+# ---- Q_4_NOC_3D_Totals_by_PSSM_CRED ----
+Q_4_NOC_3D_Totals_by_PSSM_CRED <- "
+SELECT 	NOC_Level, NOC, ENGLISH_NAME,
+		[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
+		
+INTO Q_4_NOC_3D_Totals_by_PSSM_CRED
+
+FROM (
+	SELECT PSSM_CRED, 
+	tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+		Len([SUB_MAJOR_GROUP_CODE]) AS NOC_Level,  
+		T_NOC_Broad_Categories.SUB_MAJOR_GROUP_CODE AS NOC, 
+		T_NOC_Broad_Categories.SUB_MAJOR_ENGLISH_NAME AS ENGLISH_NAME
+	FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	INNER JOIN T_NOC_Broad_Categories 
+		ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+		([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
+) AS PivotTable
+
+ORDER BY NOC_Level,NOC;"
+
+
+# ---- Q_4_NOC_3D_Totals_by_Year ----
+Q_4_NOC_3D_Totals_by_Year <- "
+SELECT 	Expr1,  Age_Group_Rollup_Label, NOC_Level, NOC, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
+		[2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+		[2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
+		
+INTO Q_4_NOC_3D_Totals_by_Year
+
+FROM (
+	SELECT 
+	  Year,  
+	  tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+		[Age_Group_Rollup_Label] + '-' 
+			+ [T_NOC_Broad_Categories].[SUB_MAJOR_GROUP_CODE] + '-' 
+			+ CAST([T_Current_Region_PSSM_Rollup_Codes].[Current_Region_PSSM_Code_Rollup] AS NVARCHAR(50)) AS Expr1, 
+		tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+		Len(SUB_MAJOR_GROUP_CODE) AS NOC_Level, 
+		T_NOC_Broad_Categories.SUB_MAJOR_GROUP_CODE AS NOC,
+		T_NOC_Broad_Categories.SUB_MAJOR_ENGLISH_NAME AS ENGLISH_NAME, 
+		T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup,
+		T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup
+	FROM (T_Current_Region_PSSM_Rollup_Codes 
+	INNER JOIN tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	  ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup) 
+	INNER JOIN T_NOC_Broad_Categories 
+	  ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR Year IN
+    ([2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+    [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+
+ORDER BY Age_Group_Rollup_Label, NOC_Level, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup;"
+
+# ---- Q_4_NOC_4D_Totals_by_PSSM_CRED ----
+Q_4_NOC_4D_Totals_by_PSSM_CRED <- "
+SELECT 	NOC_Level, NOC, ENGLISH_NAME,
+		[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
+		
+INTO Q_4_NOC_4D_Totals_by_PSSM_CRED
+
+FROM (
+	SELECT PSSM_CRED, 
+	tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+		Len([MINOR_GROUP_CODE]) AS NOC_Level,  
+		T_NOC_Broad_Categories.MINOR_GROUP_CODE AS NOC, 
+		T_NOC_Broad_Categories.MINOR_GROUP_ENGLISH_NAME AS ENGLISH_NAME
+	FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	INNER JOIN T_NOC_Broad_Categories 
+		ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+		([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
+) AS PivotTable
+
+ORDER BY NOC_Level,NOC;"
+
+# ---- Q_4_NOC_4D_Totals_by_Year ----
+Q_4_NOC_4D_Totals_by_Year <- "
+SELECT 	Expr1,  Age_Group_Rollup_Label, NOC_Level, NOC, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
+		[2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+		[2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
+		
+INTO Q_4_NOC_4D_Totals_by_Year
+
+FROM (
+	SELECT 
+	  Year,  
+	  tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN,
+		[Age_Group_Rollup_Label] + '-' 
+			+ [T_NOC_Broad_Categories].[MINOR_GROUP_CODE] + '-' 
+			+ CAST([T_Current_Region_PSSM_Rollup_Codes].[Current_Region_PSSM_Code_Rollup] AS NVARCHAR(50)) AS Expr1, 
+		tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
+		Len([MINOR_GROUP_CODE]) AS NOC_LEVEL, 
+		T_NOC_Broad_Categories.MINOR_GROUP_CODE AS NOC,
+		T_NOC_Broad_Categories.MINOR_GROUP_ENGLISH_NAME AS ENGLISH_NAME, 
+		T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup,
+		T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup
+	FROM (T_Current_Region_PSSM_Rollup_Codes 
+	INNER JOIN tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+	  ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup) 
+	INNER JOIN T_NOC_Broad_Categories 
+	  ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = T_NOC_Broad_Categories.UNIT_GROUP_CODE
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR Year IN
+    ([2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+    [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+
+ORDER BY Age_Group_Rollup_Label, NOC_Level, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup;"
+
+
+# ---- Q_4_NOC_5D_Totals_by_PSSM_CRED ----
+Q_4_NOC_5D_Totals_by_PSSM_CRED <-
+  "SELECT NOC_Level, NOC, ENGLISH_NAME,
+		[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
+		
+INTO Q_4_NOC_5D_Totals_by_PSSM_CRED
+
+FROM (
+	SELECT pssm_cred, 
+	  tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.occsn,
+		Len(unit_group_code) AS NOC_LEVEL,
+		T_NOC_Broad_Categories.unit_group_code AS NOC,	
+		T_NOC_Broad_Categories.english_name AS ENGLISH_NAME
+	FROM tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union
+	INNER JOIN T_NOC_Broad_Categories 
+		ON tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.noc = T_NOC_Broad_Categories.unit_group_code
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR PSSM_CRED IN
+		([1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
+		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
+		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
+) AS PivotTable
+
+ORDER BY NOC_Level, NOC;"
+
+
+# ---- Q_4_NOC_5D_Totals_by_Year ----
+Q_4_NOC_5D_Totals_by_Year <- "
+SELECT Expr1,  Age_Group_Rollup_Label,  NOC_Level, NOC,  ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
+		[2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], [2029/2030], 
+		[2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
+	    
+INTO Q_4_NOC_5D_Totals_by_Year
+
+FROM (
+	SELECT year,	
+		tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.occsn,
+		[age_group_rollup_label] + '-'
+			+ RIGHT(REPLICATE('0', 5) + CAST([noc] AS NVARCHAR(5)), 5) + '-' 
+			+ CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)) AS Expr1,
+		tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+		Len(unit_group_code) AS NOC_Level,
+		T_NOC_Broad_Categories.unit_group_code AS NOC, 
+		T_NOC_Broad_Categories.english_name AS ENGLISH_NAME,
+		t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+		t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup
+	FROM (t_current_region_pssm_rollup_codes 
+	INNER JOIN tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union
+	ON t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup = tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup) 
+	INNER JOIN T_NOC_Broad_Categories
+	ON tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.noc = T_NOC_Broad_Categories.unit_group_code
+) AS SourceTable
+
+PIVOT (
+    Sum(OccsN)
+	FOR Year IN
+    ([2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
+    [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035])
+) AS PivotTable
+
+ORDER BY age_group_rollup_label, NOC, current_region_pssm_code_rollup;"
+
+
+# ---- Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding ----
+Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding <-
+  "SELECT 
+  [age_group_rollup_label] + '-' 
+    + RIGHT(REPLICATE('0', 5) + CAST([noc] AS NVARCHAR(5)), 5) + '-' 
+    + CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)) AS Expr1,
+  tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+  Len(unit_group_code) AS NOC_Level,
+  T_NOC_Broad_Categories.unit_group_code AS NOC,
+  T_NOC_Broad_Categories.english_name AS ENGLISH NAME,
+  t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+  t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+  tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.year,
+  Round(Sum([occsn]), 0) AS CountN
+INTO Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding 
+FROM   (t_current_region_pssm_rollup_codes
+  INNER JOIN tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union
+  ON t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup = tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup)
+INNER JOIN T_NOC_Broad_Categories
+   ON tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.noc = T_NOC_Broad_Categories.unit_group_code
+GROUP  BY [age_group_rollup_label] + '-' + '-' + RIGHT(REPLICATE('0', 5) + CAST([noc] AS NVARCHAR(5)), 5) + '-' +
+  CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)) ,
+  tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+  Len(unit_group_code),
+  T_NOC_Broad_Categories.unit_group_code,
+  T_NOC_Broad_Categories.english_name,
+  t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+  t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+  tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.year
+ORDER BY tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union.age_group_rollup_label,
+T_NOC_Broad_Categories.unit_group_code,
+t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup;"
+
+
+# ---- Q_4_NOC_Totals_by_PSSM_CRED ----
+Q_4_NOC_Totals_by_PSSM_CRED <-
+  "SELECT q_4_noc_4d_totals_by_pssm_cred.noc_level,
+       q_4_noc_4d_totals_by_pssm_cred.noc,
+       q_4_noc_4d_totals_by_pssm_cred.english_name,
+       q_4_noc_4d_totals_by_pssm_cred.apprappr,
+       q_4_noc_4d_totals_by_pssm_cred.apprcert,
+       q_4_noc_4d_totals_by_pssm_cred.[1 - cert],
+       q_4_noc_4d_totals_by_pssm_cred.[2 - cert],
+       q_4_noc_4d_totals_by_pssm_cred.[1 - dipl],
+       q_4_noc_4d_totals_by_pssm_cred.[2 - dipl],
+       q_4_noc_4d_totals_by_pssm_cred.[1 - adgr or ut],
+       q_4_noc_4d_totals_by_pssm_cred.[2 - adgr or ut],
+       q_4_noc_4d_totals_by_pssm_cred.[1 - adct or adip],
+       q_4_noc_4d_totals_by_pssm_cred.[2 - adct or adip],
+       q_4_noc_4d_totals_by_pssm_cred.bach,
+       q_4_noc_4d_totals_by_pssm_cred.[1 - pdct or pddp],
+       q_4_noc_4d_totals_by_pssm_cred.[2 - pdct or pddp],
+       q_4_noc_4d_totals_by_pssm_cred.mast,
+       q_4_noc_4d_totals_by_pssm_cred.doct
+FROM   q_4_noc_4d_totals_by_pssm_cred
+UNION ALL
+SELECT q_4_noc_3d_totals_by_pssm_cred.pssm_skill_level,
+       q_4_noc_3d_totals_by_pssm_cred.pssm_skill_level + q_4_noc_3d_totals_by_pssm_cred.noc,
+       q_4_noc_3d_totals_by_pssm_cred.skill_level_category_code,
+       q_4_noc_3d_totals_by_pssm_cred.noc_level,
+       q_4_noc_3d_totals_by_pssm_cred.noc_skill_type,
+       q_4_noc_3d_totals_by_pssm_cred.noc,
+       q_4_noc_3d_totals_by_pssm_cred.minor_group_english_name,
+       q_4_noc_3d_totals_by_pssm_cred.apprappr,
+       q_4_noc_3d_totals_by_pssm_cred.apprcert,
+       q_4_noc_3d_totals_by_pssm_cred.[1 - cert],
+       q_4_noc_3d_totals_by_pssm_cred.[2 - cert],
+       q_4_noc_3d_totals_by_pssm_cred.[1 - dipl],
+       q_4_noc_3d_totals_by_pssm_cred.[2 - dipl],
+       q_4_noc_3d_totals_by_pssm_cred.[1 - adgr or ut],
+       q_4_noc_3d_totals_by_pssm_cred.[2 - adgr or ut],
+       q_4_noc_3d_totals_by_pssm_cred.[1 - adct or adip],
+       q_4_noc_3d_totals_by_pssm_cred.[2 - adct or adip],
+       q_4_noc_3d_totals_by_pssm_cred.bach,
+       q_4_noc_3d_totals_by_pssm_cred.[1 - pdct or pddp],
+       q_4_noc_3d_totals_by_pssm_cred.[2 - pdct or pddp],
+       q_4_noc_3d_totals_by_pssm_cred.mast,
+       q_4_noc_3d_totals_by_pssm_cred.doct
+FROM   q_4_noc_3d_totals_by_pssm_cred
+UNION ALL
+SELECT q_4_noc_2d_totals_by_pssm_cred.pssm_skill_level,
+       q_4_noc_2d_totals_by_pssm_cred.pssm_skill_level + q_4_noc_2d_totals_by_pssm_cred.noc,
+       q_4_noc_2d_totals_by_pssm_cred.skill_level_category_code,
+       q_4_noc_2d_totals_by_pssm_cred.noc_level,
+       q_4_noc_2d_totals_by_pssm_cred.noc_skill_type,
+       q_4_noc_2d_totals_by_pssm_cred.noc,
+       q_4_noc_2d_totals_by_pssm_cred.major_group_english_name,
+       q_4_noc_2d_totals_by_pssm_cred.apprappr,
+       q_4_noc_2d_totals_by_pssm_cred.apprcert,
+       q_4_noc_2d_totals_by_pssm_cred.[1 - cert],
+       q_4_noc_2d_totals_by_pssm_cred.[2 - cert],
+       q_4_noc_2d_totals_by_pssm_cred.[1 - dipl],
+       q_4_noc_2d_totals_by_pssm_cred.[2 - dipl],
+       q_4_noc_2d_totals_by_pssm_cred.[1 - adgr or ut],
+       q_4_noc_2d_totals_by_pssm_cred.[2 - adgr or ut],
+       q_4_noc_2d_totals_by_pssm_cred.[1 - adct or adip],
+       q_4_noc_2d_totals_by_pssm_cred.[2 - adct or adip],
+       q_4_noc_2d_totals_by_pssm_cred.bach,
+       q_4_noc_2d_totals_by_pssm_cred.[1 - pdct or pddp],
+       q_4_noc_2d_totals_by_pssm_cred.[2 - pdct or pddp],
+       q_4_noc_2d_totals_by_pssm_cred.mast,
+       q_4_noc_2d_totals_by_pssm_cred.doct
+FROM   q_4_noc_2d_totals_by_pssm_cred
+UNION ALL
+SELECT q_4_noc_1d_totals_by_pssm_cred.pssm_skill_level,
+       q_4_noc_1d_totals_by_pssm_cred.pssm_skill_level + q_4_noc_1d_totals_by_pssm_cred.noc,
+       q_4_noc_1d_totals_by_pssm_cred.skill_level_category_code,
+       q_4_noc_1d_totals_by_pssm_cred.noc_level,
+       q_4_noc_1d_totals_by_pssm_cred.noc_skill_type,
+       q_4_noc_1d_totals_by_pssm_cred.noc,
+       q_4_noc_1d_totals_by_pssm_cred.skill_type_english_name,
+       q_4_noc_1d_totals_by_pssm_cred.apprappr,
+       q_4_noc_1d_totals_by_pssm_cred.apprcert,
+       q_4_noc_1d_totals_by_pssm_cred.[1 - cert],
+       q_4_noc_1d_totals_by_pssm_cred.[2 - cert],
+       q_4_noc_1d_totals_by_pssm_cred.[1 - dipl],
+       q_4_noc_1d_totals_by_pssm_cred.[2 - dipl],
+       q_4_noc_1d_totals_by_pssm_cred.[1 - adgr or ut],
+       q_4_noc_1d_totals_by_pssm_cred.[2 - adgr or ut],
+       q_4_noc_1d_totals_by_pssm_cred.[1 - adct or adip],
+       q_4_noc_1d_totals_by_pssm_cred.[2 - adct or adip],
+       q_4_noc_1d_totals_by_pssm_cred.bach,
+       q_4_noc_1d_totals_by_pssm_cred.[1 - pdct or pddp],
+       q_4_noc_1d_totals_by_pssm_cred.[2 - pdct or pddp],
+       q_4_noc_1d_totals_by_pssm_cred.mast,
+       q_4_noc_1d_totals_by_pssm_cred.doct
+FROM   q_4_noc_1d_totals_by_pssm_cred
+ORDER  BY 6,
+          4,
+          1;"
+
+
+# ---- Q_4_NOC_Totals_by_Year ----
+Q_4_NOC_Totals_by_Year <-
+  "SELECT *
+INTO Q_4_NOC_Totals_by_Year 
+FROM Q_4_NOC_4D_Totals_by_Year
+UNION ALL SELECT *
+FROM Q_4_NOC_3D_Totals_by_Year
+UNION ALL SELECT *
+FROM Q_4_NOC_2D_Totals_by_Year
+UNION ALL SELECT *
+FROM Q_4_NOC_1D_Totals_by_Year
+UNION ALL SELECT *
+FROM Q_4_NOC_5D_Totals_by_Year
+ORDER BY 6, 4, 2, 8;"
+
+
+# ---- Q_4_NOC_Totals_by_Year_and_PSSM_CRED ----
+Q_4_NOC_Totals_by_Year_and_PSSM_CRED <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
+tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, 
+tbl_NOC_Skill_Level_Aged_17_34.PSSM_Skill_Level, 
+tbl_NOC_Skill_Level_Aged_17_34.SKILL_LEVEL_Initial, 
+tbl_NOC_Skill_Level_Aged_17_34.SKILL_LEVEL_CATEGORY_CODE, 
+tbl_NOC_Skill_Level_Aged_17_34.UNIT_GROUP_CODE AS NOC, 
+tbl_NOC_Skill_Level_Aged_17_34.ENGLISH_NAME, 
+Sum(tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN) AS CountN, 
+RoundToLarger(Sum([OccsN]),0) AS CountNRnd
+FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union 
+INNER JOIN tbl_NOC_Skill_Level_Aged_17_34 
+ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC = tbl_NOC_Skill_Level_Aged_17_34.UNIT_GROUP_CODE
+GROUP BY tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
+tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tbl_NOC_Skill_Level_Aged_17_34.PSSM_Skill_Level, 
+tbl_NOC_Skill_Level_Aged_17_34.SKILL_LEVEL_Initial, tbl_NOC_Skill_Level_Aged_17_34.SKILL_LEVEL_CATEGORY_CODE, 
+tbl_NOC_Skill_Level_Aged_17_34.UNIT_GROUP_CODE, tbl_NOC_Skill_Level_Aged_17_34.ENGLISH_NAME
+HAVING (((tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year) In ('2011/2012','2012/2013','2013/2014','2014/2015','2015/2016')));"
+
+
+# ---- Q_4_NOC_Totals_by_Year_BC ----
+Q_4_NOC_Totals_by_Year_BC <-
+  "SELECT [q_4_noc_totals_by_year].[age_group_rollup_label] + '-'
+       + [q_4_noc_totals_by_year].[noc] + '-'
+       + CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50))  AS  Expr1000,
+       q_4_noc_totals_by_year.age_group_rollup_label,
+       q_4_noc_totals_by_year.noc_level,
+       q_4_noc_totals_by_year.noc,
+       q_4_noc_totals_by_year.english_name,
+       t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+       t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+       Sum(q_4_noc_totals_by_year.[2023/2024]) AS [2023/2024],
+       Sum(q_4_noc_totals_by_year.[2024/2025]) AS [2024/2025],
+       Sum(q_4_noc_totals_by_year.[2025/2026]) AS [2025/2026],
+       Sum(q_4_noc_totals_by_year.[2026/2027]) AS [2026/2027],
+       Sum(q_4_noc_totals_by_year.[2027/2028]) AS [2027/2028],
+       Sum(q_4_noc_totals_by_year.[2028/2029]) AS [2028/2029],
+       Sum(q_4_noc_totals_by_year.[2029/2030]) AS [2029/2030],
+       Sum(q_4_noc_totals_by_year.[2030/2031]) AS [2030/2031],
+       Sum(q_4_noc_totals_by_year.[2031/2032]) AS [2031/2032],
+       Sum(q_4_noc_totals_by_year.[2032/2033]) AS [2032/2033],
+       Sum(q_4_noc_totals_by_year.[2033/2034]) AS [2033/2034],
+       Sum(q_4_noc_totals_by_year.[2034/2035]) AS [2034/2035]
+INTO Q_4_NOC_Totals_by_Year_BC
+FROM   (q_4_noc_totals_by_year
+  INNER JOIN t_current_region_pssm_rollup_codes_bc
+    ON q_4_noc_totals_by_year.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup)
+  INNER JOIN t_current_region_pssm_rollup_codes
+    ON t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup_bc = t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup
+GROUP  BY [q_4_noc_totals_by_year].[age_group_rollup_label] 
+          + '-' + [q_4_noc_totals_by_year].[noc] + '-'
+          + CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)),
+          q_4_noc_totals_by_year.age_group_rollup_label,
+          q_4_noc_totals_by_year.noc_level,
+          q_4_noc_totals_by_year.noc,
+          q_4_noc_totals_by_year.english_name,
+          t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+          t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+          t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup;"
+
+# ---- Q_4_NOC_Totals_by_Year_Total ----
+Q_4_NOC_Totals_by_Year_Total <- "
+SELECT [q_4_noc_totals_by_year].[age_group_rollup_label]
+    + '-' + [q_4_noc_totals_by_year].[noc] + '-' +
+    CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)) AS Expr1000,
+    q_4_noc_totals_by_year.age_group_rollup_label,
+    q_4_noc_totals_by_year.noc_level,
+    q_4_noc_totals_by_year.noc,
+    q_4_noc_totals_by_year.english_name, 
+    t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+    t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+    Sum(q_4_noc_totals_by_year.[2023/2024]) AS [2023/2024], 
+    Sum(q_4_noc_totals_by_year.[2024/2025]) AS [2024/2025], 
+    Sum(q_4_noc_totals_by_year.[2025/2026]) AS [2025/2026], 
+    Sum(q_4_noc_totals_by_year.[2026/2027]) AS [2026/2027], 
+    Sum(q_4_noc_totals_by_year.[2027/2028]) AS [2027/2028], 
+    Sum(q_4_noc_totals_by_year.[2028/2029]) AS [2028/2029], 
+    Sum(q_4_noc_totals_by_year.[2029/2030]) AS [2029/2030], 
+    Sum(q_4_noc_totals_by_year.[2030/2031]) AS [2030/2031],
+    Sum(q_4_noc_totals_by_year.[2031/2032]) AS [2031/2032],
+    Sum(q_4_noc_totals_by_year.[2032/2033]) AS [2032/2033],
+    Sum(q_4_noc_totals_by_year.[2033/2034]) AS [2033/2034],
+    Sum(q_4_noc_totals_by_year.[2034/2035]) AS [2034/2035]
+INTO Q_4_NOC_Totals_by_Year_Total
+FROM (q_4_noc_totals_by_year
+INNER JOIN t_current_region_pssm_rollup_codes_bc
+ON q_4_noc_totals_by_year.current_region_pssm_code_rollup = t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup)
+INNER JOIN t_current_region_pssm_rollup_codes 
+ON t_current_region_pssm_rollup_codes_bc.current_region_pssm_code_rollup_total= t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup
+GROUP BY [q_4_noc_totals_by_year].[age_group_rollup_label]
+    + '-' + [q_4_noc_totals_by_year].[noc] + '-' +
+    CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)),
+    q_4_noc_totals_by_year.age_group_rollup_label,
+    q_4_noc_totals_by_year.noc_level,
+    q_4_noc_totals_by_year.noc, q_4_noc_totals_by_year.english_name,
+    t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
+    t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup,
+    t_current_region_pssm_rollup_codes.current_region_pssm_name_rollup;"
+
+
+# ---- Q_5_NOC_Totals_by_Year_and_BC ----
+Q_5_NOC_Totals_by_Year_and_BC <-
+  "SELECT Q_4_NOC_Totals_by_Year.*
+INTO Q_5_NOC_Totals_by_Year_and_BC
+FROM Q_4_NOC_Totals_by_Year
+UNION ALL SELECT Q_4_NOC_Totals_by_Year_BC.*
+FROM Q_4_NOC_Totals_by_Year_BC
+ORDER BY 6, 4, 2, 8;"
+
+
+# ---- Q_5_NOC_Totals_by_Year_and_BC_and_Total ----
+Q_5_NOC_Totals_by_Year_and_BC_and_Total <-
+  "SELECT Q_4_NOC_Totals_by_Year.*
+INTO Q_5_NOC_Totals_by_Year_and_BC_and_Total
+FROM Q_4_NOC_Totals_by_Year
+
+UNION ALL SELECT Q_4_NOC_Totals_by_Year_BC.*
+FROM Q_4_NOC_Totals_by_Year_BC
+
+UNION ALL SELECT Q_4_NOC_Totals_by_Year_Total.*
+FROM Q_4_NOC_Totals_by_Year_Total
+ORDER BY 6, 4, 2, 8;"
+
+# ---- Q_6_tmp_tbl_Model ----
+Q_6_tmp_tbl_Model <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+INTO tmp_tbl_Model
+FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
+
+Q_6_tmp_tbl_Model_QI <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+ INTO tmp_tbl_QI
+ FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
+
+# ---- Q_6_tmp_tbl_Model_Inc_Private_Inst ----
+Q_6_tmp_tbl_Model_Inc_Private_Inst <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+INTO tmp_tbl_Model_Inc_Private_Inst
+FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
+
+# ---- Q_6_tmp_tbl_Model_Program_Projection ----
+Q_6_tmp_tbl_Model_Program_Projection <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+INTO tmp_tbl_Model_Program_Projection
+FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
+
+# ---- Q_7_QI ----
+Q_7_QI_Old <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.PSSM_Skill_Level, tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, tmp_tbl_Model.NOC_Level, 
+tmp_tbl_Model.NOC_SKILL_TYPE, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, tmp_tbl_Model.[2023/2024] AS Model_Y1, tmp_tbl_QI.[2023/2024] AS QI_Y1, 
+IIf([tmp_tbl_QI].[Expr1]=Null,'',Abs(([Model_Y1]-[QI_Y1])/[QI_Y1])) AS ErrorRate
+FROM tmp_tbl_Model LEFT JOIN tmp_tbl_QI ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1000
+ORDER BY 6, 4, 2, 8;"
+
+Q_7_QI <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.NOC_Level, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+tmp_tbl_Model.[2023/2024] AS Model_Y1, 
+tmp_tbl_QI.[2023/2024] AS QI_Y1,
+CASE WHEN [tmp_tbl_QI].[Expr1] = Null THEN '' ELSE Abs(tmp_tbl_Model.[2023/2024]-tmp_tbl_QI.[2023/2024])/tmp_tbl_QI.[2023/2024] END AS ErrorRate
+FROM tmp_tbl_Model 
+LEFT JOIN tmp_tbl_QI 
+	ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1"
+
+
+# ---- Q_8_Labour_Supply_Total_by_Year ----
+Q_8_Labour_Supply_Total_by_Year <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED AS Expr1, 
+Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
+WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year) In 
+  ('2023/2024','2024/2025','2026/2027','2027/2028','2029/2030','2030/2031','2031/2032','2032/2033','2033/2034','2034/2035')))
+GROUP BY tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED;"
+
+
+# ---- qry_10a_Model ----
+qry_10a_Model <-
+  "SELECT tmp_tbl_Model.Expr1, 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+tmp_tbl_Model.[2023/2024], 
+tmp_tbl_Model.[2024/2025], 
+tmp_tbl_Model.[2025/2026], 
+tmp_tbl_Model.[2026/2027], 
+tmp_tbl_Model.[2027/2028], 
+tmp_tbl_Model.[2028/2029], 
+tmp_tbl_Model.[2029/2030], 
+tmp_tbl_Model.[2030/2031],
+tmp_tbl_Model.[2031/2032],
+tmp_tbl_Model.[2032/2033],
+tmp_tbl_Model.[2033/2034],
+tmp_tbl_Model.[2034/2035],
+tmp_tbl_QI.[2023/2024] AS QI, 
+tmp_tbl_Model_Inc_Private_Inst.[2023/2024] AS CI
+INTO qry_10a_Model
+FROM (tmp_tbl_Model 
+LEFT JOIN tmp_tbl_QI 
+ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1) 
+LEFT JOIN tmp_tbl_Model_Inc_Private_Inst ON tmp_tbl_Model.Expr1 = tmp_tbl_Model_Inc_Private_Inst.Expr1
+ORDER BY 2, 7, 5, 3, 9;"
+
+
+# ---- qry_10a_Model_Public_Release ----
+qry_10a_Model_Public_Release <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+CEILING([tmp_tbl_Model].[2023/2024]) AS [2023/2024], 
+CEILING([tmp_tbl_Model].[2024/2025]) AS [2024/2025], 
+CEILING([tmp_tbl_Model].[2025/2026]) AS [2025/2026], 
+CEILING([tmp_tbl_Model].[2026/2027]) AS [2026/2027], 
+CEILING([tmp_tbl_Model].[2027/2028]) AS [2027/2028], 
+CEILING([tmp_tbl_Model].[2028/2029]) AS [2028/2029], 
+CEILING([tmp_tbl_Model].[2029/2030]) AS [2029/2030], 
+CEILING([tmp_tbl_Model].[2030/2031]) AS [2030/2031],
+CEILING([tmp_tbl_Model].[2031/2032]) AS [2031/2032],
+CEILING([tmp_tbl_Model].[2032/2033]) AS [2032/2033],
+CEILING([tmp_tbl_Model].[2033/2034]) AS [2033/2034],
+CEILING([tmp_tbl_Model].[2034/2035]) AS [2034/2035]
+INTO qry_10a_Model_Public_Release
+FROM ((tmp_tbl_Model 
+LEFT JOIN tmp_tbl_QI 
+  ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1) 
+  LEFT JOIN tmp_tbl_Model_Inc_Private_Inst 
+    ON tmp_tbl_Model.Expr1 = tmp_tbl_Model_Inc_Private_Inst.Expr1) 
+LEFT JOIN T_Suppression_Public_Release_NOC 
+  ON (tmp_tbl_Model.Age_Group_Rollup_Label = T_Suppression_Public_Release_NOC.Age_Group_Rollup_Label) 
+AND (tmp_tbl_Model.NOC = T_Suppression_Public_Release_NOC.NOC_CD)
+WHERE (((tmp_tbl_Model.NOC_Level) = 5) And ((tmp_tbl_Model.NOC) <> '99999') 
+And ((tmp_tbl_Model.Current_Region_PSSM_Code_Rollup)=5900) 
+And (((Abs(tmp_tbl_Model.[2023/2024]-tmp_tbl_QI.[2023/2024])/tmp_tbl_QI.[2023/2024]))<0.25) 
+And ((T_Suppression_Public_Release_NOC.Age_Group_Rollup_Label) Is Null) 
+And ((T_Suppression_Public_Release_NOC.NOC_CD) Is Null))
+ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
+
+
+# ---- qry_10a_Model_Public_Release_Suppressed ----
+qry_10a_Model_Public_Release_Suppressed <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+CEILING(Sum([tmp_tbl_Model].[2023/2024])) AS [2023/2024], 
+CEILING(Sum([tmp_tbl_Model].[2024/2025])) AS [2024/2025], 
+CEILING(Sum([tmp_tbl_Model].[2025/2026])) AS [2025/2026], 
+CEILING(Sum([tmp_tbl_Model].[2026/2027])) AS [2026/2027], 
+CEILING(Sum([tmp_tbl_Model].[2027/2028])) AS [2027/2028], 
+CEILING(Sum([tmp_tbl_Model].[2028/2029])) AS [2028/2029], 
+CEILING(Sum([tmp_tbl_Model].[2029/2030])) AS [2029/2030], 
+CEILING(Sum([tmp_tbl_Model].[2030/2031])) AS [2030/2031],
+CEILING(Sum([tmp_tbl_Model].[2031/2032])) AS [2031/2032],
+CEILING(Sum([tmp_tbl_Model].[2032/2033])) AS [2032/2033],
+CEILING(Sum([tmp_tbl_Model].[2033/2034])) AS [2033/2034],
+CEILING(Sum([tmp_tbl_Model].[2034/2035])) AS [2034/2035]
+INTO qry_10a_Model_Public_Release_Suppressed
+FROM tmp_tbl_Model LEFT JOIN qry_10a_Model_Public_Release 
+ON (tmp_tbl_Model.Age_Group_Rollup_Label = qry_10a_Model_Public_Release.Age_Group_Rollup_Label) 
+AND (tmp_tbl_Model.NOC = qry_10a_Model_Public_Release.NOC)
+WHERE (((qry_10a_Model_Public_Release.Age_Group_Rollup_Label) Is Null) 
+AND ((qry_10a_Model_Public_Release.NOC) Is Null) AND ((tmp_tbl_Model.NOC_Level)=5))
+GROUP BY tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup
+HAVING (((tmp_tbl_Model.Current_Region_PSSM_Code_Rollup)=5900))
+ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
+
+
+# ---- qry_10a_Model_Public_Release_Suppressed_Total ----
+qry_10a_Model_Public_Release_Suppressed_Total <-
+  "SELECT '' AS Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, '99998' AS [NOC], 'Other' AS [ENGLISH_NAME], 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2023/2024] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2023/2024] END)) AS [2023/2024], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2024/2025] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2024/2025] END)) AS [2024/2025], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2025/2026] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2025/2026] END)) AS [2025/2026], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2026/2027] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2026/2027] END)) AS [2026/2027], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2027/2028] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2027/2028] END)) AS [2027/2028], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2028/2029] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2028/2029] END)) AS [2028/2029], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2029/2030] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2029/2030] END)) AS [2029/2030], 
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2030/2031] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2030/2031] END)) AS [2030/2031],
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2031/2032] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2031/2032] END)) AS [2031/2032],
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2032/2033] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2032/2033] END)) AS [2032/2033],
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2033/2034] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2033/2034] END)) AS [2033/2034],
+Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2034/2035] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2034/2035] END)) AS [2034/2035]
+INTO qry_10a_Model_Public_Release_Suppressed_Total
+FROM tmp_tbl_Model LEFT JOIN qry_10a_Model_Public_Release ON tmp_tbl_Model.Expr1 = qry_10a_Model_Public_Release.Expr1
+WHERE (((tmp_tbl_Model.NOC_Level)=5) AND ((qry_10a_Model_Public_Release.Expr1) Is Null))
+GROUP BY tmp_tbl_Model.Age_Group_Rollup_Label,
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup
+HAVING (((tmp_tbl_Model.Current_Region_PSSM_Code_Rollup) = 5900));"
+
+
+# ---- qry_10a_Model_Public_Release_Union ----
+qry_10a_Model_Public_Release_Union <-
+  "SELECT qry_10a_Model_Public_Release.*
+INTO qry_10a_Model_Public_Release_Union
+FROM qry_10a_Model_Public_Release
+UNION ALL SELECT qry_10a_Model_Public_Release_Suppressed_Total.*
+FROM qry_10a_Model_Public_Release_Suppressed_Total
+ORDER BY 2, 6, 4, 5, 8;"
+
+
+# ---- qry_10a_Model_QI_PPCI ----
+qry_10a_Model_QI_PPCI <-
+  "SELECT tmp_tbl_Model.Expr1, 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+--no longer present in NOC data
+--tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
+tmp_tbl_Model.NOC_Level, 
+-- no longer present in NOC data
+--tmp_tbl_Model.NOC_SKILL_TYPE, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+Ceiling([tmp_tbl_Model].[2023/2024]) AS [2023/2024], 
+Ceiling([tmp_tbl_Model].[2024/2025]) AS [2024/2025], 
+Ceiling([tmp_tbl_Model].[2025/2026]) AS [2025/2026], 
+Ceiling([tmp_tbl_Model].[2026/2027]) AS [2026/2027], 
+Ceiling([tmp_tbl_Model].[2027/2028]) AS [2027/2028], 
+Ceiling([tmp_tbl_Model].[2028/2029]) AS [2028/2029], 
+Ceiling([tmp_tbl_Model].[2029/2030]) AS [2029/2030], 
+Ceiling([tmp_tbl_Model].[2030/2031]) AS [2030/2031], 
+Ceiling([tmp_tbl_Model].[2031/2032]) AS [2031/2032], 
+Ceiling([tmp_tbl_Model].[2032/2033]) AS [2032/2033], 
+Ceiling([tmp_tbl_Model].[2033/2034]) AS [2033/2034], 
+Ceiling([tmp_tbl_Model].[2034/2035]) AS [2034/2035], 
+(Abs([tmp_tbl_Model].[2023/2024]-[tmp_tbl_QI].[2023/2024])/[tmp_tbl_QI].[2023/2024]) AS [Quality Indicator], 
+IIf(IsNull([tmp_tbl_Model_Inc_Private_Inst].[2023/2024]),0,[tmp_tbl_Model].[2023/2024]/[tmp_tbl_Model_Inc_Private_Inst].[2023/2024]) AS [Coverage Indicator]
+FROM ((tmp_tbl_Model 
+LEFT JOIN tmp_tbl_QI ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1) 
+LEFT JOIN tmp_tbl_Model_Inc_Private_Inst ON tmp_tbl_Model.Expr1 = tmp_tbl_Model_Inc_Private_Inst.Expr1) 
+LEFT JOIN T_Suppression_Public_Release_NOC ON (tmp_tbl_Model.Age_Group_Rollup_Label = T_Suppression_Public_Release_NOC.Age_Group_Rollup_Label) 
+AND (tmp_tbl_Model.NOC = T_Suppression_Public_Release_NOC.NOC_CD)
+WHERE (((tmp_tbl_Model.NOC_Level)=5) 
+AND ((tmp_tbl_Model.NOC)<>'99999') 
+AND ((T_Suppression_Public_Release_NOC.Age_Group_Rollup_Label) Is Null) 
+AND ((T_Suppression_Public_Release_NOC.NOC_CD) Is Null))
+ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC, 2, 5, 4, 8;"
+
+
+# ---- qry_10a_Model_QI_PPCI_No_Supp ----
+qry_10a_Model_QI_PPCI_No_Supp <-
+  "SELECT tmp_tbl_Model.Expr1, 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+--tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
+tmp_tbl_Model.NOC_Level, 
+--tmp_tbl_Model.NOC_SKILL_TYPE, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+Ceiling([tmp_tbl_Model].[2023/2024]) AS [2023/2024], 
+Ceiling([tmp_tbl_Model].[2024/2025]) AS [2024/2025], 
+Ceiling([tmp_tbl_Model].[2025/2026]) AS [2025/2026],
+Ceiling([tmp_tbl_Model].[2026/2027]) AS [2026/2027], 
+Ceiling([tmp_tbl_Model].[2027/2028]) AS [2027/2028], 
+Ceiling([tmp_tbl_Model].[2028/2029]) AS [2028/2029],
+Ceiling([tmp_tbl_Model].[2029/2030]) AS [2029/2030],
+Ceiling([tmp_tbl_Model].[2030/2031]) AS [2030/2031], 
+Ceiling([tmp_tbl_Model].[2031/2032]) AS [2031/2032], 
+Ceiling([tmp_tbl_Model].[2032/2033]) AS [2032/2033], 
+Ceiling([tmp_tbl_Model].[2033/2034]) AS [2033/2034], 
+Ceiling([tmp_tbl_Model].[2034/2035]) AS [2034/2035], 
+IIf((Abs([tmp_tbl_Model].[2023/2024]-[tmp_tbl_QI].[2023/2024])/[tmp_tbl_QI].[2023/2024])<0.25,(Abs([tmp_tbl_Model].[2023/2024]-[tmp_tbl_QI].[2023/2024])/[tmp_tbl_QI].[2023/2024]),
+IIf([tmp_tbl_Model].[2023/2024]<10 
+Or [tmp_tbl_QI].[2023/2024]<10 
+Or [tmp_tbl_Model].[2023/2024]=Null 
+Or [tmp_tbl_QI].[2023/2024]=Null,'999999999',
+(Abs([tmp_tbl_Model].[2023/2024]-[tmp_tbl_QI].[2023/2024])/[tmp_tbl_QI].[2023/2024]))) AS [Quality Indicator], 
+IIf(
+IsNull([tmp_tbl_Model_Inc_Private_Inst].[2023/2024],0)=0,0,
+[tmp_tbl_Model].[2023/2024]/[tmp_tbl_Model_Inc_Private_Inst].[2023/2024]) AS [Coverage Indicator]
+FROM (tmp_tbl_Model LEFT JOIN tmp_tbl_QI ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1) 
+LEFT JOIN tmp_tbl_Model_Inc_Private_Inst ON tmp_tbl_Model.Expr1 = tmp_tbl_Model_Inc_Private_Inst.Expr1
+WHERE (((tmp_tbl_Model.NOC_Level)=5))
+ORDER BY 2,4,6;"
+
+
+# ---- qry_10a_Model_QI_PPCI_Suppressed ----
+qry_10a_Model_QI_PPCI_Suppressed <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
+--tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
+--tmp_tbl_Model.NOC_SKILL_TYPE, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+Ceiling(Sum([tmp_tbl_Model].[2023/2024])) AS [2023/2024], 
+Ceiling(Sum([tmp_tbl_Model].[2024/2025])) AS [2024/2025], 
+Ceiling(Sum([tmp_tbl_Model].[2025/2026])) AS [2025/2026], 
+Ceiling(Sum([tmp_tbl_Model].[2026/2027])) AS [2026/2027], 
+Ceiling(Sum([tmp_tbl_Model].[2027/2028])) AS [2027/2028], 
+Ceiling(Sum([tmp_tbl_Model].[2028/2029])) AS [2028/2029], 
+Ceiling(Sum([tmp_tbl_Model].[2029/2030])) AS [2029/2030], 
+Ceiling(Sum([tmp_tbl_Model].[2030/2031])) AS [2030/2031], 
+Ceiling(Sum([tmp_tbl_Model].[2031/2032])) AS [2031/2032], 
+Ceiling(Sum([tmp_tbl_Model].[2032/2033])) AS [2032/2033], 
+Ceiling(Sum([tmp_tbl_Model].[2033/2034])) AS [2033/2034], 
+Ceiling(Sum([tmp_tbl_Model].[2034/2035])) AS [2034/2035], 
+qry_10a_Model_QI_PPCI.Expr1
+FROM tmp_tbl_Model LEFT JOIN qry_10a_Model_QI_PPCI ON tmp_tbl_Model.Expr1 = qry_10a_Model_QI_PPCI.Expr1
+WHERE (((tmp_tbl_Model.NOC_Level)=5))
+GROUP BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
+tmp_tbl_Model.NOC_SKILL_TYPE, tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+qry_10a_Model_QI_PPCI.Expr1
+HAVING (((qry_10a_Model_QI_PPCI.Expr1) Is Null))
+ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
+
+
+# ---- qry_10a_Model_QI_PPCI_Suppressed_Total ----
+qry_10a_Model_QI_PPCI_Suppressed_Total <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
+--'N/A' AS [NOC Skill Level], 
+tmp_tbl_Model.NOC_Level, 
+--'N/A' AS [NOC Skill Type], 
+'99998' AS [NOC 2021], 
+'Other' AS [Occupation Description], 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+Sum(Ceiling([tmp_tbl_Model].[2023/2024])) AS [2023/2024], 
+Sum(Ceiling([tmp_tbl_Model].[2024/2025])) AS [2024/2025], 
+Sum(Ceiling([tmp_tbl_Model].[2025/2026])) AS [2025/2026], 
+Sum(Ceiling([tmp_tbl_Model].[2026/2027])) AS [2026/2027], 
+Sum(Ceiling([tmp_tbl_Model].[2027/2028])) AS [2027/2028], 
+Sum(Ceiling([tmp_tbl_Model].[2028/2029])) AS [2028/2029], 
+Sum(Ceiling([tmp_tbl_Model].[2029/2030])) AS [2029/2030], 
+Sum(Ceiling([tmp_tbl_Model].[2030/2031])) AS [2030/2031], 
+Sum(Ceiling([tmp_tbl_Model].[2031/2032])) AS [2031/2032], 
+Sum(Ceiling([tmp_tbl_Model].[2032/2033])) AS [2032/2033], 
+Sum(Ceiling([tmp_tbl_Model].[2033/2034])) AS [2033/2034], 
+Sum(Ceiling([tmp_tbl_Model].[2034/2035])) AS [2034/2035]
+FROM tmp_tbl_Model LEFT JOIN qry_10a_Model_QI_PPCI ON tmp_tbl_Model.Expr1 = qry_10a_Model_QI_PPCI.Expr1
+WHERE (((qry_10a_Model_QI_PPCI.Expr1) Is Null))
+GROUP BY 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC_Level, 
+--'N/A', 
+'99998', 
+'Other', 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup
+HAVING (((tmp_tbl_Model.NOC_Level)=5));"
+
+# ---- qry_10b_Quality_Indicator ----
+qry_10b_Quality_Indicator <-
+  "SELECT tmp_tbl_Model.Expr1, 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC_Level, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+tmp_tbl_QI.[2023/2024]
+FROM tmp_tbl_Model LEFT JOIN tmp_tbl_QI 
+ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1
+ORDER BY tmp_tbl_Model.Expr1;"
+
+
+# ---- qry_10c_Coverage_Indicator ----
+qry_10c_Coverage_Indicator <-
+  "SELECT tmp_tbl_Model.Expr1, 
+tmp_tbl_Model.Age_Group_Rollup_Label, 
+tmp_tbl_Model.NOC_Level, 
+tmp_tbl_Model.NOC, 
+tmp_tbl_Model.ENGLISH_NAME, 
+tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
+tmp_tbl_Model_Inc_Private_Inst.[2023/2024] AS Expr2
+FROM tmp_tbl_Model 
+LEFT JOIN tmp_tbl_Model_Inc_Private_Inst 
+  ON tmp_tbl_Model.Expr1 = tmp_tbl_Model_Inc_Private_Inst.Expr1
+ORDER BY tmp_tbl_Model.Expr1;"
+
+
+# ---- qry_10d_tmp_No_Near_Completers ----
+qry_10d_tmp_No_Near_Completers <-
+  "SELECT [tmp_tbl_Model_2017-05-16].Expr1, [tmp_tbl_Model_2017-05-16].Age_Group_Rollup_Label, 
+[tmp_tbl_Model_2017-05-16].PSSM_Skill_Level, [tmp_tbl_Model_2017-05-16].SKILL_LEVEL_CATEGORY_CODE, 
+[tmp_tbl_Model_2017-05-16].NOC_Level, [tmp_tbl_Model_2017-05-16].NOC_SKILL_TYPE, 
+[tmp_tbl_Model_2017-05-16].NOC, [tmp_tbl_Model_2017-05-16].ENGLISH_NAME, 
+[tmp_tbl_Model_2017-05-16].Current_Region_PSSM_Code_Rollup, 
+[tmp_tbl_Model_2017-05-16].Current_Region_PSSM_Name_Rollup, 
+[tmp_tbl_Model_2017-05-16].[2015/2016], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2015/2016], 
+[tmp_tbl_Model_2017-05-16].[2016/2017], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2016/2017], 
+[tmp_tbl_Model_2017-05-16].[2017/2018], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2017/2018], 
+[tmp_tbl_Model_2017-05-16].[2018/2019], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2018/2019], 
+[tmp_tbl_Model_2017-05-16].[2019/2020], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2019/2020], 
+[tmp_tbl_Model_2017-05-16].[2020/2021], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2020/2021], 
+[tmp_tbl_Model_2017-05-16].[2021/2022], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2021/2022], 
+[tmp_tbl_Model_2017-05-16].[2022/2023], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2022/2023], 
+[tmp_tbl_Model_2017-05-16].[2023/2024], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2023/2024], 
+[tmp_tbl_Model_2017-05-16].[2024/2025], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2024/2025], 
+[tmp_tbl_Model_2017-05-16].[2025/2026], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2025/2026], 
+[tmp_tbl_Model_2017-05-16].[2026/2027], 
+[tmp_tbl_Model_2017-06-08_No_Near_Completers].[2026/2027]
+FROM [tmp_tbl_Model_2017-05-16] LEFT JOIN [tmp_tbl_Model_2017-06-08_No_Near_Completers] 
+ON [tmp_tbl_Model_2017-05-16].Expr1 = [tmp_tbl_Model_2017-06-08_No_Near_Completers].Expr1
+ORDER BY 2, 7, 5, 3, 9;"
+
+
+# ---- qry_LCIP4_CRED ----
+qry_LCIP4_CRED <-
+  "SELECT Occupation_Distributions.LCIP4_CRED
+FROM Occupation_Distributions
+GROUP BY Occupation_Distributions.LCIP4_CRED
+ORDER BY Occupation_Distributions.LCIP4_CRED;"
+
+
+# ---- qry_LCIP4_CRED_Filtered_NOC ----
+qry_LCIP4_CRED_Filtered_NOC <-
+  "SELECT TOP 10 Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC, Occupation_Distributions.Count, Occupation_Distributions.[percent]
+FROM Occupation_Distributions INNER JOIN qry_LCIP4_CRED ON Occupation_Distributions.LCIP4_CRED=qry_LCIP4_CRED.LCIP4_CRED
+WHERE (((Occupation_Distributions.Count) In (Select Top 3 [Count] From Occupation_Distributions WHERE [Occupation_Distributions].[LCIP4_CRED]=[qry_LCIP4_CRED].[LCIP4_CRED] Order By [Count] Desc)))
+ORDER BY Occupation_Distributions.[percent] DESC;"
+
+
+# ---- qry_LCIP4_CRED_NOC ----
+qry_LCIP4_CRED_NOC <-
+  "SELECT Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC
+FROM Occupation_Distributions
+GROUP BY Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC
+ORDER BY Occupation_Distributions.LCIP4_CRED;"
+
+
+# ---- qry100_Grad_Skill_Level ----
+qry100_Grad_Skill_Level <-
+  "SELECT Q_4_NOC_4D_Totals_by_PSSM_CRED.PSSM_Skill_Level AS Expr1, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRAPPR) AS SumOfAPPRAPPR, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRCERT) AS SumOfAPPRCERT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - CERT]) AS [SumOf1 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - DIPL]) AS [SumOf1 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADGR or UT]) AS [SumOf1 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADCT or ADIP]) AS [SumOf1 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.BACH) AS SumOfBACH, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - PDCT or PDDP]) AS [SumOf1 - PDCT or PDDP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.MAST) AS SumOfMAST, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.DOCT) AS SumOfDOCT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - CERT]) AS [SumOf2 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - DIPL]) AS [SumOf2 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADGR or UT]) AS [SumOf2 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADCT or ADIP]) AS [SumOf2 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - PDCT or PDDP]) AS [SumOf2 - PDCT or PDDP]
+FROM Q_4_NOC_4D_Totals_by_PSSM_CRED
+GROUP BY Q_4_NOC_4D_Totals_by_PSSM_CRED.PSSM_Skill_Level;"
+
+
+# ---- qry99_Presentations_Graduates_Appendix ----
+qry99_Presentations_Graduates_Appendix_old <-
+  "TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
+SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name
+FROM T_PSSM_Credential_Grouping_Appendix INNER JOIN Q_1c_Grad_Projections_by_Program ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
+WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
+GROUP BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name, T_PSSM_Credential_Grouping_Appendix.ORDER
+ORDER BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.ORDER
+PIVOT Q_1c_Grad_Projections_by_Program.Year;"
+
+
+# ---- qry99_Presentations_Graduates_Appendix ----
+qry99_Presentations_Graduates_Appendix <-
+  "SELECT Age_Group_Rollup_Label, PSSM_Credential_Name, 
+[2023/2024], 
+[2024/2025], 
+[2025/2026], 
+[2026/2027], 
+[2027/2028], 
+[2028/2029], 
+[2029/2030], 
+[2030/2031],
+[2031/2032],
+[2032/2033],
+[2033/2034],
+[2034/2035]
+FROM (
+SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, 
+Q_1c_Grad_Projections_by_Program.Year as yr,
+T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name, 
+Grads
+FROM T_PSSM_Credential_Grouping_Appendix 
+INNER JOIN Q_1c_Grad_Projections_by_Program 
+	ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
+WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
+) AS SourceTable
+PIVOT (
+    Sum([Grads]) FOR Yr IN ([2023/2024], 
+[2024/2025], 
+[2025/2026], 
+[2026/2027], 
+[2027/2028], 
+[2028/2029], 
+[2029/2030], 
+[2030/2031],
+[2031/2032],
+[2032/2033],
+[2033/2034],
+[2034/2035])
+) AS PivotTable;"
+
+
+# ---- qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals ----
+qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals_old <-
+  "TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
+SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label
+FROM T_PSSM_Credential_Grouping_Appendix 
+INNER JOIN Q_1c_Grad_Projections_by_Program 
+ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
+WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
+GROUP BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label
+PIVOT Q_1c_Grad_Projections_by_Program.Year;"
+
+# ---- qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals ----
+qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals <-
+  "SELECT Age_Group_Rollup_Label, 
+[2023/2024], 
+[2024/2025], 
+[2025/2026], 
+[2026/2027], 
+[2027/2028], 
+[2028/2029], 
+[2029/2030], 
+[2030/2031],
+[2031/2032],
+[2032/2033],
+[2033/2034],
+[2034/2035]
+FROM (
+SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, 
+Q_1c_Grad_Projections_by_Program.Year as yr,
+T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name, 
+Grads
+FROM T_PSSM_Credential_Grouping_Appendix 
+INNER JOIN Q_1c_Grad_Projections_by_Program 
+	ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
+WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
+) AS SourceTable
+PIVOT (
+    Sum([Grads]) FOR Yr IN ([2023/2024], 
+[2024/2025], 
+[2025/2026], 
+[2026/2027], 
+[2027/2028], 
+[2028/2029], 
+[2029/2030], 
+[2030/2031],
+[2031/2032],
+[2032/2033],
+[2033/2034],
+[2034/2035])
+) AS PivotTable;"
+
+
+# ---- qry99_Presentations_Graduates_Appendix_Unrounded ----
+qry99_Presentations_Graduates_Appendix_Unrounded <-
+  "TRANSFORM Sum(Q_1c_Grad_Projections_by_Program.Grads) AS SumOfGrads
+SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name
+FROM T_PSSM_Credential_Grouping_Appendix INNER JOIN Q_1c_Grad_Projections_by_Program ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
+WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
+GROUP BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name, T_PSSM_Credential_Grouping_Appendix.ORDER
+ORDER BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.ORDER
+PIVOT Q_1c_Grad_Projections_by_Program.Year;"
+
+
+# ---- qry99_Presentations_Graduates_Including_those_not_projected ----
+qry99_Presentations_Graduates_Including_those_not_projected <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
+FROM Graduate_Projections INNER JOIN T_PSSM_CRED_RECODE ON Graduate_Projections.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
+WHERE ((((Graduate_Projections.Year)='2015/2016' Or (Graduate_Projections.Year)='2016/2017')=False) And (((Graduate_Projections.Age_Group)='15 to 16' Or (Graduate_Projections.Age_Group)='65 to 89')=False) And ((Graduate_Projections.PSSM_CRED) Not Like 'P - %'))
+GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
+ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
+
+
+# ---- qry99_Presentations_Labour_Force ----
+qry99_Presentations_Labour_Force <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.New_Labour_Supply) AS SumOfNew_Labour_Supply, T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
+WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
+GROUP BY tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup;"
+
+
+# ---- qry99_Presentations_Labour_Force_BC ----
+qry99_Presentations_Labour_Force_BC <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+FROM ((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_PSSM_CRED_RECODE ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED) INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup) INNER JOIN T_Current_Region_PSSM_Rollup_Codes ON T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC = T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup
+WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
+GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
+ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
+
+
+# ---- qry99_Presentations_Labour_Force_Overall ----
+qry99_Presentations_Labour_Force_Overall <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_PSSM_CRED_RECODE ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
+WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
+GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
+ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
+
+
+# ---- qry99_Presentations_Occs ----
+qry99_Presentations_Occs <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC, Sum(tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN) AS SumOfOccsN
+FROM (tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup) INNER JOIN T_Current_Region_PSSM_Rollup_Codes ON T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC = T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup
+GROUP BY tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC
+HAVING (((tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'));"
+
+
+# ---- qry99_Presentations_PPSCI_Graduates ----
+qry99_Presentations_PPSCI_Graduates <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
+FROM Graduate_Projections INNER JOIN T_PSSM_CRED_RECODE ON Graduate_Projections.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
+GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER, Graduate_Projections.Year
+HAVING (((Graduate_Projections.Year)='2019/2020'))
+ORDER BY T_PSSM_CRED_RECODE.ORDER;"
+
+# ---- qry9999_NOC_4031_4032 ----
+qry9999_NOC_4031_4032 <-
+  "SELECT [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_Credential AS Expr1, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_CRED AS Expr2, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup AS Expr3, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup_Label AS Expr4, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year AS Expr5, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC AS Expr6, Sum([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].OccsN) AS SumOfOccsN
+FROM [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16]
+WHERE ((([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9910 And ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9911 And ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9999))
+GROUP BY [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_Credential, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_CRED, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup_Label, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC
+HAVING ((([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup)=3) And (([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year)='2015/2016') And (([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC)='4031' Or ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC)='4032'))
+ORDER BY [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC;"
+
+###############################################################################################
+# end
+###############################################################################################


### PR DESCRIPTION


**Refactor DACSO program matching step from SQL-style joins to clearer R dplyr joins**

***

## PR Description

### Summary

This PR refactors the `02a-dacso-program-matching` step as part of the broader repo work to translate SQL query logic into **R dplyr**. This file is one stage in that migration and focuses on keeping the R output aligned with the existing SQL-based process. 

### What changed

*   Refactored the file to use a clearer R pattern for joins on string business keys.
*   Added explicit helper functions to create normalized join keys instead of hiding the logic inside a custom join wrapper.
*   Updated high-risk joins to use generated `*_KEY` columns where string matching can behave differently in SQL Server and R. 
*   Kept final output tables written to SQL Server with the `_r` suffix so R-generated outputs are clearly separated from the SQL versions. 
*   Trimmed some of the check / diagnostic patterns so the script is easier to follow while still preserving the main matching logic. 

### Why this matters

A key issue in the SQL → R translation is that **joins on string keys do not behave the same way by default**. SQL Server often matches character keys case-insensitively, while R joins are case-sensitive. This can cause false mismatches when translating SQL logic directly into `dplyr`. This refactor makes that behavior explicit by generating normalized join keys before the join. 

### Notes

*   This change is intended to improve readability and reduce hidden side effects in the join logic.
*   Original business columns are kept intact; helper key columns are dropped before writing final outputs.
*   Output tables created by the R script continue to use the `_r` suffix for easier comparison against SQL-based outputs. 

### Validation

Recommended validation for this step:

*   compare row counts between SQL and R outputs, 
*   compare matched / unmatched program counts, 
*   compare final output tables written with `_r` suffix against the SQL versions. 

```sql
SELECT 'sql' AS src, COUNT(*) AS n FROM [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO"
UNION ALL
SELECT 'r'   AS src, COUNT(*) AS n FROM   [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO_r"
;
SELECT * FROM [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO"
EXCEPT
SELECT * FROM [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO_r";
SELECT * FROM [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO_r"
EXCEPT
SELECT * FROM [PSSM2023].[IDIR\JDUAN]."STP_Credential_Non_Dup_Programs_DACSO";
```
