### PR TITLE
chore: sync .gitignore with PR #88 merge, stop tracking debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,23 +10,7 @@ tmp
 *.html
 .github/copilot-instructions.md
 
-R/02a-appso-programs.txt
-R/02a-bgs-program-matching-backup-2.R
-R/02a-dacso-program-matching-test-id.R
-R/02a-dacso-program-matching.txt
-sql/Notebook-refactor-1.ipynb
-sql/test_refactor.r
-sql/test_refactor.sql
-tmp/input-data.csv
-tmp/output.csv
-R/app.R
-R/Compare the current in-memory tmp_tb_model.R
-docs/PSSM Analyst Manual — Running the Mode.md
-*.js
-*.css
-*.ttf
-*.map
-*.png
+
 plugin.yml
 presentations/presentation-06-2026_files/
 .factory/
@@ -37,4 +21,4 @@ docs/02a-update-cred-non-dup-diagiam.md
 .gitignore
 .claude/
 docs/agents/
-AGENTS.md
+split-pr-89.sh

--- a/.gitignore
+++ b/.gitignore
@@ -10,13 +10,31 @@ tmp
 *.html
 .github/copilot-instructions.md
 
-.github/copilot-instructions.md
-
+R/02a-appso-programs.txt
+R/02a-bgs-program-matching-backup-2.R
+R/02a-dacso-program-matching-test-id.R
+R/02a-dacso-program-matching.txt
+sql/Notebook-refactor-1.ipynb
+sql/test_refactor.r
+sql/test_refactor.sql
+tmp/input-data.csv
+tmp/output.csv
+R/app.R
+R/Compare the current in-memory tmp_tb_model.R
+docs/PSSM Analyst Manual — Running the Mode.md
+*.js
+*.css
+*.ttf
+*.map
+*.png
+plugin.yml
+presentations/presentation-06-2026_files/
+.factory/
 tmp/
 .github/agents/*
 .github/instructions/*
 docs/02a-update-cred-non-dup-diagiam.md
-AGENTS.md
 .gitignore
-docs/agents/
 .claude/
+docs/agents/
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,7 @@ R/02a-dacso-program-matching.txt
 sql/Notebook-refactor-1.ipynb
 sql/test_refactor.r
 sql/test_refactor.sql
-tmp/input-data.csv
-tmp/output.csv
+tmp/*.*
 R/app.R
 R/Compare the current in-memory tmp_tb_model.R
 docs/PSSM Analyst Manual — Running the Mode.md

--- a/R/.gitignore
+++ b/R/.gitignore
@@ -2,3 +2,5 @@ execution_log.txt
 gender_cleaning.R
 *.txt
 *.csv
+04-graduate-projections-refactor.R
+03-near-completers-ttrain-refactor.R

--- a/R/.gitignore
+++ b/R/.gitignore
@@ -2,5 +2,3 @@ execution_log.txt
 gender_cleaning.R
 *.txt
 *.csv
-04-graduate-projections-refactor.R
-03-near-completers-ttrain-refactor.R

--- a/R/.gitignore
+++ b/R/.gitignore
@@ -1,5 +1,4 @@
 execution_log.txt
-gender_cleaning.R
 *.txt
 *.csv
 04-graduate-projections-refactor.R

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,6 @@
 /.quarto/
 !styles.css
 cip-to-noc*
+*.ttf
+*.map
+*.png


### PR DESCRIPTION
Part 1 of 4 splitting PR #89.

- Union .gitignore rules from PR #88 (documentation-clean-up) and PR #89.
- Add R/.gitignore for R-side scratch files.
- Untrack debug.log (should never have been committed).

No code or docs changes. Safe to merge on inspection.

Follow-ups (stacked): #<PR2> docs, #<PR3> utils, #<PR4> code.
Replaces #89.
