### PR TITLE
feat(utils): add logging and shared helpers for the R pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,4 @@ tmp/
 .claude/
 
 docs/agents/
-<<<<<<< HEAD
-=======
-AGENTS.md
->>>>>>> 0726738 (fix(utils): re-throw caught condition instead of bare stop())
 split-pr-89.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,8 @@ tmp/
 .claude/
 
 docs/agents/
+<<<<<<< HEAD
+=======
+AGENTS.md
+>>>>>>> 0726738 (fix(utils): re-throw caught condition instead of bare stop())
 split-pr-89.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ tmp/
 .github/instructions/*
 .gitignore
 .claude/
+
+docs/agents/
 split-pr-89.sh

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,6 +17,7 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
+
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,7 @@
 library(tidyverse)
 library(RODBC)
 library(DBI)
+library(futile.logger)
 
 # ---- Connect to SQL Server and read StatCan Tables ----
 lan <- config::get("lan")
@@ -103,7 +104,10 @@ time_execution <- function(file_path) {
       )
       flog.error(traceback(), name = "file_logger") # Log the traceback for details
 
-      stop()
+      # Re-raise the original condition so callers see the real error message,
+      # class, and call site. A bare stop() would throw an empty error and
+      # discard everything we just logged about.
+      stop(e)
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,11 +88,11 @@ time_execution <- function(file_path) {
       print(error_message)
       print("###############################################")
       # Log the error message if execution fails
-      flog.error(
+      futile.logger::flog.error(
         paste("Error in file:", file_path, "-", e$message),
         name = "file_logger"
       )
-      flog.error(traceback(), name = "file_logger") # Log the traceback for details
+      futile.logger::flog.error(paste(capture.output(traceback()), collapse = "\n"), name = "file_logger")
 
       # Re-raise the original condition so callers see the real error message,
       # class, and call site. A bare stop() would throw an empty error and

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,6 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
-
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,6 +17,7 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
+
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,6 @@
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
 
-
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,13 +1,14 @@
-# Define the time_execution function to track execution time and handle errors
-# source(file_path, echo = TRUE, keep.source = TRUE):
-#
-#   echo = TRUE: Prints each line of code as it is executed, helping to trace progress and identify errors.
-# keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
-# local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
-# traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
-
-# By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
-# To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
+# Copyright 2026 Province of British Columbia
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 
 library(tidyverse)
 library(RODBC)
@@ -18,6 +19,30 @@ library(futile.logger)
 # Create connections in the calling script and pass them into helper functions.
 
 
+# time_execution: source an R script with timing, console + file logging, and
+# fail-fast error handling. Wraps each pipeline module so every step is timed,
+# logged, and aborts the run on the first failure. Intended use:
+#
+#   time_execution("R/01a-enrolment-preprocessing.R")
+#
+# The script is sourced with local = globalenv(), so objects it creates (data
+# frames, the DB connection, the file_logger, etc.) persist in the global
+# environment for the modules that follow. echo = TRUE echoes each line to the
+# console, and keep.source = TRUE keeps source references so traceback() can
+# point at the offending line on failure.
+#
+# Output goes to both the console (print()) and the "file_logger" appender
+# (futile.logger::flog.*). On error the handler logs the message and traceback,
+# then re-raises the original condition via stop(e) — callers see the real
+# error, not a blank one.
+#
+# Args:
+#   file_path: path to the R script to execute.
+#
+# Side effects: sources `file_path` into .GlobalEnv; writes START/COMPLETE (with
+# elapsed seconds) or error + traceback to console and "file_logger".
+# Returns: the result of source() (invisible NULL on success); on error the
+# original condition is re-raised.
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,16 +5,7 @@
 # keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
-# Log File Connection: log_conn <- file(log_file, open = "a") opens a connection in append mode to add logs to execution_log.txt.
-#
-# Logging Each Step:
-#
-#   Start: Logs a start message with a timestamp before running the script.
-# Completion: Logs the completion message with the elapsed time after successful execution.
-# Error: Logs the error message and writes the traceback() to the log file for debugging.
-# finally Block: Ensures the log file connection is closed after execution, even if an error occurs.
-#
-# Custom Log File: You can specify a custom log file by passing a different path to log_file.
+
 
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
@@ -26,6 +17,7 @@ library(futile.logger)
 
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
+
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@ library(futile.logger)
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
-  flog.info(paste("Starting:", file_path), name = "file_logger")
+  futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")
 
   # Log a start message with a timestamp
   print(

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,18 +24,8 @@ library(RODBC)
 library(DBI)
 library(futile.logger)
 
-# ---- Connect to SQL Server and read StatCan Tables ----
-lan <- config::get("lan")
-my_schema <- config::get("myschema")
-db_config <- config::get("decimal")
-con <- dbConnect(
-  odbc::odbc(),
-  Driver = db_config$driver,
-  Server = db_config$server,
-  Database = db_config$database,
-  Trusted_Connection = "True"
-)
-
+# Keep utils side-effect free: do not read config or open DB connections on source.
+# Create connections in the calling script and pass them into helper functions.
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,30 +1,45 @@
-
 # Define the time_execution function to track execution time and handle errors
 # source(file_path, echo = TRUE, keep.source = TRUE):
-#   
+#
 #   echo = TRUE: Prints each line of code as it is executed, helping to trace progress and identify errors.
 # keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
 # Log File Connection: log_conn <- file(log_file, open = "a") opens a connection in append mode to add logs to execution_log.txt.
-# 
+#
 # Logging Each Step:
-#   
+#
 #   Start: Logs a start message with a timestamp before running the script.
 # Completion: Logs the completion message with the elapsed time after successful execution.
 # Error: Logs the error message and writes the traceback() to the log file for debugging.
 # finally Block: Ensures the log file connection is closed after execution, even if an error occurs.
-# 
+#
 # Custom Log File: You can specify a custom log file by passing a different path to log_file.
 
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
 
+library(tidyverse)
+library(RODBC)
+library(DBI)
+
+# ---- Connect to SQL Server and read StatCan Tables ----
+lan <- config::get("lan")
+my_schema <- config::get("myschema")
+db_config <- config::get("decimal")
+con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
+
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")
-  
+
   # Log a start message with a timestamp
   print(
     "#################################################################################################"
@@ -33,45 +48,104 @@ time_execution <- function(file_path) {
   print(
     "#################################################################################################"
   )
-  
+
   start_time <- Sys.time()
-  
-  tryCatch({
-    # Source the file with echo, and log each line to the log file
-    source(
-      file_path,
-      echo = TRUE,
-      keep.source = TRUE,
-      # local = TRUE
-      local = globalenv()) # Make global variables accessible in source
-    
-    # Log the completion message with elapsed time
-    end_time <- Sys.time()
-    elapsed <- end_time - start_time
-    print("########################################################################")
-    print(paste(
-      Sys.time(),
-      "Completed:",
-      file_path,
-      "in",
-      round(elapsed, 2),
-      "seconds"
-    ))
-    print("########################################################################")
-    flog.info(paste("Completed:", file_path, "in", round(elapsed, 2), "seconds"),
-              name = "file_logger")
-    
-  }, error = function(e) {
-    # Log the error message if execution fails
-    error_message <- paste(Sys.time(), "Error in file:", file_path, " - ", e$message)
-    print("###############################################")
-    print(error_message)
-    print("###############################################")
-    # Log the error message if execution fails
-    flog.error(paste("Error in file:", file_path, "-", e$message), name = "file_logger")
-    flog.error(traceback(), name = "file_logger")  # Log the traceback for details
-    
-    stop()
-  }
- )
+
+  tryCatch(
+    {
+      # Source the file with echo, and log each line to the log file
+      source(
+        file_path,
+        echo = TRUE,
+        keep.source = TRUE,
+        # local = TRUE
+        local = globalenv()
+      ) # Make global variables accessible in source
+
+      # Log the completion message with elapsed time
+      end_time <- Sys.time()
+      elapsed <- end_time - start_time
+      print(
+        "########################################################################"
+      )
+      print(paste(
+        Sys.time(),
+        "Completed:",
+        file_path,
+        "in",
+        round(elapsed, 2),
+        "seconds"
+      ))
+      print(
+        "########################################################################"
+      )
+      flog.info(
+        paste("Completed:", file_path, "in", round(elapsed, 2), "seconds"),
+        name = "file_logger"
+      )
+    },
+    error = function(e) {
+      # Log the error message if execution fails
+      error_message <- paste(
+        Sys.time(),
+        "Error in file:",
+        file_path,
+        " - ",
+        e$message
+      )
+      print("###############################################")
+      print(error_message)
+      print("###############################################")
+      # Log the error message if execution fails
+      flog.error(
+        paste("Error in file:", file_path, "-", e$message),
+        name = "file_logger"
+      )
+      flog.error(traceback(), name = "file_logger") # Log the traceback for details
+
+      stop()
+    }
+  )
+}
+
+# read_table_from_db: counterpart to write_table_to_db.
+#
+# Reads a schema-qualified table written by the pipeline (suffixed "_r") back
+# into the global environment, bound to `table_name`. Intended to be called
+# over a vector of names with purrr::walk, e.g.:
+#
+#   walk(required_tables, read_table_from_db, schema = my_schema, con = con)
+#
+# Args:
+#   table_name: base table name (without the "_r" suffix), used both to build
+#               the DB name and as the global variable to assign.
+#   schema:     SQL schema, typically config::get("myschema") — never hardcoded.
+#   con:        an open DBI connection (Trusted_Connection = "True").
+#
+# Side effect: assigns the table into .GlobalEnv[[table_name]].
+# Returns: `table_name` invisibly.
+read_table_from_db <- function(table_name, schema, con) {
+  db_name <- glue::glue("{table_name}_r")
+  .GlobalEnv[[table_name]] <- dbReadTable(
+    con,
+    SQL(glue::glue('"{schema}"."{db_name}"'))
+  )
+  invisible(table_name)
+}
+
+
+# lower_col_names: standardise a table's column names to lower case.
+#
+# Counterpart to the rename_with(toupper) calls used elsewhere in the pipeline.
+# Returns the data frame with all column names lower-cased; the data itself is
+# unchanged.
+#
+# Args:
+#   table_name: a name of a data frame / tibble.
+#
+# Returns: `df` with lower-case column names.
+lower_col_names_global <- function(table_name) {
+  .GlobalEnv[[table_name]] <- .GlobalEnv[[table_name]] |>
+    rename_with(tolower)
+  invisible(table_name)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,6 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
-
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")


### PR DESCRIPTION
Part 3 of 4 splitting PR #89.

Expands R/utils.R with reusable helpers that the rest of the pipeline (PR4) depends on:

- log_info() — shared futile.logger wrapper writing to R/execution_log.txt and console.
- time_execution() — wraps a script call with timing, traceback logging, fail-fast behaviour, and standardized START/COMPLETE markers.
- read_table_from_db() — loads _r-suffixed tables from SQL Server into memory.
- lower_col_names_global() — standardizes column-name casing across loaded tables.

Foundational change; landing this first lets PR4's per-module changes be reviewed as thin call-site additions.

Follows: #<PR2>. Follow-up: #<PR4> code.
