### PR TITLE
split/4b-loader-logic: feat(loaders): projection loader logic, INFOWARE lookups, StatCan loads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,4 @@ tmp/
 .claude/
 
 docs/agents/
-<<<<<<< HEAD
-=======
-AGENTS.md
->>>>>>> 0726738 (fix(utils): re-throw caught condition instead of bare stop())
 split-pr-89.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,8 @@ tmp/
 .claude/
 
 docs/agents/
+<<<<<<< HEAD
+=======
+AGENTS.md
+>>>>>>> 0726738 (fix(utils): re-throw caught condition instead of bare stop())
 split-pr-89.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ tmp/
 .github/instructions/*
 .gitignore
 .claude/
+
+docs/agents/
 split-pr-89.sh

--- a/R/load-custom-stats-can.R
+++ b/R/load-custom-stats-can.R
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # ******************************************************************************
-# Load custom Statistics Canada data from staging area in LAN project folder, to decimal.  
+# Load custom Statistics Canada data from staging area in LAN project folder, to decimal.
 # ******************************************************************************
 
 # ---- libraries and global variables
@@ -27,32 +27,37 @@ raw_data_file <- glue::glue("{lan}/data/statcan/stat-can-data-export.csv")
 
 # ----- Connection to decimal ----
 db_config <- config::get("decimal")
-con <- dbConnect(odbc(),
-                 Driver = db_config$driver,
-                 Server = db_config$server,
-                 Database = db_config$database,
-                 Trusted_Connection = "True")
+con <- dbConnect(
+  odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 # ---- Read raw data  ----
 raw_data <- read_csv(raw_data_file, locale = locale(encoding = "latin1"))
 
 # ---- Clean data ----
-data <- raw_data %>% 
-  clean_names() %>% 
-  rename(age_group = age,
-         occupation_NOC = occupation,
-         masters_degree_and_earned_doctorate = master_s_degree_and_earned_doctorate # funky apostrophe header name
-  ) %>% 
+data <- raw_data %>%
+  clean_names() %>%
+  rename(
+    age_group = age,
+    occupation_NOC = occupation,
+    masters_degree_and_earned_doctorate = master_s_degree_and_earned_doctorate # funky apostrophe header name
+  ) %>%
   # fix the geography column en-dashes
-  mutate(geography = str_replace(geography,"\u0096","-"))
+  mutate(geography = str_replace(geography, "\u0096", "-"))
 
 # ---- Write to decimal ----
-dbWriteTableArrow(con,
-                  name = "STAT_CAN",
-                  nanoarrow::as_nanoarrow_array_stream(data))
+dbWriteTableArrow(
+  con,
+  name = "STAT_CAN_r",
+  nanoarrow::as_nanoarrow_array_stream(data)
+)
 
 # ---- Read from decimal ----
-dbReadTable(con, "STAT_CAN")
+dbReadTable(con, "STAT_CAN_r")
 
 # ---- Disconnect ----
 dbDisconnect(con)

--- a/R/load-infoware-lookups.R
+++ b/R/load-infoware-lookups.R
@@ -1,0 +1,307 @@
+# Copyright 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+library(tidyverse)
+library(RODBC)
+library(odbc)
+library(DBI)
+library(glue)
+library(RJDBC)
+library(dbplyr)
+
+# ---- Configure LAN Paths and DB Connection -----
+lan <- config::get("lan")
+db_config <- config::get("decimal")
+my_schema <- config::get("myschema")
+
+# Connect to Decimal
+con <- dbConnect(
+  odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "TRUE"
+)
+
+# only if those table are not in the analyst's schema, we load those tables
+
+# ---- Read in INFOWARE tables ----
+# only run once to get tables ready
+iw_config <- config::get("infoware")
+
+odbcListDrivers()
+
+iw_con <- dbConnect(
+  odbc::odbc(),
+  Driver = "Oracle in instantclient_19_30",
+  DBQ = "DEV01.world",
+  UID = iw_config$uid,
+  PWD = iw_config$pwd
+)
+
+# ## ** NOTE **
+# ## Ideally match on all data but prioritizing the most recent 6 years - see documentation
+# ## Update which BGS_DIST tables to include.
+
+# ## Run the following to get a list of all tables available
+# # alltables_Infoware <- dbReadTable(iw_con,"ALL_TABLES")
+
+# ---- Write initial tables to Decimal ----
+## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
+# !! UPDATE THE TABLES AND ROW NUMBERS !! - connection won't write the full datasets to decimal due to size
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23")
+  )
+) {
+  INFOWARE_BGS_DIST_19_23 <- dbReadTable(
+    iw_con,
+    DBI::Id(schema = "INFOWARE", table = "BGS_DIST_19_23")
+  )
+
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23"),
+    INFOWARE_BGS_DIST_19_23[1:80000, ]
+  )
+
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23"),
+    INFOWARE_BGS_DIST_19_23[80001:121074, ],
+    append = TRUE
+  )
+}
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22")
+  )
+) {
+  INFOWARE_BGS_DIST_18_22 <- dbReadTable(
+    iw_con,
+    DBI::SQL("INFOWARE.BGS_DIST_18_22")
+  )
+
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22"),
+    INFOWARE_BGS_DIST_18_22[1:80000, ]
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22"),
+    INFOWARE_BGS_DIST_18_22[80001:118632, ],
+    append = TRUE
+  )
+}
+
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO")
+  )
+) {
+  INFOWARE_BGS_COHORT_INFO <- dbReadTable(
+    iw_con,
+    DBI::SQL("INFOWARE.BGS_COHORT_INFO")
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
+    INFOWARE_BGS_COHORT_INFO[1:80000, ]
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
+    INFOWARE_BGS_COHORT_INFO[80001:160000, ],
+    append = TRUE
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
+    INFOWARE_BGS_COHORT_INFO[160001:240000, ],
+    append = TRUE
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
+    INFOWARE_BGS_COHORT_INFO[240001:290758, ],
+    append = TRUE
+  )
+}
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_6DIGITS_CIP2016")
+  )
+) {
+  INFOWARE_L_CIP_6DIGITS_CIP2016 <- dbReadTable(
+    iw_con,
+    DBI::Id(schema = "INFOWARE", table = "L_CIP_6DIGITS_CIP2016")
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_6DIGITS_CIP2016"),
+    INFOWARE_L_CIP_6DIGITS_CIP2016
+  )
+}
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_4DIGITS_CIP2016")
+  )
+) {
+  INFOWARE_L_CIP_4DIGITS_CIP2016 <- dbReadTable(
+    iw_con,
+    DBI::Id(schema = "INFOWARE", table = "L_CIP_4DIGITS_CIP2016")
+  )
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_4DIGITS_CIP2016"),
+    INFOWARE_L_CIP_4DIGITS_CIP2016
+  )
+}
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_2DIGITS_CIP2016")
+  )
+) {
+  INFOWARE_L_CIP_2DIGITS_CIP2016 <- dbReadTable(
+    iw_con,
+    DBI::Id(schema = "INFOWARE", table = "L_CIP_2DIGITS_CIP2016")
+  )
+
+  dbWriteTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_2DIGITS_CIP2016"),
+    INFOWARE_L_CIP_2DIGITS_CIP2016
+  )
+}
+
+
+# ---- Read in INFOWARE tables ----
+# iw_config <- config::get("infoware")
+# jdbc_config <- config::get("jdbc")
+
+# jdbcDriver <- JDBC(jdbc_config$class, classPath = jdbc_config$path)
+
+# iw_con <- dbConnect(
+#   jdbcDriver,
+#   iw_config$database,
+#   iw_config$uid,
+#   iw_config$pwd
+# )
+# new way to load data from infoware
+# iw_config <- config::get("infoware")
+
+# odbcListDrivers()
+
+# iw_con <- dbConnect(
+#   odbc::odbc(),
+#   Driver = "Oracle in instantclient_19_30",
+#   DBQ = "DEV01.world",
+#   UID = iw_config$uid,
+#   PWD = iw_config$pwd
+# )
+# all the comment-outed data steps are only running for once.
+# now infoware has INFOWARE.L_CIP_6DIGITS_CIP2021 table. We may need to update soon.
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_PROGRAMS")
+  )
+) {
+  INFOWARE_PROGRAMS <- dbReadTable(iw_con, DBI::SQL("INFOWARE.PROGRAMS"))
+  dbWriteTable(
+    con,
+    SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS"')),
+    INFOWARE_PROGRAMS
+  )
+}
+
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_PROGRAMS_2016")
+  )
+) {
+  INFOWARE_PROGRAMS_2016 <- dbReadTable(
+    iw_con,
+    DBI::SQL("INFOWARE.PROGRAMS_BKUP_NOV_2024_CIP2016_CIP2021")
+  )
+  dbWriteTable(
+    con,
+    SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS_2016"')),
+    INFOWARE_PROGRAMS_2016
+  )
+}
+
+
+if (
+  !dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "INFOWARE_PROGRAMS_HIST_PRGMID_XREF")
+  )
+) {
+  INFOWARE_PROGRAMS_HIST_PRGMID_XREF <- dbReadTable(
+    iw_con,
+    DBI::SQL("INFOWARE.PROGRAMS_HIST_PRGMID_XREF")
+  )
+  dbWriteTable(
+    con,
+    SQL(glue::glue('"{my_schema}"."INFOWARE_PROGRAMS_HIST_PRGMID_XREF"')),
+    INFOWARE_PROGRAMS_HIST_PRGMID_XREF
+  )
+}
+
+
+dbDisconnect(iw_con)
+
+dbDisconnect(con)
+
+# ## check tables loaded correctly
+# {
+#   nrow <- tbl(con, "INFOWARE_BGS_DIST_19_23") %>% tally()
+#   nrow ## how many rows?
+#   tbl(con, "INFOWARE_BGS_DIST_19_23") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
+
+#   nrow <- tbl(con, "INFOWARE_BGS_DIST_18_22") %>% tally()
+#   nrow ## how many rows?
+#   tbl(con, "INFOWARE_BGS_DIST_18_22") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
+
+#   nrow <- tbl(con, "INFOWARE_BGS_COHORT_INFO") %>% tally()
+#   nrow ## how many rows?
+#   tbl(con, "INFOWARE_BGS_COHORT_INFO") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
+
+#   rm(nrow)
+# }
+
+# ## remove tables and use decimal versions for remainder of code
+# rm(
+#   INFOWARE_BGS_DIST_19_23,
+#   INFOWARE_BGS_DIST_18_22,
+#   INFOWARE_BGS_COHORT_INFO,
+#   INFOWARE_L_CIP_6DIGITS_CIP2016,
+#   INFOWARE_L_CIP_4DIGITS_CIP2016,
+#   INFOWARE_L_CIP_2DIGITS_CIP2016
+# )

--- a/R/load-occupation-projections.R
+++ b/R/load-occupation-projections.R
@@ -11,19 +11,58 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # ******************************************************************************
-# Load datasets required to run program projections step
+# Load datasets required to run the OCCUPATION projections step (step 07).
+# (Header previously said "program projections" - stale; this feeds 07, not 06.)
 # ******************************************************************************
 
+# ============================================================================
+# WHAT THIS SCRIPT DOES
+#   Data-loading partner for 07-occupation-projections.R. It pulls every input
+#   that step 07 needs into the global environment, then writes only the lookup
+#   CSVs back to the analyst's IDIR schema as "<name>_r". Inputs come from two
+#   places:
+#     1. SQL Server "_r" tables built by earlier steps (02b, 04, 06).
+#     2. Lookup CSVs on the LAN (development/csv/gh-source/lookups/07/...).
+#
+# WHAT IT LOADS AND WHY 07 NEEDS IT
+#   The two distribution families drive 07's probability chain:
+#     OCCSN = GRADUATES x P(CIP|cred,age) x P(supply|CIP) x P(NOC|CIP,region)
+#   - labour_supply_distribution*   -> P(in labour supply | CIP)   (Q_2 series)
+#   - occupation_distributions*     -> P(NOC | CIP, region)        (Q_3 series)
+#   Each family is loaded in FOUR variants because 07 falls back through looser
+#   proxies when an exact program match is missing:
+#     <base>          exact LCIP4_CRED match
+#     <base>_No_TT    same key with TTRAIN stripped out  (trades fallback)
+#     <base>_LCP2     2-digit CIP (broader program group)
+#     <base>_LCP2_No_TT   2-digit CIP with TTRAIN stripped
+#   Plus the program mix (cohort_program_distributions_*, from 06), the graduate
+#   forecasts (graduate_projections, from 04), and CIP code lookups.
+#
+# THREE TRANSFORMS REPEATED ON ALMOST EVERY TABLE (explained in full below at the
+# first labour-supply block, then referenced briefly afterwards):
+#   1. janitor::clean_names(case = "all_caps")
+#   2. str_replace(" OR ", " or ")  on the credential key columns
+#   3. filter(!SURVEY == "PTIB")    (distribution tables only)
+#
+# RUN CONTEXT
+#   The connection is intentionally LEFT OPEN for step 07 (the paired analysis
+#   script), so this file does not dbDisconnect(). Only the lookup CSVs are
+#   persisted; the SQL-read tables already exist as "_r" and stay in memory.
+# ============================================================================
+
 library(tidyverse)
-library(RODBC)
+# library(RODBC)   # REMOVED: unused. This script uses DBI/odbc, not RODBC.
 library(config)
 library(DBI)
 
 # ---- Configure LAN and file paths ----
+# Environment-specific values come from config.yml (never hardcoded). `lan` is
+# the network path to the lookup CSVs; `my_schema` is this analyst's IDIR schema.
 lan <- config::get("lan")
 my_schema <- config::get("myschema")
 
 # ---- Connection to decimal ----
+# Windows Integrated Authentication (Trusted_Connection = "True") per convention.
 db_config <- config::get("decimal")
 con <- dbConnect(
   odbc::odbc(),
@@ -38,20 +77,32 @@ con <- dbConnect(
 # might get FALSE that Cohort_Program_Distributions exists during first run-through.
 # Use the Static Cohort_Program_Distributions table?
 
-# Labour_Supply_Distribution
+# ---- Labour_Supply_Distribution (exact-match variant) ----
+# This first block carries the FULL explanation of the three repeated transforms;
+# every distribution table below applies the same three steps.
 labour_supply_distribution <-
   dbReadTable(
     con,
     SQL(glue::glue('"{my_schema}"."Labour_Supply_Distribution_r"'))
   ) %>%
+  # 1. Force column names to UPPER_SNAKE_CASE so they match the heritage keys
+  #    that 07 joins on (e.g. LCIP4_CRED, AGE_GROUP_ROLLUP, PSSM_CRED).
   janitor::clean_names(case = "all_caps") |>
+  # 2. Normalise credential casing. Some heritage rows store "<X> OR <Y>" with an
+  #    upper-case "OR", but 07's join keys use lower-case "or". Without this fix
+  #    the proxy joins in 07 would SILENTLY miss those credentials. any_of() means
+  #    the rename is applied only to whichever of these key columns are present.
   mutate(across(
     any_of(c("PSSM_CRED", "PSSM_CREDENTIAL", "LCP2_CRED", "LCIP2_CRED")),
     ~ str_replace(., " OR ", " or ")
   )) |>
+  # 3. Drop survey-sourced PRIVATE rows. 07 REBUILDS the PTIB (private) rows as
+  #    proxies - it copies the public distributions and re-tags them "P - ". So
+  #    the original PTIB rows must be removed here first to avoid double-counting.
   filter(!SURVEY == "PTIB")
 
-# Labour_Supply_Distribution_LCP2
+# ---- Labour_Supply_Distribution_LCP2 (2-digit CIP fallback) ----
+# Same three transforms (clean_names / " OR "->" or " / drop PTIB) as above.
 labour_supply_distribution_lcp2 <-
   dbReadTable(
     con,
@@ -64,7 +115,8 @@ labour_supply_distribution_lcp2 <-
   )) |>
   filter(!SURVEY == "PTIB")
 
-# Labour_Supply_Distribution_No_TT
+# ---- Labour_Supply_Distribution_No_TT (TTRAIN-stripped fallback) ----
+# First fallback in 07 for trades programs whose TTRAIN value has no survey data.
 labour_supply_distribution_no_tt <-
   dbReadTable(
     con,
@@ -77,7 +129,8 @@ labour_supply_distribution_no_tt <-
   )) |>
   filter(!SURVEY == "PTIB")
 
-# Labour_Supply_Distribution_LCP2_No_TT
+# ---- Labour_Supply_Distribution_LCP2_No_TT (broadest fallback) ----
+# 2-digit CIP with TTRAIN stripped - the loosest labour-supply proxy in 07.
 labour_supply_distribution_lcp2_no_tt <-
   dbReadTable(
     con,
@@ -90,7 +143,9 @@ labour_supply_distribution_lcp2_no_tt <-
   )) |>
   filter(!SURVEY == "PTIB")
 
-# Occupation_Distributions
+# ---- Occupation_Distributions (exact-match variant) ----
+# The four occupation variants mirror the four labour-supply variants above and
+# feed 07's Q_3 proxy waterfall. Same three transforms throughout.
 occupation_distributions <-
   dbReadTable(
     con,
@@ -104,7 +159,7 @@ occupation_distributions <-
   filter(!SURVEY == "PTIB")
 
 
-# Occupation_Distributions_No_TT
+# ---- Occupation_Distributions_No_TT (TTRAIN-stripped fallback) ----
 occupation_distributions_no_tt <-
   dbReadTable(
     con,
@@ -117,7 +172,7 @@ occupation_distributions_no_tt <-
   )) |>
   filter(!SURVEY == "PTIB")
 
-# Occupation_Distributions_LCP2
+# ---- Occupation_Distributions_LCP2 (2-digit CIP fallback) ----
 occupation_distributions_lcp2 <-
   dbReadTable(
     con,
@@ -131,7 +186,7 @@ occupation_distributions_lcp2 <-
   filter(!SURVEY == "PTIB")
 
 
-# Occupation_Distributions_LCP2_No_TT
+# ---- Occupation_Distributions_LCP2_No_TT (broadest fallback) ----
 occupation_distributions_lcp2_no_tt <-
   dbReadTable(
     con,
@@ -144,7 +199,10 @@ occupation_distributions_lcp2_no_tt <-
   )) |>
   filter(!SURVEY == "PTIB")
 
-# Cohort_Program_Distributions_Projected
+# ---- Cohort_Program_Distributions_Projected (P(CIP|cred,age), from 06) ----
+# NOTE: the program-mix and graduate tables do NOT drop PTIB. 07 reads their PTIB
+# rows directly (the private program mix from 06 is legitimate input), unlike the
+# distribution tables above where 07 rebuilds PTIB as proxies.
 cohort_program_distributions_projected <-
   dbReadTable(
     con,
@@ -156,7 +214,8 @@ cohort_program_distributions_projected <-
     ~ str_replace(., " OR ", " or ")
   ))
 
-# Cohort_Program_Distributions_Static
+# ---- Cohort_Program_Distributions_Static (2023/24 snapshot mix, from 06) ----
+# 07's `model` toggle picks projected vs static; both are loaded so either works.
 cohort_program_distributions_static <-
   dbReadTable(
     con,
@@ -168,7 +227,8 @@ cohort_program_distributions_static <-
     ~ str_replace(., " OR ", " or ")
   ))
 
-# Graduate_Projection
+# ---- Graduate_Projections (GRADUATES by cred x age x year, from 04) ----
+# The starting volume in 07's chain; PTIB rows retained (see note above).
 graduate_projections <-
   dbReadTable(
     con,
@@ -180,21 +240,60 @@ graduate_projections <-
     ~ str_replace(., " OR ", " or ")
   ))
 
-infoware_l_cip_4digits_cip2016 <-
-  dbReadTable(
-    con,
-    SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_4DIGITS_CIP2016"'))
-  ) %>%
+# ---- CIP code lookups (Statistics Canada CIP 2016) ----
+# 4-digit and 6-digit CIP tables. 07 derives its LCP2<->LCP4 map from the 6-digit
+# version for the 2-digit proxy steps. No " OR "->" or " needed (no credential
+# columns here).
+# ---- Student Outcomes Lookups (loaded for ALL runs, incl. QI) ----
+# Statistics Canada CIP 2016 code lookups (4- and 6-digit). latin1 encoding is
+# required because the source files contain accented characters. These are kept
+# in memory for downstream steps (not written to the DB below).
+infoware_l_cip_4digits_cip2016 <- readr::read_csv(
+  glue::glue(
+    "{lan}/development/csv/infoware/INFOWARE_L_CIP_4DIGITS_CIP2016.csv"
+  ),
+  col_types = cols(
+    .default = col_guess()
+  ),
+  locale = locale(
+    encoding = "latin1"
+  )
+) %>%
   janitor::clean_names(case = "all_caps")
 
-infoware_l_cip_6digits_cip2016 <-
-  dbReadTable(
-    con,
-    SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_6DIGITS_CIP2016"'))
-  ) %>%
+infoware_l_cip_6digits_cip2016 <- readr::read_csv(
+  glue::glue(
+    "{lan}/development/csv/infoware/INFOWARE_L_CIP_6DIGITS_CIP2016.csv"
+  ),
+  col_types = cols(.default = col_guess()),
+  locale = locale(
+    encoding = "latin1"
+  )
+) %>%
   janitor::clean_names(case = "all_caps")
+
+# infoware_l_cip_4digits_cip2016 <-
+#   dbReadTable(
+#     con,
+#     SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_4DIGITS_CIP2016"'))
+#   ) %>%
+#   janitor::clean_names(case = "all_caps")
+
+# infoware_l_cip_6digits_cip2016 <-
+#   dbReadTable(
+#     con,
+#     SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_6DIGITS_CIP2016"'))
+#   ) %>%
+#   janitor::clean_names(case = "all_caps")
 
 # -------------------- LOAD LOOKUPS ------------------------
+# Small reference CSVs from the LAN. These are the tables PERSISTED back to the DB
+# at the end (the SQL-read tables above are not re-written). The three exclusion
+# lists force every column to character so later anti_join() key comparisons in 07
+# don't fail on type mismatches.
+
+# Programs to exclude from projection by 4-digit CIP (Student Outcomes can't /
+# shouldn't project these).
 t_exclude_from_projections_lcp4_cd <-
   readr::read_csv(
     glue::glue(
@@ -205,7 +304,8 @@ t_exclude_from_projections_lcp4_cd <-
   janitor::clean_names(case = "all_caps") %>%
   mutate(across(everything(), ~ as.character(.)))
 
-# this is an empty table!!
+# Exclusions by full CIP-credential key. Currently EMPTY, but loaded so 07's
+# anti_join() has a table to reference (an empty anti_join is a safe no-op).
 t_exclude_from_projections_lcip4_cred <-
   readr::read_csv(
     glue::glue(
@@ -216,7 +316,7 @@ t_exclude_from_projections_lcip4_cred <-
   janitor::clean_names(case = "all_caps") %>%
   mutate(across(everything(), ~ as.character(.)))
 
-# this is an empty table!!
+# Exclusions by credential. Also EMPTY; loaded for the same anti_join no-op reason.
 t_exclude_from_projections_pssm_credential <-
   readr::read_csv(
     glue::glue(
@@ -227,6 +327,9 @@ t_exclude_from_projections_pssm_credential <-
   janitor::clean_names(case = "all_caps") %>%
   mutate(across(everything(), ~ as.character(.)))
 
+# CIP-credential combinations barred from using the 2-digit labour-supply proxy
+# (e.g. CIP-51 medical programs whose occupation link is too specific to borrow
+# from the broader group). Consumed in 07's Q_2 LCP2 step.
 t_exclude_from_labour_supply_unknown_lcp2_proxy <-
   readr::read_csv(
     glue::glue(
@@ -237,6 +340,8 @@ t_exclude_from_labour_supply_unknown_lcp2_proxy <-
   janitor::clean_names(case = "all_caps") %>%
   mutate(across(everything(), ~ as.character(.)))
 
+# 4-digit -> 2-digit CIP map. (07 also derives this from the 6-digit CIP table;
+# this CSV is the lookup-sourced copy that gets persisted as "_r".)
 t_lcp2_lcp4 <-
   readr::read_csv(
     glue::glue("{lan}/development/csv/gh-source/lookups/07/T_LCP2_LCP4.csv"),
@@ -245,6 +350,8 @@ t_lcp2_lcp4 <-
   janitor::clean_names(case = "all_caps") %>%
   mutate(across(everything(), ~ as.character(.)))
 
+# Fine age band -> rollup band. Used in 07's Q_1c step to roll the 9 fine bands
+# up to the 5 projection bands the distributions are keyed on.
 tbl_age_groups <-
   readr::read_csv(
     glue::glue("{lan}/development/csv/gh-source/lookups/07/tbl_Age_Groups.csv"),
@@ -252,6 +359,7 @@ tbl_age_groups <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Rollup band code -> label (e.g. "17 to 29").
 tbl_age_groups_rollup <-
   readr::read_csv(
     glue::glue(
@@ -261,6 +369,7 @@ tbl_age_groups_rollup <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Region rollup codes (all regions) - attached to NOC totals in 07's Q_4 step.
 t_current_region_pssm_rollup_codes <-
   readr::read_csv(
     glue::glue(
@@ -270,6 +379,7 @@ t_current_region_pssm_rollup_codes <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Region rollup codes (BC only) - used when collapsing regions to the BC total.
 t_current_region_pssm_rollup_codes_bc <-
   readr::read_csv(
     glue::glue(
@@ -279,6 +389,7 @@ t_current_region_pssm_rollup_codes_bc <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Credential recode lookup (heritage credential code mappings).
 t_pssm_cred_recode <-
   readr::read_csv(
     glue::glue(
@@ -288,6 +399,7 @@ t_pssm_cred_recode <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Credential code -> human-readable name (used by the report appendix in 08).
 t_pssm_credential_grouping_appendix <-
   readr::read_csv(
     glue::glue(
@@ -297,10 +409,14 @@ t_pssm_credential_grouping_appendix <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# DISABLED upstream: NOC skill-type lookup is no longer used by 07 (kept for
+# reference / possible future use). Left commented intentionally.
 # T_NOC_Skill_Type <-
 #   readr::read_csv(glue::glue("{lan}/development/csv/gh-source/lookups/07/T_NOC_Skill_Type.csv"),  col_types = cols(.default = col_guess())) %>%
 #   janitor::clean_names(case = "all_caps")
 
+# NOC broad->unit hierarchy (1- to 5-digit). 07 joins this in Q_4 to roll OCCSN
+# up the NOC hierarchy. NOTE: read from the step-02 folder, not step-07.
 t_noc_broad_categories <-
   readr::read_csv(
     glue::glue(
@@ -311,11 +427,14 @@ t_noc_broad_categories <-
   janitor::clean_names(case = "all_caps")
 
 ## ------------------------------------ Clean Up --------------------------------------------------
-# Current workflow:
-#  - Write key tables back to sql server.  These are tables needed for downstream work, or tables
-# that might be needed for later reference outside of this analysis.
-#  - Close DB connections
-#  - Remove all objects at the end of each script.
+# Workflow:
+#  - Persist ONLY the lookup CSVs loaded above, each written to "<schema>"."<name>_r".
+#    The SQL-read distribution/program/grad tables are NOT re-written (they already
+#    exist as "_r") - they stay in memory for step 07.
+#  - The connection is intentionally LEFT OPEN for step 07 (paired script); this
+#    file does not dbDisconnect().
+#  - NOTE: the comment lines below about "Close DB connections" and "Remove all
+#    objects" are stale boilerplate - neither happens here by design.
 ## ------------------------------------------------------------------------------------------------
 
 tables_to_keep <- c(
@@ -335,12 +454,14 @@ tables_to_keep <- c(
   "t_noc_broad_categories"
 )
 
+# Write one named global object to "<schema>"."<table_name>_r", overwriting any
+# existing copy. Called over tables_to_keep with walk().
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    base::get(table_name, envir = .GlobalEnv), # fetch the object by name
     overwrite = TRUE
   )
 }

--- a/R/load-program-projections.R
+++ b/R/load-program-projections.R
@@ -10,20 +10,48 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# ============================================================================
+# WHAT THIS SCRIPT DOES
+#   Data-loading partner for 06-program-projections.R. It loads every input that
+#   step 06 needs and writes the key ones back to the analyst's IDIR schema as
+#   "<name>_r" tables. Inputs come from three places:
+#     1. Lookup CSVs on the LAN (development/csv/...).
+#     2. Tables already in the analyst's schema (built by earlier steps, e.g.
+#        tbl_credential_highest_rank_r, credential_non_dup_r, T_Cohorts_Recoded_r).
+#     3. A derived table built here: tbl_program_projection_input (the weighted
+#        graduate counts by CIP4 x credential x age x year that drive the program
+#        forecast in 06).
+#
+# RUN BEHAVIOUR
+#   The bulk of the loading is wrapped in `if (regular_run | ptib_run)`. The QI
+#   run deliberately SKIPS it so the projected/static distributions already in
+#   the DB are preserved (QI does not update them).
+# ============================================================================
+
 library(tidyverse)
-library(RODBC)
+# library(RODBC)   # REMOVED: unused. This script uses DBI/odbc, not RODBC.
 library(config)
 library(DBI)
 
-regular_run = T
-ptib_run = T
-qi_run = F
+# ---- Run flags ----
+# Defaults below are for a standalone "regular + PTIB" load (load everything).
+# When this script is sourced via the orchestrator (prep-for-*-run.R with
+# local = globalenv()), the run flags are inherited from the caller, so these
+# assignments are effectively overrides - keep that in mind if results look like
+# the wrong run was loaded. (TRUE/FALSE per project convention, not T/F.)
+# regular_run <- TRUE
+# ptib_run <- FALSE
+# qi_run <- FALSE
 
 # ---- Configure LAN and file paths ----
+# All environment-specific values come from config.yml (never hardcoded).
+# `lan` is the network path to the source CSVs; `my_schema` is this analyst's
+# IDIR schema (e.g. "IDIR\NAME") that intermediate tables are written to.
 lan <- config::get("lan")
 my_schema <- config::get("myschema")
 
 # ---- Connection to decimal ----
+# Windows Integrated Authentication (Trusted_Connection = "True") per convention.
 db_config <- config::get("decimal")
 con <- dbConnect(
   odbc::odbc(),
@@ -33,12 +61,17 @@ con <- dbConnect(
   Trusted_Connection = "True"
 )
 
-if (regular_run == T | ptib_run == T) {
-  # Check out whether it makes sense to re-load all lookups, regardless, and move this conditional to
-  # later in the script, to where the projected/static distributions are cleared.  The trade off being
-  # that the code is easier to read.
+# Load everything for the Regular and PTIB runs; skip for the QI run (which keeps
+# the existing projected/static distributions in the DB untouched).
+if (regular_run == TRUE | ptib_run == TRUE) {
+  # TODO (original author): consider always reloading the lookups and moving this
+  # conditional down to where the projected/static distributions are cleared.
+  # Trade-off is readability vs. reloading lookups unnecessarily on the QI run.
 
-  # ---- Lookups  ----
+  # ---- Lookups (rollover horizon + age-group + credential-grouping tables) ----
+
+  # Year-2..Year-12 cohort program distribution rollover factors (used to extend
+  # the program mix across the projection horizon in 06).
   t_cohort_program_distributions_y2_to_y12 <-
     readr::read_csv(
       glue::glue(
@@ -48,6 +81,7 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # Apprenticeship Year-2..Year-10 rollover factors (APPSO horizon).
   t_appr_y2_to_y10 <-
     readr::read_csv(
       glue::glue(
@@ -57,6 +91,7 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # Maps near-completer age bands -> graduate-projection age bands.
   tbl_age_groups_near_completers <-
     readr::read_csv(
       glue::glue(
@@ -66,6 +101,7 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # Standard age-group code -> label lookup (note: read from the step-07 folder).
   tbl_age_groups <-
     readr::read_csv(
       glue::glue(
@@ -75,6 +111,9 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # PSSM projection credential grouping (maps raw credential -> projection
+  # credential category). Title-case the projection credential so it joins
+  # cleanly to PSI_CREDENTIAL_CATEGORY downstream.
   t_pssm_projection_cred_grp <-
     readr::read_csv(
       glue::glue(
@@ -87,6 +126,8 @@ if (regular_run == T | ptib_run == T) {
       PSSM_PROJECTION_CREDENTIAL = str_to_title(PSSM_PROJECTION_CREDENTIAL)
     )
 
+  # Survey-year weights for the STP-based program distribution (Model selects
+  # which weighting vintage to use, e.g. '2023-2024').
   t_weights_stp <-
     readr::read_csv(
       glue::glue(
@@ -96,6 +137,8 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # AgeIndex -> AgeGroup lookup. NOT clean_names'd: the original column names
+  # (AgeIndex / AgeGroup) are relied on by the join below.
   agegrouplookup <-
     readr::read_csv(
       glue::glue(
@@ -105,46 +148,73 @@ if (regular_run == T | ptib_run == T) {
     )
 
   # ---- Build tbl_Program_Projection_Input ----
+  # This is the core derived input for 06: weighted graduate counts by
+  # CIP4 x credential x age-group x award-year, scoped to the modelled population.
+
+  # Highest-ranked credential per graduate (built in an earlier step).
   tbl_credential_highest_rank <- dbReadTable(
     con,
     SQL(glue::glue('"{my_schema}"."tbl_credential_highest_rank_r"'))
   )
 
+  # De-duplicated credential records (carry CIP and source flags per graduate).
   credential_non_dup <- dbReadTable(
     con,
     SQL(glue::glue('"{my_schema}"."credential_non_dup_r"'))
   )
 
-  # bring research university and outcomes credential into tbl_credential_highest_rank
-  # this should have been done at end of 01c-credential-analysis.R
-  tbl_credential_highest_rank <- tbl_credential_highest_rank |>
-    left_join(
-      credential_non_dup |>
-        select(id, research_university, outcomes_cred) |>
-        rename_with(toupper, everything()),
-      by = join_by(ID)
-    )
+  # Bring RESEARCH_UNIVERSITY and OUTCOMES_CRED onto the highest-rank table.
+  # (Author note: ideally done at the end of 01c-credential-analysis.R; done here
+  # because it was missed upstream.)
+  # tbl_credential_highest_rank <- tbl_credential_highest_rank |>
+  #   rename_with(toupper, everything()) |>
+  #   left_join(
+  #     credential_non_dup |>
+  #       rename_with(toupper, everything()) |>
+  #       select(
+  #         ID,
+  #         # RESEARCH_UNIVERSITY,
+  #         OUTCOMES_CRED
+  #       ),
+  #     by = join_by(ID)
+  #   )
+  # comment out since those two columns are already there.
 
   tbl_program_projection_input <- tbl_credential_highest_rank |>
+    rename_with(toupper, everything()) |>
     select(
       ID,
       AGE_GROUP_AT_GRAD,
       PSI_CREDENTIAL_CATEGORY,
       PSI_AWARD_SCHOOL_YEAR_DELAYED,
-      PSI_VISA_STATUS,
-      RESEARCH_UNIVERSITY,
-      OUTCOMES_CRED
+      PSI_VISA_STATUS
+      # RESEARCH_UNIVERSITY,
+      # OUTCOMES_CRED
     ) |>
+    # Attach the age-group label for each graduate.
     inner_join(
       agegrouplookup |> select(AgeIndex, AgeGroup),
       by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")
     ) |>
+    # Attach the 4-digit CIP (and cluster) for each graduate.
     inner_join(
       credential_non_dup |>
-        select(id, final_cip_code_4, final_cip_cluster_code) |>
-        rename_with(toupper, everything()),
+        rename_with(toupper, everything()) |>
+        select(
+          ID,
+          FINAL_CIP_CODE_4,
+          FINAL_CIP_CLUSTER_CODE,
+          RESEARCH_UNIVERSITY,
+          OUTCOMES_CRED
+        ),
       by = "ID"
     ) |>
+    # Population scope for the program projection:
+    #   - drop CIP clusters "09" and "10" (handled outside this stream),
+    #   - drop Apprenticeships (modelled separately via the APPSO stream),
+    #   - keep only Domestic or unknown-visa graduates, and for research
+    #     universities exclude DACSO-sourced outcomes credentials to avoid
+    #     double-counting graduates already represented via the DACSO survey.
     filter(
       FINAL_CIP_CLUSTER_CODE != "09",
       FINAL_CIP_CLUSTER_CODE != "10",
@@ -169,6 +239,9 @@ if (regular_run == T | ptib_run == T) {
             is.na(RESEARCH_UNIVERSITY))
       )
     ) |>
+    # Collapse to one row per age-group x credential x award-year x CIP4 with a
+    # graduate Count. Expr1 is a heritage Access column (credential+agegroup key)
+    # carried for parity; Count = n() is weighted downstream in 06.
     summarise(
       Expr1 = first(paste0(PSI_CREDENTIAL_CATEGORY, AgeGroup)),
       Count = n(),
@@ -180,16 +253,23 @@ if (regular_run == T | ptib_run == T) {
       )
     )
 
-  qry_private_credentials_06d1_cohort_dist <-
-    dbReadTable(
-      con,
-      SQL(glue::glue(
-        '"{my_schema}"."qry_Private_Credentials_06d1_Cohort_Dist_r"'
-      ))
-    )
+  # Private-college cohort distribution (from step 05). Column 2 holds the
+  # credential; rename it to PSSM_CREDENTIAL so 06 can align it with the other
+  # streams.
 
-  names(qry_private_credentials_06d1_cohort_dist)[2] <- "PSSM_CREDENTIAL"
+  if (ptib_run == TRUE) {
+    qry_private_credentials_06d1_cohort_dist <-
+      dbReadTable(
+        con,
+        SQL(glue::glue(
+          '"{my_schema}"."qry_Private_Credentials_06d1_Cohort_Dist_r"'
+        ))
+      )
 
+    names(qry_private_credentials_06d1_cohort_dist)[2] <- "PSSM_CREDENTIAL"
+  }
+
+  # Near-completer ratios by age x CIP4 x trades-training (from step 03).
   dacso_near_completers_ratios_age_at_grad_cip4_ttrain <-
     dbReadTable(
       con,
@@ -199,6 +279,8 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
+  # Combined recoded student-outcomes cohorts (the program -> CIP -> NOC source
+  # table; built in 02b). Used in 06 for the public/grad/apprenticeship streams.
   t_cohorts_recoded <- dbReadTable(
     con,
     SQL(glue::glue(
@@ -206,11 +288,11 @@ if (regular_run == T | ptib_run == T) {
     ))
   )
 
-  # ---- Rollover data ----
-  # this whole section is hacky - we are essentially defining a schema in the db.
-  # starting with a fresh schema (no rows).  But we don't clear them if we are doing the QI run
-  # because we want to keep the projected/static distributions in there, as they are not being updated in the QI run.
-  # maybe better to just make a schema instead
+  # ---- Rollover data: define EMPTY projected/static distribution tables ----
+  # Hacky pattern (author-flagged): rather than create a schema, read the rollover
+  # CSVs purely to inherit their COLUMN STRUCTURE, then empty them with
+  # filter(FALSE). 06 fills these incrementally. They are not cleared on the QI
+  # run so its existing distributions survive. (A real DB schema would be cleaner.)
   cohort_program_distributions_projected <-
     readr::read_csv(
       glue::glue(
@@ -229,7 +311,8 @@ if (regular_run == T | ptib_run == T) {
     ) |>
     janitor::clean_names(case = "all_caps")
 
-  # The R version is
+  # Empty both tables (keep columns only) and force the three columns that 06
+  # writes as character so later bind_rows() don't hit type mismatches.
   cohort_program_distributions_static <- cohort_program_distributions_static |>
     filter(FALSE) |>
     mutate(
@@ -245,14 +328,18 @@ if (regular_run == T | ptib_run == T) {
       GRAD_STATUS = as.character(GRAD_STATUS)
     )
 
-  # check that only required survey years are in T_Cohorts_Recoded
+  # Guard: T_Cohorts_Recoded must only contain the expected survey years.
+  # Fails fast if an unexpected year slipped into the cohort build.
   stopifnot(exprs = {
     t_cohorts_recoded |> distinct(SURVEY_YEAR) |> pull() %in% c(2019:2023)
   })
 }
 
 
-# ---- Student Outcomes Lookups ----
+# ---- Student Outcomes Lookups (loaded for ALL runs, incl. QI) ----
+# Statistics Canada CIP 2016 code lookups (4- and 6-digit). latin1 encoding is
+# required because the source files contain accented characters. These are kept
+# in memory for downstream steps (not written to the DB below).
 infoware_l_cip_4digits_cip2016 <- readr::read_csv(
   glue::glue(
     "{lan}/development/csv/infoware/INFOWARE_L_CIP_4DIGITS_CIP2016.csv"
@@ -276,15 +363,19 @@ infoware_l_cip_6digits_cip2016 <- readr::read_csv(
 )
 
 ## ------------------------------------ Clean Up --------------------------------------------------
-# Current workflow:
-#  - Write key tables back to sql server.  These are tables needed for downstream work, or tables
-# that might be needed for later reference outside of this analysis.
-#  - Close DB connections
-#  - Remove all objects at the end of each script.
+# Workflow:
+#  - Write the key tables back to SQL Server (those needed by 06 or for later
+#    reference). Each is written into the analyst's schema with an "_r" suffix.
+#  - (The infoware CIP lookups and intermediate tables like
+#    tbl_credential_highest_rank / credential_non_dup are intentionally NOT
+#    persisted; they remain in the in-memory environment for the next step.)
+#  - Note: the historical comment about removing all objects no longer applies -
+#    objects are kept in memory and gc() only releases freed memory.
 ## ------------------------------------------------------------------------------------------------
 
 tables_to_keep <- c(
-  # keep all tables that were read into this script via read_csv
+  # all the lookups read from CSV above, plus the derived input and the two
+  # (empty) rollover distribution tables.
   "t_cohort_program_distributions_y2_to_y12",
   "t_appr_y2_to_y10",
   "tbl_age_groups_near_completers",
@@ -297,15 +388,20 @@ tables_to_keep <- c(
   "cohort_program_distributions_static"
 )
 
+# Write one named global object to "<schema>"."<table_name>_r", overwriting any
+# existing copy. Called over tables_to_keep with walk().
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    base::get(table_name, envir = .GlobalEnv), # fetch the object by name
     overwrite = TRUE
   )
 }
 
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+
+# NOTE: this script does not dbDisconnect(con) - the connection is intentionally
+# left open for the paired analysis step (06) that runs next in the pipeline.
 gc()

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,6 +17,7 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
+
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,7 @@
 library(tidyverse)
 library(RODBC)
 library(DBI)
+library(futile.logger)
 
 # ---- Connect to SQL Server and read StatCan Tables ----
 lan <- config::get("lan")
@@ -103,7 +104,10 @@ time_execution <- function(file_path) {
       )
       flog.error(traceback(), name = "file_logger") # Log the traceback for details
 
-      stop()
+      # Re-raise the original condition so callers see the real error message,
+      # class, and call site. A bare stop() would throw an empty error and
+      # discard everything we just logged about.
+      stop(e)
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,11 +88,11 @@ time_execution <- function(file_path) {
       print(error_message)
       print("###############################################")
       # Log the error message if execution fails
-      flog.error(
+      futile.logger::flog.error(
         paste("Error in file:", file_path, "-", e$message),
         name = "file_logger"
       )
-      flog.error(traceback(), name = "file_logger") # Log the traceback for details
+      futile.logger::flog.error(paste(capture.output(traceback()), collapse = "\n"), name = "file_logger")
 
       # Re-raise the original condition so callers see the real error message,
       # class, and call site. A bare stop() would throw an empty error and

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,6 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
-
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,6 +17,7 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
+
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,7 +6,6 @@
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
 
-
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,13 +1,14 @@
-# Define the time_execution function to track execution time and handle errors
-# source(file_path, echo = TRUE, keep.source = TRUE):
-#
-#   echo = TRUE: Prints each line of code as it is executed, helping to trace progress and identify errors.
-# keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
-# local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
-# traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
-
-# By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
-# To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
+# Copyright 2026 Province of British Columbia
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
 
 library(tidyverse)
 library(RODBC)
@@ -18,6 +19,30 @@ library(futile.logger)
 # Create connections in the calling script and pass them into helper functions.
 
 
+# time_execution: source an R script with timing, console + file logging, and
+# fail-fast error handling. Wraps each pipeline module so every step is timed,
+# logged, and aborts the run on the first failure. Intended use:
+#
+#   time_execution("R/01a-enrolment-preprocessing.R")
+#
+# The script is sourced with local = globalenv(), so objects it creates (data
+# frames, the DB connection, the file_logger, etc.) persist in the global
+# environment for the modules that follow. echo = TRUE echoes each line to the
+# console, and keep.source = TRUE keeps source references so traceback() can
+# point at the offending line on failure.
+#
+# Output goes to both the console (print()) and the "file_logger" appender
+# (futile.logger::flog.*). On error the handler logs the message and traceback,
+# then re-raises the original condition via stop(e) — callers see the real
+# error, not a blank one.
+#
+# Args:
+#   file_path: path to the R script to execute.
+#
+# Side effects: sources `file_path` into .GlobalEnv; writes START/COMPLETE (with
+# elapsed seconds) or error + traceback to console and "file_logger".
+# Returns: the result of source() (invisible NULL on success); on error the
+# original condition is re-raised.
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,16 +5,7 @@
 # keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
-# Log File Connection: log_conn <- file(log_file, open = "a") opens a connection in append mode to add logs to execution_log.txt.
-#
-# Logging Each Step:
-#
-#   Start: Logs a start message with a timestamp before running the script.
-# Completion: Logs the completion message with the elapsed time after successful execution.
-# Error: Logs the error message and writes the traceback() to the log file for debugging.
-# finally Block: Ensures the log file connection is closed after execution, even if an error occurs.
-#
-# Custom Log File: You can specify a custom log file by passing a different path to log_file.
+
 
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
@@ -26,6 +17,7 @@ library(futile.logger)
 
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
+
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,7 +20,7 @@ library(futile.logger)
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
-  flog.info(paste("Starting:", file_path), name = "file_logger")
+  futile.logger::flog.info(paste("Starting:", file_path), name = "file_logger")
 
   # Log a start message with a timestamp
   print(

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,18 +24,8 @@ library(RODBC)
 library(DBI)
 library(futile.logger)
 
-# ---- Connect to SQL Server and read StatCan Tables ----
-lan <- config::get("lan")
-my_schema <- config::get("myschema")
-db_config <- config::get("decimal")
-con <- dbConnect(
-  odbc::odbc(),
-  Driver = db_config$driver,
-  Server = db_config$server,
-  Database = db_config$database,
-  Trusted_Connection = "True"
-)
-
+# Keep utils side-effect free: do not read config or open DB connections on source.
+# Create connections in the calling script and pass them into helper functions.
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,30 +1,45 @@
-
 # Define the time_execution function to track execution time and handle errors
 # source(file_path, echo = TRUE, keep.source = TRUE):
-#   
+#
 #   echo = TRUE: Prints each line of code as it is executed, helping to trace progress and identify errors.
 # keep.source = TRUE: Retains source references to each line, which can improve the accuracy of the traceback.
 # local = TRUE: Executes in a local environment, preventing side effects on the global environment (optional but useful for modularization).
 # traceback(): After an error, traceback() provides a stack trace that shows the line numbers and function calls leading up to the error, making it easier to identify the specific line in the sourced file that caused the issue.
 # Log File Connection: log_conn <- file(log_file, open = "a") opens a connection in append mode to add logs to execution_log.txt.
-# 
+#
 # Logging Each Step:
-#   
+#
 #   Start: Logs a start message with a timestamp before running the script.
 # Completion: Logs the completion message with the elapsed time after successful execution.
 # Error: Logs the error message and writes the traceback() to the log file for debugging.
 # finally Block: Ensures the log file connection is closed after execution, even if an error occurs.
-# 
+#
 # Custom Log File: You can specify a custom log file by passing a different path to log_file.
 
 # By default, source() runs the code in a new environment, so variables defined in the global environment (like log_file) are not accessible within that sourced script unless explicitly passed or the globalenv is specified.
 # To make all global variables accessible within each source() call, set local = globalenv(). This allows the sourced file to inherit the global environment variables, including log_file and file_logger:
 
+library(tidyverse)
+library(RODBC)
+library(DBI)
+
+# ---- Connect to SQL Server and read StatCan Tables ----
+lan <- config::get("lan")
+my_schema <- config::get("myschema")
+db_config <- config::get("decimal")
+con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
+
 
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")
-  
+
   # Log a start message with a timestamp
   print(
     "#################################################################################################"
@@ -33,45 +48,104 @@ time_execution <- function(file_path) {
   print(
     "#################################################################################################"
   )
-  
+
   start_time <- Sys.time()
-  
-  tryCatch({
-    # Source the file with echo, and log each line to the log file
-    source(
-      file_path,
-      echo = TRUE,
-      keep.source = TRUE,
-      # local = TRUE
-      local = globalenv()) # Make global variables accessible in source
-    
-    # Log the completion message with elapsed time
-    end_time <- Sys.time()
-    elapsed <- end_time - start_time
-    print("########################################################################")
-    print(paste(
-      Sys.time(),
-      "Completed:",
-      file_path,
-      "in",
-      round(elapsed, 2),
-      "seconds"
-    ))
-    print("########################################################################")
-    flog.info(paste("Completed:", file_path, "in", round(elapsed, 2), "seconds"),
-              name = "file_logger")
-    
-  }, error = function(e) {
-    # Log the error message if execution fails
-    error_message <- paste(Sys.time(), "Error in file:", file_path, " - ", e$message)
-    print("###############################################")
-    print(error_message)
-    print("###############################################")
-    # Log the error message if execution fails
-    flog.error(paste("Error in file:", file_path, "-", e$message), name = "file_logger")
-    flog.error(traceback(), name = "file_logger")  # Log the traceback for details
-    
-    stop()
-  }
- )
+
+  tryCatch(
+    {
+      # Source the file with echo, and log each line to the log file
+      source(
+        file_path,
+        echo = TRUE,
+        keep.source = TRUE,
+        # local = TRUE
+        local = globalenv()
+      ) # Make global variables accessible in source
+
+      # Log the completion message with elapsed time
+      end_time <- Sys.time()
+      elapsed <- end_time - start_time
+      print(
+        "########################################################################"
+      )
+      print(paste(
+        Sys.time(),
+        "Completed:",
+        file_path,
+        "in",
+        round(elapsed, 2),
+        "seconds"
+      ))
+      print(
+        "########################################################################"
+      )
+      flog.info(
+        paste("Completed:", file_path, "in", round(elapsed, 2), "seconds"),
+        name = "file_logger"
+      )
+    },
+    error = function(e) {
+      # Log the error message if execution fails
+      error_message <- paste(
+        Sys.time(),
+        "Error in file:",
+        file_path,
+        " - ",
+        e$message
+      )
+      print("###############################################")
+      print(error_message)
+      print("###############################################")
+      # Log the error message if execution fails
+      flog.error(
+        paste("Error in file:", file_path, "-", e$message),
+        name = "file_logger"
+      )
+      flog.error(traceback(), name = "file_logger") # Log the traceback for details
+
+      stop()
+    }
+  )
+}
+
+# read_table_from_db: counterpart to write_table_to_db.
+#
+# Reads a schema-qualified table written by the pipeline (suffixed "_r") back
+# into the global environment, bound to `table_name`. Intended to be called
+# over a vector of names with purrr::walk, e.g.:
+#
+#   walk(required_tables, read_table_from_db, schema = my_schema, con = con)
+#
+# Args:
+#   table_name: base table name (without the "_r" suffix), used both to build
+#               the DB name and as the global variable to assign.
+#   schema:     SQL schema, typically config::get("myschema") — never hardcoded.
+#   con:        an open DBI connection (Trusted_Connection = "True").
+#
+# Side effect: assigns the table into .GlobalEnv[[table_name]].
+# Returns: `table_name` invisibly.
+read_table_from_db <- function(table_name, schema, con) {
+  db_name <- glue::glue("{table_name}_r")
+  .GlobalEnv[[table_name]] <- dbReadTable(
+    con,
+    SQL(glue::glue('"{schema}"."{db_name}"'))
+  )
+  invisible(table_name)
+}
+
+
+# lower_col_names: standardise a table's column names to lower case.
+#
+# Counterpart to the rename_with(toupper) calls used elsewhere in the pipeline.
+# Returns the data frame with all column names lower-cased; the data itself is
+# unchanged.
+#
+# Args:
+#   table_name: a name of a data frame / tibble.
+#
+# Returns: `df` with lower-case column names.
+lower_col_names_global <- function(table_name) {
+  .GlobalEnv[[table_name]] <- .GlobalEnv[[table_name]] |>
+    rename_with(tolower)
+  invisible(table_name)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,6 @@ library(futile.logger)
 # Keep utils side-effect free: do not read config or open DB connections on source.
 # Create connections in the calling script and pass them into helper functions.
 
-
 time_execution <- function(file_path) {
   # Log a start message with a timestamp
   flog.info(paste("Starting:", file_path), name = "file_logger")


### PR DESCRIPTION
One of 7 sub-PRs replacing #<old-PR4>.

Substantive loader changes (not just renames):

- R/load-program-projections.R — propagate RESEARCH_UNIVERSITY and OUTCOMES_CRED
  from credential_non_dup_r to support downstream joins.
- R/load-occupation-projections.R — loader logic aligned to _r sources.
- R/load-infoware-lookups.R (NEW) — loads the INFOWARE CIP taxonomy and outcomes
  reference data into SQL Server.
- R/load-custom-stats-can.R — StatCan custom loads.

Depends on: #<PR3> (utils). Independent of the other PR4 sub-PRs.
