### PR TITLE
split/4f-modules-01-02: feat(modules 01-02): SQL-to-R refactor of preprocessing and program matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp/
 
 docs/agents/
 split-pr-89.sh
+split-pr4.sh

--- a/R/01a-enrolment-preprocessing.R
+++ b/R/01a-enrolment-preprocessing.R
@@ -14,6 +14,20 @@
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 01a-enrolment-preprocessing.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -27,6 +41,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 ## --------------------------------------Required Tables------------------------------------------
 # currently repurposing data from 2023 run.  When running next update change this code to pull
@@ -62,6 +77,9 @@ stp_enrolment <- dbGetQuery(
   FROM [{my_schema}].[STP_Enrolment];"
   )
 )
+log_info(glue::glue(
+  "Loaded STP_Enrolment: {nrow(stp_enrolment)} rows, {ncol(stp_enrolment)} columns"
+))
 
 
 ## --------------------------------------Initial Data Checks--------------------------------------
@@ -69,15 +87,19 @@ stp_enrolment <- dbGetQuery(
 ##   qry00a to qry00d
 ## -----------------------------------------------------------------------------------------------
 
-stp_enrolment |>
+invalid_pen_count <- stp_enrolment |>
   filter(
     ENCRYPTED_TRUE_PEN %in%
       c("", " ", "(Unspecified)") |
       is.na(ENCRYPTED_TRUE_PEN)
   ) |>
   nrow()
+log_info(glue::glue(
+  "Rows with invalid/missing ENCRYPTED_TRUE_PEN: {invalid_pen_count}"
+))
 
-stp_enrolment |> distinct(ENCRYPTED_TRUE_PEN) |> count()
+distinct_pen_count <- stp_enrolment |> distinct(ENCRYPTED_TRUE_PEN) |> nrow()
+log_info(glue::glue("Distinct ENCRYPTED_TRUE_PEN values: {distinct_pen_count}"))
 
 # Untoggle when running new data and/or add a conditional to test for the presence of the ID field.
 # stp_enrolment <- stp_enrolment |> mutate(ID = row_number())
@@ -160,6 +182,10 @@ stp_enrolment_record_type_base <- stp_enrolment |>
   ) |>
   mutate(CIP2 = str_sub(PSI_CIP_CODE, 1, 2))
 
+log_info(glue::glue(
+  "Created stp_enrolment_record_type_base: {nrow(stp_enrolment_record_type_base)} rows"
+))
+
 
 stp_enrolment_record_type <- stp_enrolment_record_type_base |>
   mutate(
@@ -198,6 +224,12 @@ stp_enrolment_record_type <- stp_enrolment_record_type_base |>
     )
   )
 
+log_info("First RecordStatus pass complete. Counts by status:")
+log_info(paste(
+  capture.output(print(stp_enrolment_record_type |> count(RecordStatus))),
+  collapse = "\n"
+))
+
 # Notes: in the SQL queries from 2019 and earlier, some manual investigation was done to
 # find more skills based courses that were inadvertently excluded (s.b. RecordStatus 0) in the above work.
 # The manual investigation result were recorded column "Keep".  We did not do this manual work so I'm
@@ -219,6 +251,10 @@ tmp_tbl_skills_based_courses <- stp_enrolment_record_type_base |>
     PSI_CONTINUING_EDUCATION_COURSE_ONLY
   ) |>
   mutate(KEEP = as.character(NA)) # Initializing KEEP as NULL/NA
+
+log_info(glue::glue(
+  "Created tmp_tbl_skills_based_courses: {nrow(tmp_tbl_skills_based_courses)} distinct skill-based course combinations"
+))
 
 # this needs to be here
 stp_enrolment_record_type <- stp_enrolment_record_type |>
@@ -254,6 +290,10 @@ ids_to_flag_6 <- stp_enrolment_record_type_base |>
   ) |>
   pull(ID)
 
+log_info(glue::glue(
+  "IDs flagged as skills-based (RecordStatus 6) from semi-join: {length(ids_to_flag_6)}"
+))
+
 
 stp_enrolment_record_type <- stp_enrolment_record_type |>
   mutate(
@@ -276,6 +316,12 @@ stp_enrolment_record_type <- stp_enrolment_record_type |>
 stp_enrolment_record_type <- stp_enrolment_record_type |>
   select(ID, RecordStatus)
 
+log_info("Final RecordStatus assignment complete. Counts by status:")
+log_info(paste(
+  capture.output(print(stp_enrolment_record_type |> count(RecordStatus))),
+  collapse = "\n"
+))
+
 
 ## --------------------------------------- Create Valid Enrolment Table ---------------------------
 ## Creates a table of Record Status = 0 only (Valid Enrolment)
@@ -295,6 +341,10 @@ stp_enrolment_valid <- stp_enrolment |>
   inner_join(stp_enrolment_record_type, by = join_by(ID)) |>
   filter(RecordStatus == 0) |>
   select(-RecordStatus)
+
+log_info(glue::glue(
+  "Created stp_enrolment_valid (RecordStatus == 0): {nrow(stp_enrolment_valid)} rows"
+))
 
 
 ## ------------------------------------- Min Enrolment --------------------------------------------
@@ -332,6 +382,10 @@ invalid_pen_data <- stp_enrolment_valid |>
   mutate(is_min_enrol_seq_combo = row_number() == 1) |>
   ungroup()
 
+log_info(glue::glue(
+  "Valid PEN records: {nrow(valid_pen_data)}, Invalid PEN records: {nrow(invalid_pen_data)}"
+))
+
 # Combine - this should be the same as the old stp_enrolment_record_type
 stp_enrolment_valid_final <- bind_rows(valid_pen_data, invalid_pen_data) |>
   mutate(across(starts_with("is_"), ~ replace_na(.x, FALSE))) |>
@@ -346,6 +400,15 @@ stp_enrolment_record_type <- stp_enrolment_record_type |>
   mutate(across(starts_with("is_"), ~ replace_na(.x, 0)))
 
 stp_enrolment_record_type |> count(RecordStatus, is_min_enrol, is_first_enrol)
+
+log_info("Min enrolment summary (RecordStatus, is_min_enrol, is_first_enrol):")
+log_info(paste(
+  capture.output(print(
+    stp_enrolment_record_type |>
+      count(RecordStatus, is_min_enrol, is_first_enrol)
+  )),
+  collapse = "\n"
+))
 
 
 ## ------------------------------------- Clean Birthdates -----------------------------------------
@@ -383,6 +446,10 @@ birthdate_cleaning_summary <- stp_enrolment |>
   ) |>
   ungroup()
 
+log_info(glue::glue(
+  "Birthdate cleaning summary: {nrow(birthdate_cleaning_summary)} students with birthdate records"
+))
+
 #qry09 to qry11
 birthdate_update <- birthdate_cleaning_summary |>
   mutate(
@@ -411,6 +478,9 @@ stp_enrolment <- stp_enrolment |>
   ) |>
   mutate(psi_birthdate_cleaned = coalesce(psi_birthdate_cleaned, PSI_BIRTHDATE))
 # Keeping as lower case to match the SQL versions, jfn.
+log_info(glue::glue(
+  "Birthdate cleaning complete. Students with cleaned birthdate: {sum(!is.na(stp_enrolment$psi_birthdate_cleaned))} / {nrow(stp_enrolment)}"
+))
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -431,13 +501,22 @@ write_table_to_db <- function(table_name, schema, con) {
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    get(table_name, envir = .GlobalEnv),
+    base::get(table_name, envir = .GlobalEnv),
     overwrite = TRUE
   )
+  log_info(glue::glue(
+    "Wrote table '{schema}.{db_name}' ({nrow(base::get(table_name, envir = .GlobalEnv))} rows) to SQL Server"
+  ))
 }
 
+log_info(glue::glue(
+  "Writing {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse = ', ')}"
+))
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
 
-rm(list = ls())
+log_info("==== 01a-enrolment-preprocessing.R COMPLETE ====")
+
+# rm(list = ls())

--- a/R/01b-credential-preprocessing.R
+++ b/R/01b-credential-preprocessing.R
@@ -14,6 +14,20 @@
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 01b-credential-preprocessing.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -27,6 +41,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 ## --------------------------------------Required Tables------------------------------------------
 # currently repurposing data from 2023 run.  When running next update, change this code to pull
@@ -55,11 +70,17 @@ stp_credential <- dbGetQuery(
   FROM "{my_schema}"."STP_Credential"'
   )
 )
+log_info(glue::glue(
+  "Loaded STP_Credential: {nrow(stp_credential)} rows, {ncol(stp_credential)} columns"
+))
 
 stp_enrolment_record_type <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_enrolment_record_type_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_enrolment_record_type_r: {nrow(stp_enrolment_record_type)} rows"
+))
 
 stp_enrolment <- dbGetQuery(
   con,
@@ -74,20 +95,25 @@ stp_enrolment <- dbGetQuery(
   FROM "{my_schema}"."stp_enrolment_r"'
   )
 )
+log_info(glue::glue("Loaded stp_enrolment_r: {nrow(stp_enrolment)} rows"))
 
 ## --------------------------------------Initial Data Checks--------------------------------------
 ## reference: source("./sql/01-credential-preprocessing/01-credential-preprocessing-sql.R")
 ## -----------------------------------------------------------------------------------------------
 
-stp_credential |>
+invalid_pen_count <- stp_credential |>
   filter(
     ENCRYPTED_TRUE_PEN %in%
       c("", " ", "(Unspecified)") |
       is.na(ENCRYPTED_TRUE_PEN)
   ) |>
   nrow()
+log_info(glue::glue(
+  "Rows with invalid/missing ENCRYPTED_TRUE_PEN: {invalid_pen_count}"
+))
 
-stp_credential |> distinct(ENCRYPTED_TRUE_PEN) |> count()
+distinct_pen_count <- stp_credential |> distinct(ENCRYPTED_TRUE_PEN) |> nrow()
+log_info(glue::glue("Distinct ENCRYPTED_TRUE_PEN values: {distinct_pen_count}"))
 
 # Untoggle when running new data and/or add a conditional to test for the presence of the ID field.
 # stp_credential <- stp_credential |>
@@ -168,6 +194,10 @@ enrol_skills_lookup <- stp_enrolment |>
   ) |>
   mutate(is_skills_match = TRUE)
 
+log_info(glue::glue(
+  "Created enrol_skills_lookup: {nrow(enrol_skills_lookup)} distinct skill-based course combinations"
+))
+
 stp_credential_record_type <- stp_credential |>
   mutate(CIP2 = substr(PSI_CREDENTIAL_CIP, 1, 2)) |>
   left_join(
@@ -209,6 +239,12 @@ stp_credential_record_type <- stp_credential |>
   ) |>
   select(ID, ENCRYPTED_TRUE_PEN, RecordStatus)
 
+log_info("Credential RecordStatus assignment complete. Counts by status:")
+log_info(paste(
+  capture.output(print(stp_credential_record_type |> count(RecordStatus))),
+  collapse = "\n"
+))
+
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -228,13 +264,22 @@ write_table_to_db <- function(table_name, schema, con) {
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    get(table_name, envir = .GlobalEnv),
+    base::get(table_name, envir = .GlobalEnv),
     overwrite = TRUE
   )
+  log_info(glue::glue(
+    "Wrote table '{schema}.{db_name}' ({nrow(base::get(table_name, envir = .GlobalEnv))} rows) to SQL Server"
+  ))
 }
 
+log_info(glue::glue(
+  "Writing {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse = ', ')}"
+))
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
 
-rm(list = ls())
+log_info("==== 01b-credential-preprocessing.R COMPLETE ====")
+
+# rm(list = ls())

--- a/R/01c-credential-analysis.R
+++ b/R/01c-credential-analysis.R
@@ -14,6 +14,20 @@
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 01c-credential-analysis.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -27,6 +41,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -34,18 +49,30 @@ stp_enrolment <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_enrolment_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_enrolment_r: {nrow(stp_enrolment)} rows, {ncol(stp_enrolment)} columns"
+))
 stp_credential <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_credential_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_credential_r: {nrow(stp_credential)} rows, {ncol(stp_credential)} columns"
+))
 stp_credential_record_type <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_credential_record_type_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_credential_record_type_r: {nrow(stp_credential_record_type)} rows"
+))
 stp_enrolment_valid <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_enrolment_valid_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_enrolment_valid_r: {nrow(stp_enrolment_valid)} rows"
+))
 
 # Define lookup tables
 outcome_credential <- tibble(
@@ -122,7 +149,20 @@ age_group_lookup <- data.frame(
 )
 
 ## ---------------------------------------Credential View-----------------------------------------
-# Create a view with STP_Credential data with record_type == 0 and a non-blank award date
+# WHAT: Create the working `credential` table from stp_credential, keeping only records
+#       with RecordStatus == 0 (valid credentials) and a non-blank CREDENTIAL_AWARD_DATE.
+# WHY:  This is the foundational credential table for the entire supply model. It filters
+#       out invalid records (missing student numbers, developmental, skills-based, etc.)
+#       and credentials without an award date so that only genuine, completed credentials
+#       enter the modelling pipeline.
+#       Downstream, this table is used in two key ways:
+#       1. In this script (01c): it is enriched with birthdate, gender, age, and CIP data,
+#          then deduplicated to create `credential_non_dup` (the main supply modelling table).
+#       2. In 01d-enrolment-analysis.R: it is read back from SQL to backfill gender data
+#          into the enrolment analysis.
+# HOW:  Inner join stp_credential with stp_credential_record_type on ID, filter for
+#       RecordStatus == 0 and valid award dates, then select the columns needed for
+#       downstream processing.
 # reference: source("./sql/01-credential-analysis/"credential-sup-vars-from-enrolment.R")
 # qry00
 ## -----------------------------------------------------------------------------------------------
@@ -151,8 +191,23 @@ credential <- stp_credential |>
     RecordStatus
   )
 
+log_info(glue::glue(
+  "Created credential view (RecordStatus == 0, non-blank award date): {nrow(credential)} rows"
+))
 
-# ----------------------------- Make Credential Sup Vars Enrolment Table -------------------------
+## ----------------------- Make Credential Sup Vars Enrolment Table ------------------------------
+# WHAT: Build `credential_supvars_enrolment`, a crosswalk table linking each valid credential
+#       record to its most recent enrolment record. The join is done in two passes:
+#       1. By ENCRYPTED_TRUE_PEN (valid PENs only) -> cred_supvars_enrol_epen
+#       2. By PSI_CODE + PSI_STUDENT_NUMBER (for records with invalid/missing PENs) -> cred_supvars_enrol_no_pen
+#       The two passes are combined with rbind + distinct.
+# WHY:  Enrolment records contain supply-relevant variables that credential records lack:
+#       psi_birthdate_cleaned, PSI_VISA_STATUS, PSI_GENDER, LAST_SEEN_BIRTHDATE, etc.
+#       This crosswalk allows those enrolment-side variables to be joined onto the
+#       credential_supvars table for birthdate cleaning (section 04), gender backfill,
+#       and VISA status mapping.
+#       The many-to-many relationship is expected: a student may have multiple enrolment
+#       records and multiple credentials across the matching period.
 # reference: source("./sql/01-credential-analysis/"credential-sup-vars-from-enrolment.R")
 # qry01 to qry12
 ## -----------------------------------------------------------------------------------------------
@@ -193,6 +248,10 @@ cred_supvars_enrol_epen <- latest_enrolment_epen |>
     PSI_ENROLMENT_SEQUENCE
   ) |>
   distinct()
+
+log_info(glue::glue(
+  "cred_supvars_enrol_epen (PEN match): {nrow(cred_supvars_enrol_epen)} rows"
+))
 
 
 # Match via PSI_CODE/Student Number to recover records missed by PEN join.
@@ -235,13 +294,37 @@ cred_supvars_enrol_no_pen <- latest_enrolment_no_epen |>
   ) |>
   distinct()
 
+log_info(glue::glue(
+  "cred_supvars_enrol_no_pen (Student Number/PSI match): {nrow(cred_supvars_enrol_no_pen)} rows"
+))
+
 credential_supvars_enrolment <- rbind(
   cred_supvars_enrol_epen,
   cred_supvars_enrol_no_pen
 ) |>
   distinct()
 
+log_info(glue::glue(
+  "Combined credential_supvars_enrolment: {nrow(credential_supvars_enrolment)} rows"
+))
+
 # ----------------------------- Make Credential Sup Vars Table -----------------------------------
+# WHAT: Create `credential_supvars`, a credential-level table that mirrors `credential`
+#       but adds CREDENTIAL_AWARD_DATE_D (date-typed award date) and serves as the base
+#       for enrichment with birthdate, gender, and VISA status in subsequent sections.
+# WHY:  `credential_supvars` ("supply variables") is the enrichment staging table. It
+#       starts as a copy of credential with a date-typed award date, then progressively
+#       accumulates:
+#       - psi_birthdate_cleaned / psi_birthdate_cleaned_D (section 04)
+#       - psi_gender_cleaned (section 03, via gender-cleaning.r)
+#       - LAST_SEEN_BIRTHDATE (section 04, fallback for missing birthdates)
+#       - PSI_VISA_STATUS (VISA Status section, via visa_map)
+#       Once enriched, these variables are joined back into the main `credential` table
+#       (rebuilt in section 04) and carried into `credential_non_dup` for supply modelling.
+# HOW:  Select credential columns, cast CREDENTIAL_AWARD_DATE to Date type.
+#       Separately, credential_supvars_enrolment links enrolment records to credentials
+#       (via PEN or PSI_CODE/Student Number) and brings in enrolment-side variables
+#       (birthdates, VISA status, gender) that don't exist on the credential side.
 # reference: source("./sql/01-credential-analysis/"credential-sup-vars-from-enrolment.R")
 # qry0?
 ## -----------------------------------------------------------------------------------------------
@@ -298,7 +381,21 @@ credential_supvars_enrolment <- credential_supvars_enrolment |>
 
 
 ## ----------------------------02 Developmental Records-------------------------------------------
-# add a drop credential flag
+# WHAT: Flag credentials whose category is not meaningful for supply modelling so they
+#       can be excluded from the final credential table.
+# WHY:  The following PSI_CREDENTIAL_CATEGORY values represent credentials that do not
+#       correspond to a completed, recognized post-secondary qualification:
+#       - "Developmental Credential": Preparatory or upgrading coursework, not a
+#         standalone credential counted in supply.
+#       - "Other": Unclassified credentials that don't fit any standard category.
+#       - "None": No credential category was assigned by the institution.
+#       - "Short Certificate": Credentials below the threshold for supply modelling
+#         (e.g., brief non-credit courses).
+#       These records are kept in stp_credential_record_type for audit purposes but
+#       are filtered out later (line ~488) when the final `credential` table is rebuilt
+#       by requiring is.na(DropCredCategory).
+# HOW:  Left join a "Yes" flag onto stp_credential_record_type for any ID whose
+#       credential category matches the exclusion list.
 ## -----------------------------------------------------------------------------------------------
 stp_credential_record_type <-
   stp_credential_record_type |>
@@ -318,8 +415,23 @@ stp_credential_record_type <-
     by = "ID"
   )
 
+log_info(glue::glue(
+  "02 Developmental Records: DropCredCategory flagged on {sum(!is.na(stp_credential_record_type$DropCredCategory))} records"
+))
+
 
 ## ---------------------------------------- 03 Miscellaneous -------------------------------------
+# WHAT: Flag credentials awarded on or after September 1 of the current model year
+#       so they can be excluded from the final credential table.
+# WHY:  Credentials awarded in the partial/incomplete year (e.g., Sep 2023 onward for a
+#       2023/2024 model run) represent an incomplete cohort. The full academic year has
+#       not finished, so the count would under-represent the eventual total. These
+#       records are kept for audit but filtered out later (line ~489) when the final
+#       `credential` table is rebuilt by requiring is.na(DropPartialYear).
+#       Note: The cutoff date ("2023-09-01") must be updated for each new model cycle.
+# HOW:  Filter credential_supvars for records with CREDENTIAL_AWARD_DATE >= cutoff,
+#       tag them with DropPartialYear = "Yes", and right_join back to
+#       stp_credential_record_type so all records are preserved.
 ## -----------------------------------------------------------------------------------------------
 stp_credential_record_type <-
   credential_supvars |>
@@ -327,6 +439,10 @@ stp_credential_record_type <-
   select(ID) |>
   mutate(DropPartialYear = "Yes") |>
   right_join(stp_credential_record_type, by = "ID")
+
+log_info(glue::glue(
+  "03 Miscellaneous: DropPartialYear flagged on {sum(!is.na(stp_credential_record_type$DropPartialYear))} records"
+))
 
 rm(
   latest_enrolment_no_epen,
@@ -340,7 +456,9 @@ gc()
 # !! Entire section is replaced with the gender_cleaning.r script
 ## -----------------------------------------------------------------------------------------------
 
+log_info("03 Gender Cleaning: sourcing R/01c-gender-cleaning.r")
 source("R/01c-gender-cleaning.r")
+log_info("03 Gender Cleaning: complete")
 
 ## --------------------------------04 Birthdate cleaning (last seen birthdate)--------------------
 # note: check if LAST_SEEN_BIRTHDATE can be included when supvars tables are created (at the top of script)
@@ -459,8 +577,9 @@ credential <- stp_credential |>
     is.na(DropPartialYear)
   )
 
-
-## -----------------------------------05 Age and Credential---------------------------------------
+log_info(glue::glue(
+  "04 Birthdate cleaning complete. credential rebuilt: {nrow(credential)} rows after filtering RecordStatus==0, DropCredCategory, DropPartialYear"
+))
 ## -----------------------------------------------------------------------------------------------
 credential <- credential |>
   mutate(
@@ -515,8 +634,41 @@ credential <- credential |>
   ) |>
   select(-PSI_GENDER_FROM_ENROLMENT)
 
+log_info(glue::glue(
+  "05 Age and Credential: {nrow(credential)} rows. AGE_AT_GRAD range: {min(credential$AGE_AT_GRAD, na.rm=TRUE)}-{max(credential$AGE_AT_GRAD, na.rm=TRUE)}"
+))
+## -----------------------------------------------------------------------------------------------
 
-## ------------------------------------- make non dup table --------------------------------------
+## -----------------------------------05b Make Non-Dup Table--------------------------------------
+# WHAT: Deduplicate the `credential` table to create `credential_non_dup`, the primary
+#       credential-level table used for supply modelling.
+# WHY:  A student may receive the same credential (same institution, program, CIP, level,
+#       category, and award date) multiple times due to data entry duplicates or re-issuance.
+#       `credential_non_dup` keeps only one record per unique credential combination so that
+#       each completed credential is counted exactly once in the supply model.
+#
+#       This table is the central output of the credential analysis pipeline and is consumed
+#       by multiple downstream scripts:
+#       - 01e-stp-distributions.R: reads credential_non_dup_r for FINAL_CIP_CLUSTER_CODE,
+#         FINAL_CIP_CODE_4, RESEARCH_UNIVERSITY, and OUTCOMES_CRED to build aggregated
+#         credential distribution tables.
+#       - 02a-update-cred-non-dup.R: updates this table with final CIP codes from BGS/APPSO/GRAD
+#         program matching.
+#       - 02a-bgs-program-matching.R: uses credential_non_dup as the source for BGS and GRAD
+#         credential ID tables.
+#       - load-program-projections.R: reads this table for program projection loading.
+#
+#       After deduplication, the table is further enriched with:
+#       - Gender imputation (stochastic proportional fill)
+#       - Credential ranking (HIGHEST_CRED_BY_DATE, HIGHEST_CRED_BY_RANK)
+#       - Age imputation
+#       - VISA status
+#       - Delay date (CREDENTIAL_AWARD_DATE_D_DELAYED)
+#       - Research university flag and outcomes credential mapping
+# HOW:  Group by all credential-identifying fields (PEN, PSI_CODE, program code, description,
+#       CIP, level, category, award date) and keep the record with the highest ID per group.
+#       Then forward-fill gender within each student group (by PEN/Student Number/PSI Code)
+#       so the most recent gender value is applied to all that student's credentials.
 ## -----------------------------------------------------------------------------------------------
 
 credential_non_dup <- credential |>
@@ -540,8 +692,9 @@ credential_non_dup <- credential_non_dup |>
   mutate(psi_gender_cleaned = last(psi_gender_cleaned)) |>
   ungroup()
 
-
-## ----------------------------------Impute Missing Gender----------------------------------------
+log_info(glue::glue(
+  "Non-dup table created: {nrow(credential_non_dup)} rows (deduplicated from {nrow(credential)} credential rows)"
+))
 # This procedure performs proportional stochastic imputation to fill in missing gender data.
 # It calculates the existing gender distribution for each credential category and then
 # uses those ratios as weights to "flip a coin" for every empty record
@@ -575,6 +728,10 @@ credential_non_dup <- credential_non_dup |>
     )
   ) |>
   select(-genders, -weights)
+
+log_info(glue::glue(
+  "Gender imputation complete. Remaining NA genders: {sum(is.na(credential_non_dup$psi_gender_cleaned))}"
+))
 
 rm(
   credential_supvars_birthdate_clean,
@@ -648,7 +805,9 @@ credential_non_dup <- credential_non_dup |>
   ) |>
   select(-RANK)
 
-## ------------------------09 Age Gender Distributions--------------------------------------------
+log_info(glue::glue(
+  "08 Credential Ranking complete. HIGHEST_CRED_BY_DATE: {sum(credential_non_dup$HIGHEST_CRED_BY_DATE == 'Yes', na.rm=TRUE)}, HIGHEST_CRED_BY_RANK: {sum(credential_non_dup$HIGHEST_CRED_BY_RANK == 'Yes', na.rm=TRUE)}"
+))
 ## -----------------------------------------------------------------------------------------------
 age_weights <- credential_non_dup |>
   filter(
@@ -730,7 +889,9 @@ credential_non_dup <- credential_non_dup |>
   mutate(AGE_GROUP_AT_GRAD = AgeIndex) |>
   select(-AgeIndex, -LowerBound, -UpperBound)
 
-## ----------------------------------VISA Status--------------------------------------------------
+log_info(glue::glue(
+  "09 Age/Gender distributions: imputed {nrow(imputed_student_ages)} ages. Remaining NA AGE_AT_GRAD: {sum(is.na(credential_non_dup$AGE_AT_GRAD))}"
+))
 ## -----------------------------------------------------------------------------------------------
 cols_specific <- c(
   "ENCRYPTED_TRUE_PEN",
@@ -785,8 +946,35 @@ credential_non_dup <- credential_non_dup |>
     by = "ID"
   )
 
+log_info(glue::glue(
+  "VISA Status mapping complete. VISA mapped on {sum(!is.na(credential_non_dup$PSI_VISA_STATUS))} / {nrow(credential_non_dup)} records"
+))
+
 
 ## -----------------------13 Delay Date and Highest rank------------------------------------------
+# WHAT: Identify each student's highest-ranked credential and calculate a "delayed" award
+#       date/year that accounts for subsequent credentials earned after the highest one.
+# WHY:  In supply modelling, each student should be counted once, represented by their
+#       highest credential. However, some students earn a lower-ranked credential first
+#       and a higher-ranked one later. The "delay effect" captures the time gap between
+#       the highest credential and any later credential within a temporal threshold,
+#       so that the award year used for distribution counts reflects when the student
+#       effectively completed their highest qualification path.
+#
+#       `tbl_credential_highest_rank` contains only the single highest-ranked credential
+#       per student (HIGHEST_CRED_BY_RANK == "Yes"), enriched with:
+#       - CREDENTIAL_AWARD_DATE_D_DELAYED: the later award date if a delay effect exists,
+#         otherwise the original award date.
+#       - PSI_AWARD_SCHOOL_YEAR_DELAYED: the corresponding school year.
+#
+#       This table is consumed by:
+#       - 01e-stp-distributions.R: reads tbl_credential_highest_rank_r to build aggregated
+#         credential distribution tables by gender, age group, CIP, and school year.
+#       - load-program-projections.R: reads this table for program projection loading.
+# HOW:  Filter credential_non_dup for HIGHEST_CRED_BY_RANK == "Yes", then self-join on
+#       CONCATENATED_ID to find later credentials. Apply temporal thresholds per credential
+#       category (e.g., Bachelors = unlimited, Diploma <= 30 months) to filter valid delays.
+#       Coalesce delayed dates back onto the highest-rank table.
 ## -----------------------------------------------------------------------------------------------
 credential_non_dup <- credential_non_dup |>
   mutate(
@@ -799,6 +987,10 @@ credential_non_dup <- credential_non_dup |>
 
 tbl_credential_highest_rank <- credential_non_dup |>
   filter(HIGHEST_CRED_BY_RANK == "Yes")
+
+log_info(glue::glue(
+  "13 Delay Date: tbl_credential_highest_rank: {nrow(tbl_credential_highest_rank)} rows"
+))
 
 tbl_credential_delay_effect <- credential_non_dup |>
   select(
@@ -821,12 +1013,45 @@ tbl_credential_delay_effect <- credential_non_dup |>
   ) |>
   filter(LATER_AWARD_DATE > HIGHEST_AWARD_DATE)
 
+log_info(glue::glue(
+  "13 Delay Date: delay effect candidates before temporal threshold filter: {nrow(tbl_credential_delay_effect)}"
+))
+
 tbl_credential_delay_effect <- tbl_credential_delay_effect |>
   mutate(
     MONTHS_DIFF = (year(LATER_AWARD_DATE) - year(HIGHEST_AWARD_DATE)) *
       12 +
       (month(LATER_AWARD_DATE) - month(HIGHEST_AWARD_DATE)),
     # Apply credential temporal thresholds
+    #
+    # WHAT: Filter delay-effect candidates so that only "realistic" delays are kept.
+    #       A delay is realistic when the time gap between the highest credential and
+    #       a later credential falls within a category-specific maximum number of months.
+    #
+    # WHY:  When a student earns a lower-ranked credential after their highest one, it
+    #       may be a genuine continuation of the same educational path (e.g., earning a
+    #       Certificate then a Diploma within 2 years) or an unrelated credential earned
+    #       much later in life (e.g., a Certificate earned 15 years after a Bachelors).
+    #       Only the former should shift the award year used for supply distribution
+    #       counting, because it represents the effective completion of the student's
+    #       highest qualification path. The thresholds are set based on typical program
+    #       durations and are inherited from the original SQL model:
+    #
+    #       - Apprenticeship, Bachelors Degree, First Professional Degree: NO limit.
+    #         These are high-value credentials where any subsequent lower credential is
+    #         considered part of the same educational progression regardless of time gap.
+    #       - Advanced Diploma, Advanced Certificate: <= 36 months (3 years).
+    #         These programs typically take 1-2 years to complete; a 3-year window allows
+    #         for part-time study or a gap year while still being a plausible continuation.
+    #       - Diploma, Masters Degree, Graduate Diploma, Post-Degree Diploma: <= 30 months.
+    #         Masters programs are typically 1-2 years; 30 months allows for thesis
+    #         extensions or part-time completion.
+    #       - Associate Degree, Certificate, Graduate Certificate, Post-Degree Certificate:
+    #         <= 18 months (1.5 years). These are shorter programs; a tighter window ensures
+    #         only closely-related subsequent credentials are counted as delays.
+    #
+    #       Records outside these thresholds are dropped (keep = FALSE), meaning the
+    #       student's award year remains based on their highest credential's original date.
     keep = case_when(
       PSI_CREDENTIAL_CATEGORY %in%
         c(
@@ -857,6 +1082,10 @@ tbl_credential_delay_effect <- tbl_credential_delay_effect |>
     )
   ) |>
   filter(keep)
+
+log_info(glue::glue(
+  "13 Delay Date: delay effect records after temporal threshold filter: {nrow(tbl_credential_delay_effect)}"
+))
 
 tbl_credential_delay_effect <- tbl_credential_delay_effect |>
   # Isolate the latest award date per student
@@ -924,6 +1153,10 @@ credential_non_dup <- credential_non_dup |>
     by = "PSI_CREDENTIAL_CATEGORY"
   )
 
+log_info(glue::glue(
+  "14-15 Research University + Outcomes Credential complete. RESEARCH_UNIVERSITY flagged: {sum(credential_non_dup$RESEARCH_UNIVERSITY == 1, na.rm=TRUE)} records"
+))
+
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
 #  - Write key tables back to sql server.  These are tables needed for downstream work, or tables
@@ -949,15 +1182,24 @@ write_table_to_db <- function(table_name, schema, con) {
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    get(table_name, envir = .GlobalEnv),
+    base::get(table_name, envir = .GlobalEnv),
     overwrite = TRUE
   )
+  log_info(glue::glue(
+    "Wrote table '{schema}.{db_name}' ({nrow(base::get(table_name, envir = .GlobalEnv))} rows) to SQL Server"
+  ))
 }
 
+log_info(glue::glue(
+  "Writing {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse = ', ')}"
+))
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
 
-rm(list = ls())
+log_info("==== 01c-credential-analysis.R COMPLETE ====")
+
+# rm(list = ls())
 
 # ---- Break and do Program Matching ----

--- a/R/01d-enrolment-analysis.R
+++ b/R/01d-enrolment-analysis.R
@@ -13,7 +13,21 @@
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
 set.seed(123456)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 01d-enrolment-analysis.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -27,6 +41,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -35,25 +50,35 @@ age_group_lookup <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."age_group_lookup_r"'))
 )
+log_info(glue::glue("Loaded age_group_lookup_r: {nrow(age_group_lookup)} rows"))
 
 credential <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."credential_r"'))
 )
+log_info(glue::glue(
+  "Loaded credential_r: {nrow(credential)} rows, {ncol(credential)} columns"
+))
 
 stp_enrolment <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_enrolment_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_enrolment_r: {nrow(stp_enrolment)} rows, {ncol(stp_enrolment)} columns"
+))
 
 stp_enrolment_record_type <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."stp_enrolment_record_type_r"'))
 )
+log_info(glue::glue(
+  "Loaded stp_enrolment_record_type_r: {nrow(stp_enrolment_record_type)} rows"
+))
 
 ## ---------------------------------------Global Variables ---------------------------------------
 ## -----------------------------------------------------------------------------------------------
-na_vals = c("", " ", "(Unspecified)", NA)
+na_vals <- c("", " ", "(Unspecified)", NA)
 
 stp_cols <- c(
   "ID",
@@ -133,7 +158,9 @@ min_enrolment <- min_enrolment |>
   mutate(AGE_GROUP_ENROL_DATE = AgeIndex) |>
   select(-AgeIndex, -AgeGroup, -LowerBound, -UpperBound)
 
-## ----------Find gender for distinct non-null EPENs, or non-null PSI_CODE/PSI_NUMBER--------------
+log_info(glue::glue(
+  "Created min_enrolment (RecordStatus==0, is_min_enrol==1): {nrow(min_enrolment)} rows. AGE_AT_ENROL_DATE range: {min(min_enrolment$AGE_AT_ENROL_DATE, na.rm=TRUE)}-{max(min_enrolment$AGE_AT_ENROL_DATE, na.rm=TRUE)}"
+))
 # References: qry04a1 through qry04a2
 #
 # What the code does:
@@ -191,7 +218,9 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-gender_cred_epen, -gender_cred_no_epen, -gender_cred)
 
-## --------------Assign one gender/student and update MinEnrolment table ------------------------
+log_info(glue::glue(
+  "Gender backfill from credential: credential_epen={nrow(credential_epen)}, credential_no_epen={nrow(credential_no_epen)}"
+))
 # References: qry04c through qry04e2
 #
 # What the code does:
@@ -226,7 +255,9 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-FIRST_GENDER)
 
-## ---------------------------------impute gender -----------------------------------------------
+log_info(glue::glue(
+  "Historic gender forward-fill: first_gender_lookup has {nrow(first_gender_lookup)} distinct students"
+))
 # References:
 # Replicates: qry05a1 through qry06a5 and some R code from lines 101 to 170 (main)
 #
@@ -245,6 +276,10 @@ extract_no_gender_first <- min_enrolment |>
   select(ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER)
 
 total_unknowns <- nrow(extract_no_gender_first)
+
+log_info(glue::glue(
+  "Gender imputation: {total_unknowns} first-enrolment records with unknown gender"
+))
 
 # first-time valid genders (Male, Female, Gender Diverse)
 gender_weights <- min_enrolment |>
@@ -306,8 +341,11 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-PSI_GENDER_IMPUTED.pen, -PSI_GENDER_IMPUTED.nopen)
 
-## --------------------------Create Age and Gender Distrbutions----------------------------------
-# AND
+log_info(glue::glue(
+  "Gender imputation complete. Remaining NA genders: {sum(is.na(min_enrolment$PSI_GENDER))} / {nrow(min_enrolment)}"
+))
+
+
 ## ----------------------Assign age to records with missing age----------------------------------
 # Where is the SQL version: Originally sourced from branch 'main' (line 164:281)
 # Replicates: qry07a-qry08 and much R code
@@ -350,6 +388,10 @@ extract_no_age_first_enrol <- min_enrolment |>
     AGE_AT_ENROL_DATE_first = AGE_AT_ENROL_DATE
   )
 
+log_info(glue::glue(
+  "Age extraction: {nrow(extract_no_age)} records with missing AGE_AT_ENROL_DATE, {nrow(extract_no_age_first_enrol)} are first enrolments"
+))
+
 # function to impute age by gender
 # assumes that wt contains a p for every age
 impute_age_by_gender <- function(df, gender_name, wt) {
@@ -389,6 +431,10 @@ extract_no_age_first_enrol <- extract_no_age_first_enrol |>
   imap(~ impute_age_by_gender(.x, .y, age_weights)) |>
   list_rbind()
 
+log_info(glue::glue(
+  "Age imputation: imputed ages for {nrow(extract_no_age_first_enrol)} first-enrolment records"
+))
+
 # assign ages to all first enrolment records that are missing ages
 extract_no_age <- extract_no_age |>
   select(-AGE_AT_ENROL_DATE) |>
@@ -425,7 +471,9 @@ extract_no_age <- extract_no_age |>
   ) |>
   select(-AGE_AT_ENROL_DATE_to_update)
 
-# ---- start manual edits ----
+log_info(glue::glue(
+  "Age forward-fill complete. extract_no_age now has {sum(is.na(extract_no_age$AGE_AT_ENROL_DATE))} remaining NAs"
+))
 # BA Notes: Some manual updates were made here to remaining missing ages.
 # I haven't done the manual fixes as we're getting away from manual work
 # ---- end manual edits  ----
@@ -451,7 +499,9 @@ min_enrolment <- min_enrolment |>
   ) |>
   select(-AgeIndex, -LowerBound, -UpperBound)
 
-## ------------------------------------ Clean Up --------------------------------------------------
+log_info(glue::glue(
+  "Age update applied to min_enrolment. Remaining NA AGE_AT_ENROL_DATE: {sum(is.na(min_enrolment$AGE_AT_ENROL_DATE))} / {nrow(min_enrolment)}"
+))
 # Current workflow:
 #  - Write key tables back to sql server.  These are tables needed for downstream work, or tables
 # that might be needed for later reference outside of this analysis.
@@ -471,10 +521,19 @@ write_table_to_db <- function(table_name, schema, con) {
     base::get(table_name, envir = .GlobalEnv),
     overwrite = TRUE
   )
+  log_info(glue::glue(
+    "Wrote table '{schema}.{db_name}' ({nrow(base::get(table_name, envir = .GlobalEnv))} rows) to SQL Server"
+  ))
 }
 
+log_info(glue::glue(
+  "Writing {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse = ', ')}"
+))
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
 
-rm(list = ls())
+log_info("==== 01d-enrolment-analysis.R COMPLETE ====")
+
+# rm(list = ls())

--- a/R/01e-stp-distributions.R
+++ b/R/01e-stp-distributions.R
@@ -13,6 +13,20 @@
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 01e-stp-distributions.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -26,6 +40,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -34,6 +49,7 @@ age_group_lookup <- dbReadTable(
   con,
   SQL(glue::glue('"{my_schema}"."age_group_lookup_r"'))
 )
+log_info(glue::glue("Loaded age_group_lookup_r: {nrow(age_group_lookup)} rows"))
 
 # We need to bring in PSI_VISA_STATUS here as well.  (add in 01d)
 min_enrolment <- dbGetQuery(
@@ -48,26 +64,30 @@ min_enrolment <- dbGetQuery(
     FROM "{my_schema}"."min_enrolment_r"'
   )
 )
+log_info(glue::glue("Loaded min_enrolment_r: {nrow(min_enrolment)} rows"))
 
 credential_non_dup <- dbGetQuery(
   con,
   glue::glue(
     'SELECT
-      id,
+      ID,
       RESEARCH_UNIVERSITY,
       OUTCOMES_CRED,
-      FINAL_CIP_CLUSTER_CODE,
+      FINAL_CIP_CLUSTER_CODE, 
       FINAL_CIP_CODE_4
     FROM "{my_schema}"."credential_non_dup_r"'
-  )
+  ) # the FINAL_CIP is created from 02a session, so 02a session must be done before this step
 )
+log_info(glue::glue(
+  "Loaded credential_non_dup_r: {nrow(credential_non_dup)} rows"
+))
 
 tbl_credential_highest_rank <-
   dbGetQuery(
     con,
     glue::glue(
       'SELECT
-      id,
+      ID,
       psi_gender_cleaned,
       AGE_GROUP_AT_GRAD,
       PSI_CREDENTIAL_CATEGORY,
@@ -76,15 +96,21 @@ tbl_credential_highest_rank <-
     FROM "{my_schema}"."tbl_credential_highest_rank_r"'
     )
   )
+log_info(glue::glue(
+  "Loaded tbl_credential_highest_rank_r: {nrow(tbl_credential_highest_rank)} rows"
+))
 
 
 # bring research university and outcomes credential into tbl_credential_highest_rank
 # this should have been done at end of 01c-credential-analysis.R
 tbl_credential_highest_rank <- tbl_credential_highest_rank |>
   left_join(
-    credential_non_dup |> select(id, RESEARCH_UNIVERSITY, OUTCOMES_CRED),
-    by = "id"
+    credential_non_dup |> select(ID, RESEARCH_UNIVERSITY, OUTCOMES_CRED),
+    by = "ID"
   )
+log_info(
+  "Enriched tbl_credential_highest_rank with RESEARCH_UNIVERSITY and OUTCOMES_CRED from credential_non_dup"
+)
 
 ## ---------------------------- Final Credential Distributions --------------------------------
 # References: 01c-credential-analysis.R
@@ -110,12 +136,16 @@ credential_by_year_age_group <- tbl_credential_highest_rank |>
   summarise(Count = n(), .groups = "drop") |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_age_group: {nrow(credential_by_year_age_group)} rows"
+))
+
 # Exclude CIP clusters 09 and 10
 credential_by_year_age_group_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
-    by = "id"
+    credential_non_dup |> select(ID, FINAL_CIP_CLUSTER_CODE),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -125,6 +155,10 @@ credential_by_year_age_group_exclude_cips <- tbl_credential_highest_rank |>
   group_by(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED) |>
   summarise(Count = n(), .groups = "drop") |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
+
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_age_group_exclude_cips: {nrow(credential_by_year_age_group_exclude_cips)} rows"
+))
 
 # Domestic only
 credential_by_year_age_group_domestic <- tbl_credential_highest_rank |>
@@ -137,12 +171,16 @@ credential_by_year_age_group_domestic <- tbl_credential_highest_rank |>
   summarise(Count = n(), .groups = "drop") |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_age_group_domestic: {nrow(credential_by_year_age_group_domestic)} rows"
+))
+
 # Domestic only, exclude CIPs
 credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE),
-    by = "id"
+    credential_non_dup |> select(ID, FINAL_CIP_CLUSTER_CODE),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -153,6 +191,10 @@ credential_by_year_age_group_domestic_exclude_cips <- tbl_credential_highest_ran
   group_by(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED) |>
   summarise(Count = n(), .groups = "drop") |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
+
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_age_group_domestic_exclude_cips: {nrow(credential_by_year_age_group_domestic_exclude_cips)} rows"
+))
 
 # Domestic only, exclude research universities and DACSO
 # Notes from 2019 docs suggest we exclude credentials which are
@@ -169,12 +211,16 @@ credential_by_year_age_group_domestic_exclude_ru_dacso <- tbl_credential_highest
   summarise(Count = n(), .groups = "drop") |>
   arrange(AgeGroup, PSI_CREDENTIAL_CATEGORY, PSI_AWARD_SCHOOL_YEAR_DELAYED)
 
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_age_group_domestic_exclude_ru_dacso: {nrow(credential_by_year_age_group_domestic_exclude_ru_dacso)} rows"
+))
+
 # CIP4, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
 credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
-    credential_non_dup |> select(id, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
-    by = "id"
+    credential_non_dup |> select(ID, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -197,14 +243,18 @@ credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_c
     PSI_CREDENTIAL_CATEGORY,
     PSI_AWARD_SCHOOL_YEAR_DELAYED
   )
+
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips: {nrow(credential_by_year_cip4_agegroup_domestic_exclude_ru_dacso_exclude_cips)} rows"
+))
 
 # CIP4, Gender, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
 credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |>
-      select(id, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
-    by = "id"
+      select(ID, FINAL_CIP_CLUSTER_CODE, FINAL_CIP_CODE_4),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -230,13 +280,17 @@ credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <
     PSI_AWARD_SCHOOL_YEAR_DELAYED
   )
 
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips: {nrow(credential_by_year_cip4_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips)} rows"
+))
+
 # Gender, AgeGroup, Domestic, Exclude CIPs
 credential_by_year_gender_agegroup_domestic_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |>
-      select(id, FINAL_CIP_CLUSTER_CODE),
-    by = "id"
+      select(ID, FINAL_CIP_CLUSTER_CODE),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -258,13 +312,17 @@ credential_by_year_gender_agegroup_domestic_exclude_cips <- tbl_credential_highe
     PSI_AWARD_SCHOOL_YEAR_DELAYED
   )
 
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_gender_agegroup_domestic_exclude_cips: {nrow(credential_by_year_gender_agegroup_domestic_exclude_cips)} rows"
+))
+
 # Gender, AgeGroup, Domestic, Exclude RU & DACSO, Exclude CIPs
 credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl_credential_highest_rank |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_AT_GRAD" = "AgeIndex")) |>
   inner_join(
     credential_non_dup |>
-      select(id, FINAL_CIP_CLUSTER_CODE),
-    by = "id"
+      select(ID, FINAL_CIP_CLUSTER_CODE),
+    by = "ID"
   ) |>
   filter(
     PSI_CREDENTIAL_CATEGORY != "Apprenticeship",
@@ -287,6 +345,10 @@ credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl
     PSI_CREDENTIAL_CATEGORY,
     PSI_AWARD_SCHOOL_YEAR_DELAYED
   )
+
+log_info(glue::glue(
+  "Credential distribution: credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips: {nrow(credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips)} rows"
+))
 
 ## ------------------------------Final Enrolment Distributions-----------------------------
 # Reference: 01d-enrolment-analysis.R
@@ -302,6 +364,10 @@ credential_by_year_gender_agegroup_domestic_exclude_ru_dacso_exclude_cips <- tbl
 qry09c_minenrolment_by_credential_and_cip_code <- min_enrolment |>
   count(PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, name = "Expr1")
 
+log_info(glue::glue(
+  "Enrolment distribution: qry09c_minenrolment_by_credential_and_cip_code: {nrow(qry09c_minenrolment_by_credential_and_cip_code)} rows"
+))
+
 # We need to bring in PSI_VISA_STATUS to min_enrolment for this  query to work.
 # qry09c_MinEnrolment_Domestic <- min_enrolment |>
 #   inner_join(age_group_lookup, by = c("AGE_GROUP_ENROL_DATE" = "AgeIndex")) |>
@@ -312,6 +378,10 @@ qry09c_minenrolment <- min_enrolment |>
   inner_join(age_group_lookup, by = c("AGE_GROUP_ENROL_DATE" = "AgeIndex")) |>
   mutate("Groups" = paste0(PSI_GENDER, AgeGroup)) |>
   count(PSI_GENDER, PSI_SCHOOL_YEAR, Groups, name = "Expr1")
+
+log_info(glue::glue(
+  "Enrolment distribution: qry09c_minenrolment: {nrow(qry09c_minenrolment)} rows"
+))
 
 
 ## ------------------------------------ Clean Up --------------------------------------------------
@@ -344,10 +414,19 @@ write_table_to_db <- function(table_name, schema, con) {
     base::get(table_name, envir = .GlobalEnv),
     overwrite = TRUE
   )
+  log_info(glue::glue(
+    "Wrote table '{schema}.{db_name}' ({nrow(base::get(table_name, envir = .GlobalEnv))} rows) to SQL Server"
+  ))
 }
 
+log_info(glue::glue(
+  "Writing {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse = ', ')}"
+))
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
 
-rm(list = ls())
+log_info("==== 01e-stp-distributions.R COMPLETE ====")
+
+# rm(list = ls())

--- a/R/02a-appso-programs.R
+++ b/R/02a-appso-programs.R
@@ -10,6 +10,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# ==============================================================================
+# APPSO program CIP alignment
+#
+# Purpose:
+# Standardize and clean the CIP codes for APPSO (Apprenticeship) credentials
+# in the Credential_Non_Dup table. APPSO credentials use STP CIP codes directly
+# (no BGS survey matching is available for apprenticeship records), so the
+# workflow here is a one-way normalization from raw 6-digit STP CIPs to
+# validated 4-digit and 2-digit codes using INFOWARE lookup tables.
+#
+# High-level workflow:
+# 1. Connect to the database and load source/lookup table references.
+# 2. Create a cleaning table grouped by distinct STP CIP values for APPSO records.
+# 3. Fix malformed CIP values (missing trailing/leading zeros).
+# 4. Match CIPs to INFOWARE 6-digit lookup (exact, then partial fallbacks).
+# 5. Apply "general program" rule (.00 -> 01) for unmatched 4-digit codes.
+# 6. Add 4-digit and 2-digit CIP descriptive names.
+# 7. Join cleaned CIPs back to the full APPSO credential data.
+# 8. Materialize the final tables to SQL Server.
+#
+# Main outputs:
+# - Credential_Non_Dup_APPSO_IDs_r
+# - Credential_Non_Dup_STP_APPSO_Cleaning_r
+#
 # Notes
 # -----
 # - This script assumes the source tables already exist in the database.
@@ -18,13 +42,27 @@
 #   join() steps to create the same result set.
 # - Some remote databases need compute() between steps for performance or to avoid
 #   repeating large subqueries. Those calls are left commented for now.
-#
+# ==============================================================================
 
 library(dplyr)
 library(dbplyr)
 library(DBI)
 library(odbc)
 library(config)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 02a-appso-programs.R START ====")
 
 # ---- Configure database connection -------------------------------------------
 db_config <- config::get("decimal")
@@ -37,12 +75,22 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
+
+
+# ---- Read in INFOWARE tables ----
+# Note: These tables should be loaded by 'R/load-infoware-lookups.R'
+# source("R/load-infoware-lookups.R")
+# We check for their existence and proceed.
 
 # ---- Reference source tables -------------------------------------------------
 # Adjust schema/table resolution if your environment stores these elsewhere.
+# All tables below are lazy dbplyr references; queries are executed only when
+# collect() or compute() is called.
 
 credential_non_dup <- tbl(con, in_schema(my_schema, "Credential_Non_Dup_r")) %>%
   rename_with(toupper)
+# the following steps need 'load-infoware-lookup.R'
 infoware_l_cip_2digits_cip2016 <- tbl(
   con,
   in_schema(my_schema, "INFOWARE_L_CIP_2DIGITS_CIP2016")
@@ -55,15 +103,36 @@ infoware_l_cip_6digits_cip2016 <- tbl(
   con,
   in_schema(my_schema, "INFOWARE_L_CIP_6DIGITS_CIP2016")
 )
+log_info(
+  "Loaded lazy table references: Credential_Non_Dup_r, INFOWARE CIP lookup tables (2/4/6-digit)"
+)
 
 # ---- 1) SQL: create Credential_Non_Dup_STP_APPSO_Cleaning -------------------
+# WHAT: Aggregate APPSO credentials by distinct CIP code to create a compact
+#       cleaning table. This reduces the number of rows to process from the full
+#       credential table to just the unique CIP values.
+# WHY:  The cleaning logic (steps 2-10) operates on CIP codes, not individual
+#       records. Working on distinct CIPs is much faster and the results are
+#       joined back to the full table in step 11.
+
 credential_non_dup_stp_appso_cleaning <- credential_non_dup %>%
   filter(OUTCOMES_CRED == "APPSO") %>%
   count(PSI_CREDENTIAL_CIP, OUTCOMES_CRED, name = "Expr1")
 
+log_info(glue::glue(
+  "Step 1: Created APPSO cleaning table (distinct CIPs): {credential_non_dup_stp_appso_cleaning %>% tally() %>% pull()} rows"
+))
+
 # ---- 2) SQL: alter table + update original CIP -------------------------------
-# Placeholder for records finalized through manual review in Part 3C
-# The reason: dbplyr translates NA_character_ → SQL NULL (no type). SQL Server then defaults untyped NULL to int. Using sql("CAST(NULL AS VARCHAR(255))") forces the database to treat it as a character column.
+# WHAT: Add empty columns for the cleaned 4-digit and 2-digit CIP codes and
+#       their names. Also preserve the original CIP value for later joins.
+# WHY:  The cleaning steps below populate STP_CIP_CODE_4/2 progressively using
+#       coalesce(). PSI_CREDENTIAL_CIP_orig is needed because step 3 modifies
+#       PSI_CREDENTIAL_CIP in-place, and the join in step 11 must use the
+#       original value.
+# Note: dbplyr translates NA_character_ to SQL NULL (no type). SQL Server then
+#       defaults untyped NULL to int. Using sql("CAST(NULL AS VARCHAR(255))")
+#       forces the database to treat it as a character column.
 
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   mutate(
@@ -75,9 +144,14 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   )
 
 # ---- 3) SQL: clean malformed CIP values --------------------------------------
-# Step 3a equivalent: append trailing zero for 6-character values whose first
-# two characters do not contain a period.
+# WHAT: Fix two common formatting issues in STP CIP codes:
+#   3a) 6-character CIPs missing a trailing zero (e.g., "11.010" should be "11.0100")
+#   3b) 6-character CIPs missing a leading zero (e.g., "1.0100" should be "01.0100")
+# WHY:  INFOWARE lookup tables expect 7-character CIP codes (e.g., "01.0100").
+#       Malformed values would fail exact and partial matching in steps 4-7.
 
+# Step 3a: append trailing zero for 6-character values whose second character
+# is not a period (i.e., the value is missing its fourth digit).
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   mutate(
     PSI_CREDENTIAL_CIP = case_when(
@@ -88,7 +162,7 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
     )
   )
 
-# Step 3b equivalent: prepend leading zero for any value still length 6.
+# Step 3b: prepend leading zero for any value still length 6.
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   mutate(
     PSI_CREDENTIAL_CIP = case_when(
@@ -97,7 +171,16 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
     )
   )
 
+log_info("Step 3: Cleaned malformed CIP values (trailing/leading zero fixes)")
+
 # ---- 4) SQL Step1_a: exact match to INFOWARE 6-digit CIP table --------------
+# WHAT: Attempt an exact match of the cleaned CIP code against the INFOWARE
+#       6-digit lookup table to derive both 4-digit and 2-digit CIP codes.
+# WHY:  Exact matching is the most reliable way to resolve CIP codes. If the
+#       full 7-character code (e.g., "01.0100") exists in INFOWARE, we can
+#       confidently extract the corresponding 4-digit (e.g., "0101") and
+#       2-digit (e.g., "01") codes.
+
 exact_match_6 <- infoware_l_cip_6digits_cip2016 %>%
   select(
     LCIP_CD_WITH_PERIOD,
@@ -116,7 +199,16 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   ) %>%
   select(-exact_STP_CIP_CODE_4, -exact_STP_CIP_CODE_2)
 
+log_info(glue::glue(
+  "Step 4: Exact 6-digit CIP match complete. Remaining unmatched 4-digit: {credential_non_dup_stp_appso_cleaning %>% filter(is.na(STP_CIP_CODE_4)) %>% tally() %>% pull()}"
+))
+
 # ---- 5) SQL Step1_b: fallback match on first 5 characters --------------------
+# WHAT: For CIPs that failed the exact 6-digit match, try matching on the first
+#       5 characters of the CIP code (e.g., "01.01" matches "01.0100").
+# WHY:  Some STP CIP codes may have minor formatting differences or trailing
+#       digits that prevent an exact match but still correspond to a valid
+#       INFOWARE entry at the 5-character level.
 
 fallback_match_5 <- credential_non_dup_stp_appso_cleaning %>%
   filter(is.na(STP_CIP_CODE_4)) %>%
@@ -151,7 +243,18 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   ) %>%
   select(-fallback_STP_CIP_CODE_4, -fallback_STP_CIP_CODE_2)
 
+log_info(glue::glue(
+  "Step 5: 5-char fallback match complete. Remaining unmatched 4-digit: {credential_non_dup_stp_appso_cleaning %>% filter(is.na(STP_CIP_CODE_4)) %>% tally() %>% pull()}"
+))
+
 # ---- 6) SQL Step1_c: general program rule (.00 -> 01) ------------------------
+# WHAT: For CIPs still unmatched at the 4-digit level, apply a "general program"
+#       rule: if the first 5 characters match a known general-program prefix
+#       (e.g., "11.00"), default the 4-digit code to the "01" variant
+#       (e.g., "1101" = General Agriculture).
+# WHY:  General program CIPs (ending in .00) are not valid 4-digit codes in
+#       INFOWARE. The convention is to map them to the corresponding "01"
+#       general category, which is the closest valid match.
 
 general_program_prefixes <- c(
   "11.00",
@@ -179,7 +282,17 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
     )
   )
 
+log_info(
+  "Step 6: Applied general program rule (.00 -> 01) for unmatched 4-digit CIPs"
+)
+
 # ---- 7) SQL Step1_d: fallback 2-digit match on first 2 characters ------------
+# WHAT: For CIPs where the 2-digit code is still missing, try matching on the
+#       first 2 characters of the CIP code against the INFOWARE 6-digit table.
+# WHY:  The 2-digit CIP code represents the broadest program category. Even when
+#       exact and 5-char matching fail, the first 2 digits should resolve to a
+#       valid 2-digit category in most cases.
+
 fallback_match_2 <- credential_non_dup_stp_appso_cleaning %>%
   filter(is.na(STP_CIP_CODE_2)) %>%
   mutate(join_key_2 = substr(PSI_CREDENTIAL_CIP, 1, 2)) %>%
@@ -203,7 +316,16 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   ) %>%
   select(-fallback_STP_CIP_CODE_2)
 
+log_info(glue::glue(
+  "Step 7: 2-char fallback match complete. Remaining unmatched 2-digit: {credential_non_dup_stp_appso_cleaning %>% filter(is.na(STP_CIP_CODE_2)) %>% tally() %>% pull()}"
+))
+
 # ---- 8) SQL Step2: add 4-digit CIP names -------------------------------------
+# WHAT: Join the cleaned 4-digit CIP codes to the INFOWARE 4-digit lookup table
+#       to add human-readable CIP program names (e.g., "0101" -> "Agriculture").
+# WHY:  The 4-digit CIP name is needed for downstream reporting and for
+#       validating that the CIP code makes sense in context.
+
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   left_join(
     infoware_l_cip_4digits_cip2016 %>%
@@ -222,6 +344,9 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   select(-STP_CIP_CODE_4_NAME_lookup)
 
 # ---- 9) SQL Step3: add 2-digit CIP names -------------------------------------
+# WHAT: Join the cleaned 2-digit CIP codes to the INFOWARE 2-digit lookup table
+#       to add human-readable broad category names (e.g., "01" -> "Agriculture").
+
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   left_join(
     infoware_l_cip_2digits_cip2016 %>%
@@ -240,12 +365,30 @@ credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %
   select(-STP_CIP_CODE_2_NAME_lookup)
 
 # ---- 10) SQL Step4: mark missing 4-digit names as invalid --------------------
+# WHAT: For any 4-digit CIP codes that still have no name after all matching
+#       steps, mark them as "Invalid 4-digit CIP" so they can be flagged in
+#       downstream quality checks.
+# WHY:  A missing name indicates the CIP code could not be resolved to a valid
+#       INFOWARE entry. Flagging it explicitly is better than leaving it NULL.
+
 credential_non_dup_stp_appso_cleaning <- credential_non_dup_stp_appso_cleaning %>%
   mutate(
     STP_CIP_CODE_4_NAME = coalesce(STP_CIP_CODE_4_NAME, "Invalid 4-digit CIP")
   )
 
+log_info(
+  "Steps 8-10: Added 4-digit and 2-digit CIP names. Marked unresolvable 4-digit names as 'Invalid 4-digit CIP'"
+)
+
 # ---- 11) SQL: create Credential_Non_Dup_APPSO_IDs ----------------------------
+# WHAT: Join the cleaned CIP codes back to the full APPSO credential data to
+#       create the final APPSO IDs table with normalized FINAL_CIP columns.
+# WHY:  The cleaning table (step 1-10) operates on distinct CIP values only.
+#       This step expands the results back to every individual APPSO credential
+#       record, assigning FINAL_CIP_CODE_4/2 and their names.
+# HOW:  Inner join on the original (pre-cleaning) CIP value so that each
+#       credential record inherits the cleaned codes from its matching CIP.
+#       The join key uses PSI_CREDENTIAL_CIP_orig (preserved in step 2).
 
 credential_non_dup_appso_ids <- credential_non_dup %>%
   select(
@@ -279,26 +422,87 @@ credential_non_dup_appso_ids <- credential_non_dup %>%
     FINAL_CIP_CODE_2_NAME = STP_CIP_CODE_2_NAME
   )
 
+log_info(glue::glue(
+  "Step 11: Created Credential_Non_Dup_APPSO_IDs: {credential_non_dup_appso_ids %>% tally() %>% pull()} rows"
+))
+
 # ---- 12) SQL: replace '(Unspecified)' with NULL ------------------------------
+# WHAT: Clean up PSI_PROGRAM_CODE values that were imported as "(Unspecified)"
+#       by converting them to NULL.
+# WHY:  NULL is the correct representation for missing program codes. The
+#       "(Unspecified)" string is an artifact of the SQL Server import process
+#       and can cause issues in downstream joins and filters.
+
 credential_non_dup_appso_ids <- credential_non_dup_appso_ids %>%
   mutate(
     PSI_PROGRAM_CODE = na_if(PSI_PROGRAM_CODE, "(Unspecified)")
   )
 
-# write the table back to the database using computing function
+log_info("Step 12: Replaced '(Unspecified)' PSI_PROGRAM_CODE values with NULL")
 
 # ---- Optional materialization -------------------------------------------------
+# WHAT: Materialize both lazy dbplyr tables as persistent SQL Server tables so
+#       they can be used by downstream scripts without re-running the cleaning
+#       pipeline.
+# WHY:  compute() writes the lazy query result to a physical table in the
+#       database, making it available for direct querying and joins in
+#       subsequent scripts (e.g., 02a-update-cred-non-dup.R).
+
+if (
+  DBI::dbExistsTable(
+    con,
+    DBI::Id(schema = my_schema, table = "Credential_Non_Dup_APPSO_IDs_r")
+  )
+) {
+  DBI::dbRemoveTable(
+    con,
+    DBI::Id(schema = my_schema, table = "Credential_Non_Dup_APPSO_IDs_r")
+  )
+}
+
 credential_non_dup_appso_ids %>%
   compute(
     name = in_schema(my_schema, "Credential_Non_Dup_APPSO_IDs_r"),
-    temporary = FALSE
+    temporary = FALSE,
+    overwrite = T
   )
+
+log_info(glue::glue(
+  "Materialized Credential_Non_Dup_APPSO_IDs_r to SQL Server"
+))
+
+
+if (
+  DBI::dbExistsTable(
+    con,
+    DBI::Id(
+      schema = my_schema,
+      table = "Credential_Non_Dup_STP_APPSO_Cleaning_r"
+    )
+  )
+) {
+  DBI::dbRemoveTable(
+    con,
+    DBI::Id(
+      schema = my_schema,
+      table = "Credential_Non_Dup_STP_APPSO_Cleaning_r"
+    )
+  )
+}
+
 
 credential_non_dup_stp_appso_cleaning %>%
   compute(
     name = in_schema(my_schema, "Credential_Non_Dup_STP_APPSO_Cleaning_r"),
-    temporary = FALSE
+    temporary = FALSE,
+    overwrite = T
   )
+log_info(glue::glue(
+  "Materialized Credential_Non_Dup_STP_APPSO_Cleaning_r to SQL Server"
+))
 
 # ---- Disconnect ---------------------------------------------------------------
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
+
+log_info("==== 02a-appso-programs.R COMPLETE ====")

--- a/R/02a-bgs-program-matching.R
+++ b/R/02a-bgs-program-matching.R
@@ -2925,7 +2925,7 @@ credential_unmatched_cips_to_review <- credential_unmatched_cips %>%
 
 credential_unmatched_cips_to_review %>% glimpse()
 
-log_info("Test credential_unmatched_cips_to_review")
+log_info("Previewing credential_unmatched_cips_to_review (unmatched programs where BGS CIP differs from STP)")
 credential_unmatched_cips_to_review %>% tally()
 
 # ------------------------------------------------------------------------------

--- a/R/02a-bgs-program-matching.R
+++ b/R/02a-bgs-program-matching.R
@@ -86,6 +86,20 @@ library(DBI)
 library(glue)
 library(RJDBC)
 library(dbplyr)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 02a-bgs-program-matching.R START ====")
 
 # ---- Configure LAN Paths and DB Connection -----
 lan <- config::get("lan")
@@ -100,142 +114,12 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "TRUE"
 )
+log_info("Connected to SQL Server database")
 
-# ---- Read in INFOWARE tables ----
-# only run once to get tables ready
-# iw_config <- config::get("infoware")
-
-# odbcListDrivers()
-
-# iw_con <- dbConnect(
-#   odbc::odbc(),
-#   Driver = "Oracle in instantclient_19_30",
-#   DBQ = "DEV01.world",
-#   UID = iw_config$uid,
-#   PWD = iw_config$pwd
-# )
-
-# ## ** NOTE **
-# ## Ideally match on all data but prioritizing the most recent 6 years - see documentation
-# ## Update which BGS_DIST tables to include.
-
-# ## Run the following to get a list of all tables available
-# # alltables_Infoware <- dbReadTable(iw_con,"ALL_TABLES")
-
-# INFOWARE_BGS_DIST_19_23 <- dbReadTable(
-#   iw_con,
-#   DBI::Id(schema = "INFOWARE", table = "BGS_DIST_19_23")
-# )
-
-# INFOWARE_BGS_DIST_18_22 <- dbReadTable(
-#   iw_con,
-#   DBI::SQL("INFOWARE.BGS_DIST_18_22")
-# )
-# INFOWARE_BGS_COHORT_INFO <- dbReadTable(
-#   iw_con,
-#   DBI::SQL("INFOWARE.BGS_COHORT_INFO")
-# )
-
-# INFOWARE_L_CIP_6DIGITS_CIP2016 <- dbReadTable(
-#   iw_con,
-#   DBI::Id(schema = "INFOWARE", table = "L_CIP_6DIGITS_CIP2016")
-# )
-# INFOWARE_L_CIP_4DIGITS_CIP2016 <- dbReadTable(
-#   iw_con,
-#   DBI::Id(schema = "INFOWARE", table = "L_CIP_4DIGITS_CIP2016")
-# )
-# INFOWARE_L_CIP_2DIGITS_CIP2016 <- dbReadTable(
-#   iw_con,
-#   DBI::Id(schema = "INFOWARE", table = "L_CIP_2DIGITS_CIP2016")
-# )
-
-# dbDisconnect(iw_con)
-
-# # ---- Write initial tables to Decimal ----
-# ## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
-# # !! UPDATE THE TABLES AND ROW NUMBERS !! - connection won't write the full datasets to decimal due to size
-# dbWriteTable(con, "INFOWARE_BGS_DIST_19_23", INFOWARE_BGS_DIST_19_23[1:80000, ])
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_DIST_19_23",
-#   INFOWARE_BGS_DIST_19_23[80001:121074, ],
-#   append = TRUE
-# )
-# dbWriteTable(con, "INFOWARE_BGS_DIST_18_22", INFOWARE_BGS_DIST_18_22[1:80000, ])
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_DIST_18_22",
-#   INFOWARE_BGS_DIST_18_22[80001:118632, ],
-#   append = TRUE
-# )
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_COHORT_INFO",
-#   INFOWARE_BGS_COHORT_INFO[1:80000, ]
-# )
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_COHORT_INFO",
-#   INFOWARE_BGS_COHORT_INFO[80001:160000, ],
-#   append = TRUE
-# )
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_COHORT_INFO",
-#   INFOWARE_BGS_COHORT_INFO[160001:240000, ],
-#   append = TRUE
-# )
-# dbWriteTable(
-#   con,
-#   "INFOWARE_BGS_COHORT_INFO",
-#   INFOWARE_BGS_COHORT_INFO[240001:290758, ],
-#   append = TRUE
-# )
-# dbWriteTable(
-#   con,
-#   DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_6DIGITS_CIP2016"),
-#   INFOWARE_L_CIP_6DIGITS_CIP2016
-# )
-# dbWriteTable(
-#   con,
-#   DBI::Id(schema = my_schema, table = "INFOWARE_L_CIP_4DIGITS_CIP2016"),
-#   INFOWARE_L_CIP_4DIGITS_CIP2016
-# )
-# dbWriteTable(
-#   con,
-#   "INFOWARE_L_CIP_2DIGITS_CIP2016",
-#   INFOWARE_L_CIP_2DIGITS_CIP2016
-# )
-
-# ## check tables loaded correctly
-# {
-#   nrow <- tbl(con, "INFOWARE_BGS_DIST_19_23") %>% tally()
-#   nrow ## how many rows?
-#   tbl(con, "INFOWARE_BGS_DIST_19_23") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
-
-#   nrow <- tbl(con, "INFOWARE_BGS_DIST_18_22") %>% tally()
-#   nrow ## how many rows?
-#   tbl(con, "INFOWARE_BGS_DIST_18_22") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
-
-#   nrow <- tbl(con, "INFOWARE_BGS_COHORT_INFO") %>% tally()
-#   nrow ## how many rows?
-#   tbl(con, "INFOWARE_BGS_COHORT_INFO") %>% distinct(STQU_ID) %>% tally() ## are all IDs unique?
-
-#   rm(nrow)
-# }
-
-# ## remove tables and use decimal versions for remainder of code
-# rm(
-#   INFOWARE_BGS_DIST_19_23,
-#   INFOWARE_BGS_DIST_18_22,
-#   INFOWARE_BGS_COHORT_INFO,
-#   INFOWARE_L_CIP_6DIGITS_CIP2016,
-#   INFOWARE_L_CIP_4DIGITS_CIP2016,
-#   INFOWARE_L_CIP_2DIGITS_CIP2016
-# )
 
 # ---- Read in INFOWARE tables ----
 # Note: These tables should be loaded by 'R/load-infoware-lookups.R'
+# source("R/load-infoware-lookups.R")
 # We check for their existence and proceed.
 
 required_tables <- c(
@@ -259,6 +143,7 @@ if (length(missing_tables) > 0) {
     "The following required tables are missing in schema '{my_schema}': {paste(missing_tables, collapse = ', ')}. Please run 'R/load-infoware-lookups.R' first."
   ))
 }
+log_info("All required INFOWARE tables present in database")
 
 # ---- Table References ----
 infoware_bgs_19_23 <- tbl(con, in_schema(my_schema, "INFOWARE_BGS_DIST_19_23"))
@@ -274,6 +159,9 @@ cip_2_tbl <- tbl(con, in_schema(my_schema, "INFOWARE_L_CIP_2DIGITS_CIP2016"))
 
 credential_non_dup_tbl <- tbl(con, in_schema(my_schema, "credential_non_dup"))
 stp_credential_tbl <- tbl(con, in_schema(my_schema, "STP_Credential"))
+log_info(
+  "Loaded lazy table references: INFOWARE BGS/CIP tables, credential_non_dup, STP_Credential"
+)
 
 # # id should be unique for updates to be reliable.
 # infoware_cohort_info |> tally()
@@ -488,6 +376,9 @@ t_bgs_final <- t_bgs_final %>%
 # id should be unique for updates to be reliable.
 t_bgs_final |> tally()
 # 143811
+log_info(glue::glue(
+  "Part 1: Built T_BGS_Data_Final_for_OutcomesMatching_r: {t_bgs_final %>% tally() %>% pull()} rows"
+))
 
 # ------------------------------------------------------------------------------
 # Part 2: Standardize STP CIP codes to match BGS structure
@@ -634,6 +525,9 @@ stp_cip_cleaning <- stp_cip_cleaning %>%
 
 stp_cip_cleaning |> tally()
 # 681
+log_info(glue::glue(
+  "Part 2: Materialized Credential_Non_Dup_STP_CIP4_Cleaning_r: {stp_cip_cleaning %>% tally() %>% pull()} rows"
+))
 
 # ---- Part 2 (continued): Create BGS and GRAD credential ID tables ----
 # WHAT: Splits STP credential data into two separate tables: one for BGS credentials (which will undergo
@@ -707,6 +601,9 @@ bgs_ids_base <- stp_cip_ids %>%
 
 bgs_ids_base |> tally() # verify count matches expected from documentation
 # 485925 matching the number of records in 2023 according to the documentation
+log_info(glue::glue(
+  "Part 2: BGS credentials base (bgs_ids_base): {bgs_ids_base %>% tally() %>% pull()} rows"
+))
 
 # Add PSI_PEN (Personal Education Number) from STP_Credential table
 # PSI_PEN is the linking key between STP credentials and BGS survey outcomes.
@@ -735,6 +632,7 @@ credential_bgs_ids <- credential_bgs_ids %>%
     name = Id(schema = my_schema, table = "Credential_Non_Dup_BGS_IDs_r"),
     temporary = FALSE
   )
+log_info("Part 2: Materialized Credential_Non_Dup_BGS_IDs_r to SQL Server")
 
 
 # ---- GRAD Credentials: Credential_Non_Dup_GRAD_IDs ----
@@ -788,6 +686,9 @@ credential_grad_ids <- credential_grad_ids %>%
 credential_grad_ids |> tally() # verify count matches expected from documentation
 # 133844 matching the number of records in 2023 according to the documentation
 # later used in the 02a-update-cred-non-dup.R script
+log_info(glue::glue(
+  "Part 2: Materialized Credential_Non_Dup_GRAD_IDs_r: {credential_grad_ids %>% tally() %>% pull()} rows"
+))
 
 ## check Credential_Non_Dup_BGS_IDs_r for (Unspecified) - when Credential_Non_Dup loaded NULLs changed to (Unspecified)
 # {
@@ -955,6 +856,9 @@ bgs_matching %>%
 
   bgs_matching %>% tally() # Verify actual matches expected count: the same
 }
+log_info(glue::glue(
+  "Part 3A: Created bgs_matching (PEN join): {bgs_matching %>% tally() %>% pull()} rows"
+))
 
 
 ### Part 3B: Auto matching using flags ----
@@ -1162,6 +1066,9 @@ bgs_matching_flagged <- bgs_matching_flagged |>
     name = Id(schema = my_schema, table = "BGS_Matching_STP_Credential_PEN_r"),
     temporary = FALSE
   )
+log_info(glue::glue(
+  "Part 3B: Materialized BGS_Matching_STP_Credential_PEN_r with match flags: {bgs_matching_flagged %>% tally() %>% pull()} rows"
+))
 
 # bgs_matching_flagged |> tally() # Verify: 133,952 (2023)
 # bgs_matching_flagged |> glimpse() # Review structure
@@ -1343,6 +1250,9 @@ t1 <- bgs_matching_flagged |>
   )
 
 t1 |> tally() # Should be ~1,593 unique combinations (varies by year)
+log_info(glue::glue(
+  "Part 3B+: Aggregated 2-digit CIP match candidates (t1): {t1 %>% tally() %>% pull()} unique combinations"
+))
 
 ## t2: Aggregated view of 2-digit CIP matches for program-level decision making
 ## Groups individual records by institution, programs, and CIP codes to create
@@ -1369,6 +1279,9 @@ t2 <- bgs_matching_flagged %>%
   collect()
 
 t2 |> tally() # ~1593 unique program decision points
+log_info(glue::glue(
+  "Part 3B+: Collected t2 program decision points: {nrow(t2)} unique combinations"
+))
 
 # ---- Step 2: Apply multi-step decision tree to assign CIP_TO_USE ----
 # This decision tree prioritizes data quality and consistency:
@@ -1467,7 +1380,7 @@ matched_2d_cips <- matched_2d_cips %>% # this one is from t2 which is a subset o
         INSTITUTION_CODE,
         STP_PROGRAM_CODE,
         STP_PROGRAM_DESC,
-        CIP = BGS_FINAL_CIP_CODE_4,
+        CIP = BGS_FINAL_CIP_CODE_4, # CIP from 4-digit BGS survey records.
         STP_FINAL_CIP_CODE_4
       ) |>
       collect(),
@@ -1579,6 +1492,9 @@ matched_2d_cips <- matched_2d_cips %>%
   )
 
 count(matched_2d_cips, CIP_TO_USE) # All rows should have a CIP_TO_USE assignment now
+log_info(
+  "Part 3B+: All CIP_TO_USE decisions assigned (general program, cross-validation, custom, default STP)"
+)
 
 matched_2d_cips |> tally()
 matched_2d_cips |> glimpse()
@@ -1622,6 +1538,7 @@ copy_to(
 )
 
 src_tbl <- tbl(con, "matched_2d_cips_r")
+log_info("Part 3B+: Staged matched_2d_cips_r decision table to SQL Server")
 src_tbl |> glimpse()
 src_tbl |> tally()
 # 1593
@@ -1708,6 +1625,9 @@ bgs_matching_flagged |> glimpse()
 
 bgs_matching_flagged |> tally()
 # 133952
+log_info(glue::glue(
+  "Part 3B+: Applied 2-digit CIP decisions to main matching table: {bgs_matching_flagged %>% tally() %>% pull()} rows"
+))
 
 # id should be unique for updates to be reliable.
 
@@ -1765,9 +1685,10 @@ bgs_matching_tbl %>%
 # Output:
 # - BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly (review input/output table)
 #
-# "D:\PSSM\25-1319 Post-Secondary Supply Model 2022-2023\reports-final\internal_use_PSSM_2023-24_to_2034-35_20241220.xlsx"
-# "D:\PSSM\25-1319 Post-Secondary Supply Model 2022-2023\development\work\02a-program-matching\BGS\prod on 2023 data/BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos_orig.csv"
-
+# "lan\reports-final\internal_use_PSSM_2023-24_to_2034-35_20241220.xlsx"
+# "lan\development\work\02a-program-matching\BGS\prod on 2023 data/BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos_orig.csv"
+# "lan\development\work\02a-program-matching\BGS\prod on 2023 data\BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos.csv"
+lan
 # Important:
 # This section requires a manual step outside R. The script expects the reviewed
 # CSV to be returned with a populated USE_BGS_CIP field. If the file is missing,
@@ -1882,7 +1803,9 @@ BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_orig_group %>%
 # Read back the CSV with manual USE_BGS_CIP decisions from subject matter experts.
 
 BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos <- read_csv(
-  "BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos.csv"
+  glue::glue(
+    "{lan}\\development\\work\\02a-program-matching\\BGS\\prod on 2023 data\\BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_ProgramCombos.csv"
+  )
 )
 
 # ---- Part 3C.1d: Broadcast Manual Decisions to All Matching Records ----
@@ -2039,14 +1962,14 @@ BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly <- BGS_Matching_STP_Cdtl_Chec
 
 if (nrow(BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly) > 0) {
   # Stage manual updates to temporary SQL table for efficient database joining
-  copy_to(
+
+  dbWriteTable(
     con,
-    BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly,
     Id(
       schema = my_schema,
       table = "BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly_r"
     ),
-    temporary = FALSE,
+    BGS_Matching_STP_Cdtl_Check_MatchInstAwardYearOnly,
     overwrite = TRUE
   )
 
@@ -2362,6 +2285,9 @@ bgs_matching_final <- tbl(
     count(FINAL_CONSIDER_A_MATCH, FINAL_PROBABLE_MATCH) |>
     collect()
 }
+log_info(glue::glue(
+  "Part 3C/3D: Materialized final BGS_Matching_STP_Credential_PEN_r with manual review + final CIP names/clusters"
+))
 # ? still ~14000 NAs
 
 # ------------------------------------------------------------------------------
@@ -2385,6 +2311,7 @@ bgs_matching_final <- tbl(
 # ------------------------------------------------------------------------------
 
 ### Part 4A: Update with XWALK ----
+log_info("Part 4: Updating BGS credential table with final CIP decisions")
 
 {
   ## may want to make a backup copy of Credential_Non_Dup_BGS_IDs
@@ -2992,10 +2919,13 @@ credential_unmatched_cips_to_review <- credential_unmatched_cips %>%
   filter(
     MATCHED_BGS_EXAMPLE == "Yes",
     BGS_CIP_DIFFERS_FROM_STP == "Yes"
-  ) %>%
-  arrange(FINAL_CIP_CODE_4)
+  )
+# %>%
+#   arrange(FINAL_CIP_CODE_4)
 
 credential_unmatched_cips_to_review %>% glimpse()
+
+log_info("Test credential_unmatched_cips_to_review")
 credential_unmatched_cips_to_review %>% tally()
 
 # ------------------------------------------------------------------------------
@@ -3234,8 +3164,12 @@ credential_bgs_updated <- credential_bgs_updated %>%
 
 # Preview the updated credentials table structure
 credential_bgs_updated |> glimpse()
-credential_bgs_updated <- credential_bgs_updated %>%
-  as_tibble() %>%
+credential_bgs_updated_df <- credential_bgs_updated %>%
+  as_tibble()
+
+
+# str_pad function does not support tbl table.
+credential_bgs_updated_df <- credential_bgs_updated_df %>%
   mutate(
     FINAL_CIP_CODE_4 = str_pad(
       FINAL_CIP_CODE_4,
@@ -3255,7 +3189,7 @@ credential_bgs_updated <- credential_bgs_updated %>%
 dbWriteTable(
   con,
   SQL(glue::glue('"{my_schema}"."Credential_Non_Dup_BGS_IDs_r"')),
-  credential_bgs_updated,
+  credential_bgs_updated_df,
   overwrite = TRUE
 )
 
@@ -3276,6 +3210,9 @@ credential_bgs_updated |> tally()
     filter(is.na(FINAL_CIP_CLUSTER_CODE))
 }
 # passed: no missing CIP names or cluster codes remain after the override and refill steps.
+log_info(glue::glue(
+  "Part 4: Updated Credential_Non_Dup_BGS_IDs_r with final CIPs: {credential_bgs_updated %>% tally() %>% pull()} rows"
+))
 
 ## remove local tables
 rm(
@@ -3308,6 +3245,7 @@ rm(
 # ------------------------------------------------------------------------------
 
 ### Part 5A: Update with XWALK ----
+log_info("Part 5: Updating BGS outcomes table with final CIP values")
 
 {
   ## may want to make a backup copy of T_BGS_Data_Final_for_OutcomesMatching
@@ -3381,11 +3319,10 @@ t_bgs_updated <- t_bgs_updated %>%
   # Left join on STQU_ID to bring in matched CIP codes and flags
   # Rename source columns with "src_" prefix to avoid naming conflicts during updates
   left_join(
-   bgs_matching_final %>%  
-     filter(!is.na(FINAL_CONSIDER_A_MATCH) & FINAL_CONSIDER_A_MATCH != "") %>%
-       group_by(STQU_ID) %>%
-       slice_min(order_by = YEAR, n=1, with_ties =FALSE) %>%
     bgs_matching_final %>%
+      filter(!is.na(FINAL_CONSIDER_A_MATCH) & FINAL_CONSIDER_A_MATCH != "") %>%
+      group_by(STQU_ID) %>%
+      slice_min(order_by = YEAR, n = 1, with_ties = FALSE) %>%
       select(
         STQU_ID,
         FINAL_CIP_CODE_4,
@@ -3470,10 +3407,10 @@ t_bgs_updated <- t_bgs_updated %>%
       src_STP_CIP_CODE_4_NAME,
       STP_CIP_CODE_4_NAME
     ),
-     FINAL_CONSIDER_A_MATCH = if_else(
-       step1_update == TRUE,
-       src_FINAL_CONSIDER_A_MATCH,
-       FINAL_CONSIDER_A_MATCH
+    FINAL_CONSIDER_A_MATCH = if_else(
+      step1_update == TRUE,
+      src_FINAL_CONSIDER_A_MATCH,
+      FINAL_CONSIDER_A_MATCH
     ),
     FINAL_PROBABLE_MATCH = if_else(
       step1_update == TRUE,
@@ -4152,6 +4089,9 @@ t_bgs_updated <- tbl(con, in_schema(my_schema, target_name))
     filter(is.na(FINAL_CIP_CLUSTER_CODE))
 }
 # passed - no blanks in final CIP name or cluster code
+log_info(glue::glue(
+  "Part 5: Updated T_BGS_Data_Final_for_OutcomesMatching_r: {t_bgs_updated %>% tally() %>% pull()} rows"
+))
 
 # ---- Clean up ----
 
@@ -4159,4 +4099,9 @@ t_bgs_updated <- tbl(con, in_schema(my_schema, target_name))
 dbRemoveTable(con, "BGS_Matching_STP_Credential_PEN_bu_r")
 dbRemoveTable(con, "Credential_Non_Dup_BGS_IDs_bu_r")
 dbRemoveTable(con, "T_BGS_Data_Final_for_OutcomesMatching_bu_r")
+log_info("Removed backup tables")
+
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
+
+log_info("==== 02a-bgs-program-matching.R COMPLETE ====")

--- a/R/02a-dacso-program-matching.R
+++ b/R/02a-dacso-program-matching.R
@@ -42,6 +42,20 @@ library(config)
 library(glue)
 library(odbc)
 library(RJDBC) ## loads DBI
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 02a-dacso-program-matching.R START ====")
 
 # Setup ----
 
@@ -197,6 +211,7 @@ con <- dbConnect(
   Trusted_Connection = "True"
 )
 my_schema <- config::get("myschema")
+log_info("Connected to SQL Server database")
 
 # ## ---- Write initial tables to Decimal ----
 # ## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
@@ -248,6 +263,7 @@ my_schema <- config::get("myschema")
 # )
 
 # Part 1 ----
+log_info("Part 1: Building XWALK from last cycle and adding new DACSO programs")
 
 ## ---- Create programs_table from combining INFOWARE tables ----
 ## define programs_table from which to grab new programs (with and without historical linkages)
@@ -283,17 +299,21 @@ programs_table <- tbl(con, "INFOWARE_PROGRAMS_2016") %>%
   ) %>%
   collect() %>%
   refresh_programs_join_keys()
-
-## ---- Make new XWALK from last years XWALK ----
+log_info(glue::glue(
+  "Part 1: Created programs_table from INFOWARE: {nrow(programs_table)} programs"
+))
 DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23 <- tbl(
   con,
-  "DACSO_STP_ProgramsCIP4_XWALK_ALL_2020"
+  DBI::Id(schema = "dbo", table = "DACSO_STP_ProgramsCIP4_XWALK_ALL_2020")
 ) %>%
   collect() %>%
   mutate(
     CIP_CODE_4 = str_pad(CIP_CODE_4, width = 4, side = "left", pad = "0")
   ) %>%
   refresh_xwalk_join_keys()
+log_info(glue::glue(
+  "Part 1: Loaded previous XWALK (2020): {nrow(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23)} programs"
+))
 
 ## ---- Add to XWALK: New DACSO prgms WITHOUT historical linkages ----
 ## review the HAS_HISTORICAL_PRGM_ID_LINK values
@@ -1001,6 +1021,9 @@ dbWriteTable(
   DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23,
   overwrite = TRUE
 )
+log_info(glue::glue(
+  "Part 1: Wrote XWALK to Decimal: {nrow(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23)} programs (after all DACSO updates: historical links + new programs + updated CIPs)"
+))
 
 
 # ******************************************************************************
@@ -1015,6 +1038,7 @@ dbWriteTable(
 
 # check for required table
 dbExistsTable(con, SQL(glue::glue('"{my_schema}"."credential_non_dup"')))
+log_info("Part 2: Updating XWALK with new STP credential data")
 
 credential_non_dup <- sch_tbl("Credential_Non_Dup") |>
   rename_with(toupper) %>%
@@ -1078,6 +1102,10 @@ stp_dacso <- credential_non_dup %>%
     New_Manual_Match = NA_character_,
     COCI_INST_CD = NA_character_
   )
+
+log_info(glue::glue(
+  "Part 2: Created stp_dacso (DACSO subset of Credential_Non_Dup): {nrow(stp_dacso)} program combinations"
+))
 
 
 # Create PSI_CODE to COCI_INST_CD lookup table
@@ -1235,6 +1263,9 @@ stp_dacso <- stp_dacso %>%
 
 
 ## ---- Newly matched programs ----
+log_info(glue::glue(
+  "Part 2: Already matched programs: {sum(stp_dacso$Already_Matched == 'Yes', na.rm=TRUE)} / {nrow(stp_dacso)}"
+))
 # reference: to check after each query to see counts of matched
 # stp_dacso %>% count(New_Auto_Match)
 
@@ -1503,6 +1534,9 @@ rm(newly_matched_2)
 # ******************************************************************************
 # PART 3: INSTITUTION-SPECIFIC CUSTOM MATCHING
 # ******************************************************************************
+log_info(glue::glue(
+  "Part 3: Institution-specific matching. Unmatched before: {sum(is.na(stp_dacso$OUTCOMES_CIP_CODE_4))} programs"
+))
 # WHY: Some institutions use different program code formats in STP vs DACSO.
 # BCIT includes credential suffixes, CAPU uses different code lengths, and VIU
 # wraps codes in credential-category prefixes. We extract the DACSO-compatible
@@ -1950,6 +1984,9 @@ rm(xwalk_remaining, xwalk_remaining_desc)
 # ******************************************************************************
 # PART 4: FINAL UPDATE TO STP CIPS
 # ******************************************************************************
+log_info(glue::glue(
+  "Part 4: Final CIP update. Matched so far: {sum(!is.na(stp_dacso$OUTCOMES_CIP_CODE_4))} / {nrow(stp_dacso)} programs"
+))
 # WHY: Compute final CIP codes. Matched programs use the outcomes CIP; unmatched
 # programs use STP CIP from the INFOWARE taxonomy. Then fill 2-digit CIP and
 # cluster codes from the 4-digit code.
@@ -2112,6 +2149,9 @@ stp_dacso <- stp_dacso %>%
 # 5462
 
 # check the # of changed CIPS
+log_info(glue::glue(
+  "Part 4: Final CIP update complete. {nrow(stp_dacso)} programs, {sum(!is.na(stp_dacso$FINAL_CIP_CODE_4))} with FINAL_CIP_CODE_4 populated"
+))
 # ---- Review CIP changes ----
 # WHY: Diagnostic — shows programs where the final CIP differs from the original
 # STP CIP. Useful for catching incorrect matches.
@@ -2131,17 +2171,29 @@ dbWriteTable(
   stp_dacso_out,
   overwrite = TRUE
 )
+log_info(glue::glue(
+  "Wrote STP_Credential_Non_Dup_Programs_DACSO_r: {nrow(stp_dacso_out)} rows"
+))
 dbWriteTable(
   con,
   "Credential_Non_Dup_Programs_DACSO_FinalCIPS_r",
   stp_dacso_out,
   overwrite = TRUE
 )
+log_info(glue::glue(
+  "Wrote Credential_Non_Dup_Programs_DACSO_FinalCIPS_r: {nrow(stp_dacso_out)} rows"
+))
 dbWriteTable(
   con,
   "DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_r",
   DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_out,
   overwrite = TRUE
 )
+log_info(glue::glue(
+  "Wrote updated XWALK to Decimal: {nrow(DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23_out)} rows"
+))
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
+
+log_info("==== 02a-dacso-program-matching.R COMPLETE ====")

--- a/R/02a-update-cred-non-dup.R
+++ b/R/02a-update-cred-non-dup.R
@@ -52,6 +52,20 @@ library(arrow)
 library(tidyverse)
 library(odbc)
 library(DBI)
+library(futile.logger)
+
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 02a-update-cred-non-dup.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -67,6 +81,7 @@ con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database")
 
 sch_tbl <- function(tbl, conn = con, schema = my_schema) {
   dplyr::tbl(conn, DBI::Id(schema = schema, table = tbl))
@@ -101,6 +116,7 @@ dbExistsTable(
   con,
   SQL(glue::glue('"{my_schema}"."INFOWARE_L_CIP_2DIGITS_CIP2016"'))
 )
+log_info("Checked all required tables exist")
 
 ## ---------------------Add CIP columns to Credential_Non_Dup--------------------------------------
 # The credential table doesn't yet have columns for the final matched CIP codes.
@@ -125,6 +141,7 @@ ADD         OUTCOMES_CIP_CODE_4 varchar(4),
             STP_CIP_CODE_2 varchar(2),
             STP_CIP_CODE_2_NAME varchar(255);"
 )
+log_info("Added 12 CIP columns to Credential_Non_Dup_r via ALTER TABLE")
 
 ## -------------- Update CIP codes from DACSO (primary source)------------------------------------
 # DACSO provides the richest matching — it joins on 7 columns (institution,
@@ -138,6 +155,10 @@ cred_non_dup <- sch_tbl("credential_non_dup_r")
 cred_non_dup <- cred_non_dup |> rename_with(toupper)
 cred_non_dup <- cred_non_dup |>
   collect()
+
+log_info(glue::glue(
+  "Loaded credential_non_dup_r: {nrow(cred_non_dup)} records"
+))
 
 
 dacso_cips <- sch_tbl("Credential_Non_Dup_Programs_DACSO_FinalCIPs_r")
@@ -186,11 +207,16 @@ cred_non_dup <- cred_non_dup %>%
     unmatched = "ignore"
   )
 
-## ---------------------Update CIP codes from BGS program matching --------------------------------
+log_info(glue::glue(
+  "DACSO update applied: {nrow(dacso_join)} matched records, {sum(!is.na(cred_non_dup$FINAL_CIP_CODE_4))} now have FINAL_CIP_CODE_4"
+))
+
+## -----------------------------------------------------------------------------------------------------------------------------------
 # BGS (BC Government Student outcomes) records weren't matched by DACSO.
 # These are matched by a simple ID lookup from the BGS program matching script
 # (02a-bgs-program-matching). rows_update only overwrites NA values where IDs match.
 ## ------------------------------------------------------------------------------------------------
+
 bgs_cips <- sch_tbl("Credential_Non_Dup_BGS_IDs_r") %>%
   select(
     ID,
@@ -202,6 +228,7 @@ bgs_cips <- sch_tbl("Credential_Non_Dup_BGS_IDs_r") %>%
     FINAL_CIP_CLUSTER_NAME
   ) %>%
   collect()
+
 bgs_cips <- bgs_cips |> rename_with(toupper)
 
 bgs_updates <- bgs_cips |>
@@ -228,6 +255,10 @@ bgs_updates <- bgs_cips |>
 
 cred_non_dup <- cred_non_dup %>%
   rows_update(bgs_updates, by = "ID", unmatched = "ignore")
+
+log_info(glue::glue(
+  "BGS update applied: {nrow(bgs_updates)} IDs, {sum(!is.na(cred_non_dup$FINAL_CIP_CODE_4))} now have FINAL_CIP_CODE_4"
+))
 
 ## -------------------Update CIP codes from GRAD program matching----------------------------------
 # ---- update cluster codes for GRAD and APPSO (was left out of previous code)
@@ -270,6 +301,10 @@ grad_updates <- grad_cips %>%
 cred_non_dup <- cred_non_dup %>%
   rows_update(grad_updates, by = "ID", unmatched = "ignore")
 
+log_info(glue::glue(
+  "GRAD update applied: {nrow(grad_updates)} IDs, {sum(!is.na(cred_non_dup$FINAL_CIP_CODE_4))} now have FINAL_CIP_CODE_4"
+))
+
 ## -------------------Update CIP codes from APPSO program matching----------------------------------
 # APPSO (Apprentice outcomes) records get their CIP codes from the APPSO
 # cleaning script (02a-appso-programs). Like BGS/GRAD, simple ID-based lookup.
@@ -310,6 +345,10 @@ appso_updates <- appso_cips %>%
 cred_non_dup <- cred_non_dup %>%
   rows_update(appso_updates, by = "ID", unmatched = "ignore")
 
+log_info(glue::glue(
+  "APPSO update applied: {nrow(appso_updates)} IDs, {sum(!is.na(cred_non_dup$FINAL_CIP_CODE_4))} now have FINAL_CIP_CODE_4"
+))
+
 ## -------------------Populate cluster codes for GRAD and APPSO records-----------------------------
 # GRAD and APPSO records need cluster codes (broader career groupings) that
 # map from their 2-digit CIP codes. These clusters are used in downstream occupation
@@ -340,6 +379,10 @@ cred_non_dup <- cred_non_dup %>%
   ) %>%
   select(-LCP2_LCIPPC_CD, -LCP2_LCIPPC_NAME)
 
+log_info(glue::glue(
+  "Cluster codes populated for GRAD/APPSO records. Still NULL FINAL_CIP_CODE_4: {sum(is.na(cred_non_dup$FINAL_CIP_CODE_4))}"
+))
+
 # ---- check for any leftover NULLs in the final cip 4 column
 # These NULLs will be filled by the STP fallback below.
 {
@@ -364,6 +407,10 @@ cred_non_dup <- cred_non_dup %>%
 null_cleaning <- cred_non_dup %>%
   filter(is.na(FINAL_CIP_CODE_4)) %>%
   count(PSI_CREDENTIAL_CIP, OUTCOMES_CRED, name = "Expr1")
+
+log_info(glue::glue(
+  "NULL CIP cleanup: {nrow(null_cleaning)} distinct CIP codes to clean for unmatched records"
+))
 
 dbWriteTable(
   con,
@@ -499,6 +546,11 @@ null_cleaning <- null_cleaning %>%
   select(-PSI_CIP_2, -LCIP_CD_WITH_PERIOD, -LCIP_LCP4_CD, -LCIP_LCP2_CD)
 
 
+log_info(glue::glue(
+  "NULL CIP cleaning: INFOWARE matching complete. {sum(!is.na(null_cleaning$STP_CIP_CODE_4))}/{nrow(null_cleaning)} codes matched to a 4-digit CIP"
+))
+
+
 ## --------------------- Step 11: Add CIP names from lookup tables ------------------------------
 # Add human-readable names for the matched CIP codes, needed for reporting and
 # for analysts to verify that the CIP matches are sensible.
@@ -527,6 +579,10 @@ null_cleaning <- null_cleaning %>%
       STP_CIP_CODE_4_NAME
     )
   )
+
+log_info(
+  "NULL CIP cleaning: CIP names added, unmatched flagged as 'Invalid 4-digit CIP'"
+)
 
 ## ------------- Step 12: Create ID list of NULL records with matched STP CIPs -----------------
 # Join the cleaned CIP results back to the original credential records that had
@@ -598,7 +654,10 @@ dbWriteTable(
   overwrite = TRUE
 )
 
-## ------------- Step 13: Apply the NULL CIP fallback to Credential_Non_Dup -----------------------
+log_info(glue::glue(
+  "NULL CIP fallback: Created null_ids lookup with {nrow(null_ids)} records to update"
+))
+##-----------------------
 # update the final NULL CIPs
 # dbExecute(con, qry_update_Credential_Non_Dup_NULL_Final_CIPs)
 # This is the final merge — update the main credential table with the STP-derived
@@ -619,6 +678,10 @@ null_updates <- null_ids %>%
 
 cred_non_dup <- cred_non_dup %>%
   rows_update(null_updates, by = "ID", unmatched = "ignore")
+
+log_info(glue::glue(
+  "NULL CIP fallback applied: {sum(is.na(cred_non_dup$FINAL_CIP_CODE_4))} records still missing FINAL_CIP_CODE_4"
+))
 
 ## checks
 {
@@ -690,6 +753,9 @@ cred_non_dup <- cred_non_dup %>%
   )
 
 # Write final table
+log_info(glue::glue(
+  "Final cleanup complete. Writing Credential_Non_Dup_r: {nrow(cred_non_dup)} records, {sum(!is.na(cred_non_dup$FINAL_CIP_CODE_4))} with FINAL_CIP_CODE_4"
+))
 dbWriteTable(
   con,
   SQL(glue::glue('"{my_schema}"."Credential_Non_Dup_r"')),
@@ -698,5 +764,11 @@ dbWriteTable(
 )
 
 # ---- Clean up ----
-dbExecute(con, "DROP TABLE Credential_Non_Dup_STP_NULL_Cleaning")
+dbExecute(
+  con,
+  glue::glue("DROP TABLE [{my_schema}].Credential_Non_Dup_STP_NULL_Cleaning_r")
+)
 dbDisconnect(con)
+log_info("Disconnected from SQL Server")
+
+log_info("==== 02a-update-cred-non-dup.R COMPLETE ====")

--- a/R/02b-1-pssm-cohorts.R
+++ b/R/02b-1-pssm-cohorts.R
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # This script prepares student outcomes data for the following student surveys: TRD, APP, DACSO, BGS
+# need tables: load-cohort-tablename.r
 #
 # APP:
 #     Assumes geocoding has been done, and CURRENT_REGION_PSSM_CODE contains final region code to use and
@@ -53,10 +54,24 @@ library(DBI)
 library(odbc)
 library(glue)
 library(assertthat)
+library(futile.logger)
 
-regular_run <- T
-qi_run <- F
-ptib_run <- T
+## -------------------------- Logging Setup -------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== 02b-1-pssm-cohorts.R START ====")
+
+# regular_run <- T
+# qi_run <- F
+# ptib_run <- F
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -73,6 +88,8 @@ con <- dbConnect(
 )
 
 lan <- config::get("lan")
+
+log_info("Connected to SQL Server database")
 
 
 ## --------------------------------------Required Tables------------------------------------------
@@ -114,13 +131,20 @@ if (length(missing) > 0) {
     "The following required tables are missing from the environment:",
     paste(missing, collapse = ", ")
   ))
+} else {
+  log_info(glue::glue(
+    "All {length(required_tables)} required tables found in environment"
+  ))
 }
 
 
 # Set weight for model year
 target_weight <- if (qi_run) "WEIGHT_QI" else "WEIGHT"
 
+tbl_age <- tbl_age |> janitor::clean_names("all_caps") |> select(AGE, AGE_GROUP)
+
 # ---- TRD Queries ----
+log_info("Processing TRD cohort: applying weights, age groups, labour supply")
 # Applies weight for model year and derives New Labour Supply
 trd_data <- trd_data |>
   select(-WEIGHT) |>
@@ -194,6 +218,9 @@ trd_data <-
 
 trd_data[setdiff(names(t_cohorts_recoded), names(trd_data))] <- NA
 t_cohorts_recoded <- t_cohorts_recoded |> rbind(trd_data)
+log_info(glue::glue(
+  "TRD cohort added: {nrow(trd_data)} records. T_Cohorts_Recoded now has {nrow(t_cohorts_recoded)} records"
+))
 
 # ---- APP Queries ----
 # Process APPSO data into the cohorts recoded table
@@ -237,9 +264,14 @@ appso_data_final[setdiff(
   names(appso_data_final)
 )] <- NA
 t_cohorts_recoded <- t_cohorts_recoded |> rbind(appso_data_final)
+log_info(glue::glue(
+  "APPSO cohort added: {nrow(appso_data_final)} records. T_Cohorts_Recoded now has {nrow(t_cohorts_recoded)} records"
+))
 
 # ---- BGS Queries ----
-# Recode institution codes to be consistent to STP file
+log_info(
+  "Processing BGS cohort: institution recode, CIP update, weights, labour supply"
+)
 t_bgs_data_final <- t_bgs_data_final |>
   left_join(
     t_bgs_inst_recode,
@@ -342,9 +374,14 @@ t_cohorts_recoded <-
   filter(SURVEY != "BGS")
 
 t_cohorts_recoded <- t_cohorts_recoded |> rbind(bgs_update)
+log_info(glue::glue(
+  "BGS cohort added: {nrow(bgs_update)} records. T_Cohorts_Recoded now has {nrow(t_cohorts_recoded)} records"
+))
 
 # ----DACSO Queries ----
-# !! investigate!! t_dacso_data_part_1_stepa  variables TTRAIN and COSC_GRAD_STATUS_LGDS_CD_GROUP are
+log_info(
+  "Processing DACSO cohort: credential grouping, age, CIP update, weights, labour supply"
+)
 # NA (why)?  This forces  LCIP4_CRED to include NA's in the concatenated parts
 # but SQL coerces the entire variable to NA
 
@@ -515,3 +552,8 @@ write_table_to_db <- function(table_name, schema, con) {
 }
 
 walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+log_info(glue::glue(
+  "Wrote {length(tables_to_keep)} tables to DB: {paste(tables_to_keep, collapse=', ')}"
+))
+
+log_info("==== 02b-1-pssm-cohorts.R COMPLETE ====")

--- a/R/02b-2-pssm-cohorts-new-labour-supply.R
+++ b/R/02b-2-pssm-cohorts-new-labour-supply.R
@@ -23,9 +23,17 @@
 # Includes records with a labour force status for those aged 17 to 64,
 # Includes those with an invalid NOC where 100% of CIP is invalid, as the cohort number.
 
+#  participation term P(in labour supply | CIP) is the New_Labour_Supply column from 02b-2's labour_supply_distribution
+
+# OCCSN(NOC) = GRADUATES(cred, age)
+#            × P(CIP | cred, age)        ← cohort_program_distributions  (06)
+#            × P(in labour supply | CIP) ← labour_supply_distribution    (02b-2)
+#            × P(NOC | CIP, region)      ← occupation_distributions       (02b-3)
+
 # Notes:  create Weight_Age is used to calculate the age for the private institution credentials
 # and needed if the data set doesn’t have age. Some invalid NOC codes (see documentation)
 #         PDEG included at the end of occupation_distribution scripts.
+
 #
 # FIXME Labour_Supply_Distribution_LCP2/LCP_No_TT have LCP2_CRED not LCIP2_CRED
 # FIXME Missing Non-Student Outcomes and PDEG at this point.  To be brought in after
@@ -62,7 +70,7 @@ con <- dbConnect(
 
 labour_supply_distribution_stat_can <- tibble(dbReadTable(
   con,
-  SQL(glue::glue('"{my_schema}"."Labour_Supply_Distribution_Stat_Can_r"'))
+  SQL(glue::glue('"{my_schema}"."Labour_Supply_Distribution_Stat_Can"'))
 )) |>
   # not sure which one this should be but this matches what is in the SQL table
   mutate(
@@ -1080,7 +1088,7 @@ labour_supply_distribution <- labour_supply_distribution %>%
         AGE_GROUP_ROLLUP,
         LCP4_CD,
         LCIP4_CRED,
-        LCIP2_CRED,
+        # LCIP2_CRED,
         COUNT,
         TOTAL,
         New_Labour_Supply = NEW_LABOUR_SUPPLY

--- a/R/02b-3-pssm-cohorts-occupation-distributions.R
+++ b/R/02b-3-pssm-cohorts-occupation-distributions.R
@@ -9,6 +9,10 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+# OCCSN(NOC) = GRADUATES(cred, age)
+#            × P(CIP | cred, age)        ← cohort_program_distributions  (06)
+#            × P(in labour supply | CIP) ← labour_supply_distribution    (02b-2)
+#            × P(NOC | CIP, region)      ← occupation_distributions       (02b-3)
 
 library(tidyverse)
 library(glue)
@@ -56,7 +60,7 @@ con <- dbConnect(
 # move this into load scripts?
 occupation_distributions_stat_can <- dbReadTable(
   con,
-  SQL(glue::glue('"Occupation_Distributions_Stat_Can_r"'))
+  SQL(glue::glue('"Occupation_Distributions_Stat_Can"'))
 ) |>
   # not sure which one this should be but this matches what is in the SQL table
   mutate(
@@ -582,21 +586,22 @@ group_vars <- c(
 occupation_distributions <- dacso_q009_weight_occs |>
   group_by(across(c(all_of(group_vars), "NOC_CD"))) |>
   summarize(
-    COUNT = sum(WEIGHTED, na.rm = TRUE),
+    COUNT = sum(WEIGHTED, na.rm = TRUE), # + NOC = numerator
     .groups = "drop"
   ) |>
   left_join(
     dacso_q009_weight_occs |>
       group_by(across(all_of(group_vars))) |>
       summarize(
-        TOTAL = sum(WEIGHTED, na.rm = TRUE),
+        TOTAL = sum(WEIGHTED, na.rm = TRUE), # CIP×cred×region×age = denominator
         .groups = "drop"
       ),
     by = group_vars
   ) |>
   mutate(
-    PERC_DIST = COUNT / TOTAL
+    PERC_DIST = COUNT / TOTAL #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   ) |>
+  #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   transmute(
     Survey = "Student Outcomes",
     PSSM_Credential = PSSM_CREDENTIAL,
@@ -647,7 +652,7 @@ occupation_distributions_lcp2 <-
       ),
     by = group_vars
   ) |>
-  mutate(PERC_DIST = COUNT / TOTAL) |>
+  mutate(PERC_DIST = COUNT / TOTAL) |> #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   transmute(
     Survey = "Student Outcomes",
     PSSM_Credential = PSSM_CREDENTIAL,
@@ -696,7 +701,7 @@ occupation_distributions_lcp2_bc <- dacso_q009_weight_occs |>
       ),
     by = group_vars
   ) |>
-  mutate(PERC_DIST = COUNT / TOTAL) |>
+  mutate(PERC_DIST = COUNT / TOTAL) |> #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   transmute(
     Survey = "Student Outcomes",
     PSSM_Credential = PSSM_CREDENTIAL,
@@ -745,7 +750,7 @@ occupation_distributions_lcp2_bc_no_tt <- dacso_q009_weight_occs |>
       ),
     by = group_vars
   ) |>
-  mutate(PERC_DIST = COUNT / TOTAL) |>
+  mutate(PERC_DIST = COUNT / TOTAL) |> #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   transmute(
     Survey = "Student Outcomes",
     PSSM_Credential = PSSM_CREDENTIAL,
@@ -794,7 +799,7 @@ occupation_distributions_lcp2_no_tt <- dacso_q009_weight_occs |>
       ),
     by = group_vars
   ) |>
-  mutate(PERC_DIST = COUNT / TOTAL) |>
+  mutate(PERC_DIST = COUNT / TOTAL) |> #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   transmute(
     Survey = "Student Outcomes",
     PSSM_Credential = PSSM_CREDENTIAL,
@@ -861,7 +866,7 @@ occupation_distributions_no_tt <- dacso_q009_weight_occs |>
     by = c(group_vars)
   ) |>
   mutate(
-    PERC_DIST = COUNT / TOTAL
+    PERC_DIST = COUNT / TOTAL #        Percent = COUNT(NOC, CIP, …) / TOTAL(CIP, …) = P(NOC | CIP, region, age)
   ) |>
   transmute(
     Survey = "Student Outcomes",
@@ -879,63 +884,69 @@ occupation_distributions_no_tt <- dacso_q009_weight_occs |>
     Percent = PERC_DIST
   )
 
+# ------  PDEG/Law NEW LABOUR SUPPLY distribution is built in 02b-2 ------
+# Removed the duplicate NLS PDEG block that previously lived here.
+# It re-appended 'Student Outcomes' PDEG/07 rows that 02b-2 had already added
+# (the dedup filter only caught '2021 Census' rows), doubling lawyer supply.
+
 # ------  create distribution for pdeg/law distribution ------
 # These queries calculate New Labour Supply Distribution for Law/PDEG
+
 # TODO: Move to 02b-2
-labour_supply_distribution <- labour_supply_distribution |>
-  filter(
-    !(str_starts(Survey, '2021 Census') & # upper case SURVEY
-      PSSM_CREDENTIAL == "PDEG" &
-      str_starts(LCP4_CD, "07"))
-  ) #6459 records kept
+# labour_supply_distribution <- labour_supply_distribution |>
+#   filter(
+#     !(str_starts(Survey, '2021 Census') & # upper case SURVEY
+#       PSSM_CREDENTIAL == "PDEG" &
+#       str_starts(LCP4_CD, "07"))
+#   ) #6459 records kept
 
-labour_supply_distribution_pdeg <- labour_supply_distribution |>
-  filter(
-    PSSM_CREDENTIAL == "BACH",
-    str_starts(LCP4_CD, "22"),
-    str_starts(Survey, "Student Outcomes")
-  )
+# labour_supply_distribution_pdeg <- labour_supply_distribution |>
+#   filter(
+#     PSSM_CREDENTIAL == "BACH",
+#     str_starts(LCP4_CD, "22"),
+#     str_starts(Survey, "Student Outcomes")
+#   )
 
-group_vars <- c(
-  "Survey",
-  "TTRAIN",
-  "AGE_GROUP_ROLLUP"
-)
+# group_vars <- c(
+#   "Survey",
+#   "TTRAIN",
+#   "AGE_GROUP_ROLLUP"
+# )
 
-# ---- dacso_q010d2_nls_pdeg_07_count ----
-dacso_q010d5 <- labour_supply_distribution_pdeg |>
-  group_by(across(all_of(c(group_vars, "CURRENT_REGION_PSSM_CODE_ROLLUP")))) |>
-  summarize(
-    COUNT = sum(COUNT, na.rm = TRUE),
-    .groups = "drop"
-  ) |>
-  left_join(
-    labour_supply_distribution_pdeg |>
-      distinct(across(all_of(c(group_vars, "TOTAL")))) |>
-      group_by(across(all_of(group_vars))) |>
-      summarize(
-        TOTAL = sum(TOTAL, na.rm = TRUE),
-        .groups = "drop"
-      ),
-    by = group_vars
-  ) |>
-  transmute(
-    Survey = "Student Outcomes",
-    PSSM_CREDENTIAL = "PDEG",
-    PSSM_CRED = "PDEG",
-    CURRENT_REGION_PSSM_CODE_ROLLUP,
-    AGE_GROUP_ROLLUP,
-    LCP4_CD = "07",
-    TTRAIN,
-    LCIP4_CRED = "07 - PDEG",
-    LCIP2_CRED = NA_character_,
-    COUNT,
-    TOTAL,
-    New_Labour_Supply = if_else(is.na(COUNT), 0, COUNT / TOTAL)
-  )
+# # ---- dacso_q010d2_nls_pdeg_07_count ----
+# dacso_q010d5 <- labour_supply_distribution_pdeg |>
+#   group_by(across(all_of(c(group_vars, "CURRENT_REGION_PSSM_CODE_ROLLUP")))) |>
+#   summarize(
+#     COUNT = sum(COUNT, na.rm = TRUE),
+#     .groups = "drop"
+#   ) |>
+#   left_join(
+#     labour_supply_distribution_pdeg |>
+#       distinct(across(all_of(c(group_vars, "TOTAL")))) |>
+#       group_by(across(all_of(group_vars))) |>
+#       summarize(
+#         TOTAL = sum(TOTAL, na.rm = TRUE),
+#         .groups = "drop"
+#       ),
+#     by = group_vars
+#   ) |>
+#   transmute(
+#     Survey = "Student Outcomes",
+#     PSSM_CREDENTIAL = "PDEG",
+#     PSSM_CRED = "PDEG",
+#     CURRENT_REGION_PSSM_CODE_ROLLUP,
+#     AGE_GROUP_ROLLUP,
+#     LCP4_CD = "07",
+#     TTRAIN,
+#     LCIP4_CRED = "07 - PDEG",
+#     LCIP2_CRED = NA_character_,
+#     COUNT,
+#     TOTAL,
+#     New_Labour_Supply = if_else(is.na(COUNT), 0, COUNT / TOTAL)
+#   )
 
-labour_supply_distribution <- labour_supply_distribution |>
-  rbind(dacso_q010d5)
+# labour_supply_distribution <- labour_supply_distribution |>
+#   rbind(dacso_q010d5)
 
 # ---- Calculate Occupational Distribution for Law/PDEG
 # Collapse the following 4 queries into one for readability.
@@ -1041,9 +1052,9 @@ occupation_distributions <- occupation_distributions |>
         PSSM_CREDENTIAL = PSSM_CREDENTIAL,
         PSSM_CRED,
         LCP4_CD,
-        TTRAIN,
+        TTRAIN = NA_character_,
         LCIP4_CRED,
-        LCIP2_CRED,
+        LCIP2_CRED = NA_character_,
         NOC,
         CURRENT_REGION_PSSM_CODE_ROLLUP,
         AGE_GROUP_ROLLUP,
@@ -1068,7 +1079,8 @@ tables_to_keep <- c(
   "occupation_distributions_lcp2",
   "occupation_distributions_lcp2_no_tt",
   "occupation_distributions_lcp2_bc",
-  "occupation_distributions_lcp2_bc_no_tt"
+  "occupation_distributions_lcp2_bc_no_tt",
+  "t_suppression_public_release_noc"
 )
 
 write_table_to_db <- function(table_name, schema, con) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,9 +136,9 @@ time_execution <- function(file_path) {
 # Returns: `table_name` invisibly.
 read_table_from_db <- function(table_name, schema, con) {
   db_name <- glue::glue("{table_name}_r")
-  .GlobalEnv[[table_name]] <- dbReadTable(
+  .GlobalEnv[[table_name]] <- DBI::dbReadTable(
     con,
-    SQL(glue::glue('"{schema}"."{db_name}"'))
+    DBI::Id(schema = schema, table = as.character(db_name))
   )
   invisible(table_name)
 }


### PR DESCRIPTION
One of 7 sub-PRs replacing #<old-PR4>.

Rewrites modules 01-02 from SQL (SELECT INTO / UPDATE / ALTER TABLE) to R using
dplyr, DBI, dbWriteTable, left_join, mutate, rows_update. All outputs follow the
_r suffix convention.

Module 01 — enrolment / credential preprocessing:
- R/01a-enrolment-preprocessing.R
- R/01b-credential-preprocessing.R
- R/01c-credential-analysis.R
- R/01d-enrolment-analysis.R
- R/01e-stp-distributions.R

Module 02 — program matching and cohorts:
- R/02a-appso-programs.R
- R/02a-bgs-program-matching.R
- R/02a-dacso-program-matching.R
- R/02a-update-cred-non-dup.R
- R/02b-1-pssm-cohorts.R
- R/02b-2-pssm-cohorts-new-labour-supply.R
- R/02b-3-pssm-cohorts-occupation-distributions.R

Depends on: #<PR3> (utils — read_table_from_db, lower_col_names_global, logging).
Independent of the other PR4 sub-PRs.
