### PR TITLE
style: air formatting baseline (R/SQL)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,11 @@
 {
-  "mayank1513.trello-kanban.Workspace.filePath": ".tkb"
+  "mayank1513.trello-kanban.Workspace.filePath": ".tkb",
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
 }

--- a/R/01a-enrolment-preprocessing.R
+++ b/R/01a-enrolment-preprocessing.R
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-library(tidyverse)
-library(odbc)
-library(DBI)
-library(futile.logger)
+pacman::p_load(
+  tidyverse,
+  odbc,
+  DBI,
+  futile.logger
+)
+
 
 ## -------------------------- Logging Setup -------------------------------------------------------
 ## -----------------------------------------------------------------------------------------------
@@ -31,7 +34,7 @@ log_info("==== 01a-enrolment-preprocessing.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
-db_config <- config::get("decimal")
+db_config <- config::get("decimal2026")
 my_schema <- config::get("myschema")
 
 con <- dbConnect(
@@ -53,7 +56,7 @@ stp_enrolment <- dbGetQuery(
   con,
   glue::glue(
     "SELECT
-    ID,
+    /*ID,*/
     ENCRYPTED_TRUE_PEN,
     ATTENDING_PSI_OUTSIDE_BC,
     PSI_CIP_CODE,
@@ -74,7 +77,7 @@ stp_enrolment <- dbGetQuery(
     PSI_VISA_STATUS,
     PSI_BIRTHDATE,
     LAST_SEEN_BIRTHDATE
-  FROM [{my_schema}].[STP_Enrolment];"
+  FROM [STP_Enrolment_2024];"
   )
 )
 log_info(glue::glue(
@@ -102,7 +105,7 @@ distinct_pen_count <- stp_enrolment |> distinct(ENCRYPTED_TRUE_PEN) |> nrow()
 log_info(glue::glue("Distinct ENCRYPTED_TRUE_PEN values: {distinct_pen_count}"))
 
 # Untoggle when running new data and/or add a conditional to test for the presence of the ID field.
-# stp_enrolment <- stp_enrolment |> mutate(ID = row_number())
+stp_enrolment <- stp_enrolment |> mutate(ID = row_number())
 
 ## --------------------------------------Reformat yy-mm-dd to yyyy-mm-dd---------------------------
 ## reference: source("./sql/01-enrolment-preprocessing/convert-date-scripts.R")

--- a/R/01a-enrolment-preprocessing.R
+++ b/R/01a-enrolment-preprocessing.R
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-pacman::p_load(
-  tidyverse,
-  odbc,
-  DBI,
-  futile.logger
-)
+library(tidyverse)
+library(odbc)
+library(DBI)
+library(futile.logger)
 
 
 ## -------------------------- Logging Setup -------------------------------------------------------

--- a/R/01b-credential-preprocessing.R
+++ b/R/01b-credential-preprocessing.R
@@ -55,7 +55,7 @@ stp_credential <- dbGetQuery(
     'SELECT
     CREDENTIAL_AWARD_DATE,
     ENCRYPTED_TRUE_PEN,
-    ID,
+    /*ID,*/
     PSI_CODE,
     PSI_CREDENTIAL_CATEGORY,
     PSI_CREDENTIAL_CIP,
@@ -67,7 +67,7 @@ stp_credential <- dbGetQuery(
     PSI_PROGRAM_EFFECTIVE_DATE,
     PSI_SCHOOL_YEAR,
     PSI_STUDENT_NUMBER
-  FROM "{my_schema}"."STP_Credential"'
+  FROM "STP_Credential_2024"'
   )
 )
 log_info(glue::glue(
@@ -116,9 +116,9 @@ distinct_pen_count <- stp_credential |> distinct(ENCRYPTED_TRUE_PEN) |> nrow()
 log_info(glue::glue("Distinct ENCRYPTED_TRUE_PEN values: {distinct_pen_count}"))
 
 # Untoggle when running new data and/or add a conditional to test for the presence of the ID field.
-# stp_credential <- stp_credential |>
-#   mutate(ID = row_number()) |>
-#   relocate(ID, .before = CREDENTIAL_AWARD_DATE)
+stp_credential <- stp_credential |>
+  mutate(ID = row_number()) |>
+  relocate(ID, .before = CREDENTIAL_AWARD_DATE)
 
 # ---- Reformat yy-mm-dd to yyyy-mm-dd ----
 date_cols <- c(

--- a/R/load-outcomes-data.R
+++ b/R/load-outcomes-data.R
@@ -55,7 +55,7 @@ decimal_con <- dbConnect(
 )
 # make sure vpn is on, and the lan is available. Or switch to safepath approach.
 use_schema <- config::get("myschema")
-lan = config::get("lan")
+lan <- config::get("lan")
 so_lan_path <- glue::glue("{lan}/data/student-outcomes/csv/so-provision/")
 
 # read csv's into objects in memory.
@@ -106,7 +106,7 @@ APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB <- as.numeric(
   APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB
 )
 
-BGS_Q001_BGS_Data_2019_2023$PEN = as.character(BGS_Q001_BGS_Data_2019_2023$PEN)
+BGS_Q001_BGS_Data_2019_2023$PEN <- as.character(BGS_Q001_BGS_Data_2019_2023$PEN)
 
 DACSO_Q003_DACSO_DATA_Part_1_stepA <- DACSO_Q003_DACSO_DATA_Part_1_stepA %>%
   mutate(across(.cols = c(TPID_LGND_CD, COCI_PEN), .fns = as.character))

--- a/R/noc-imputation.R
+++ b/R/noc-imputation.R
@@ -10,17 +10,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-
 # ---- Target summary table ----
 # Note that there is suppression even here compared to total Age, Field of Study
 all_occupations_summary <- data %>%
-  filter(occupation_NOC=="All occupations") %>%
-  group_by(age_group,major_field_cip) %>%
-  summarize(All_Occs_Above_Bach=sum(!!rlang::sym(above_bach_var)),
-            All_Occs_PDEG=sum(!!rlang::sym(pdeg_var)),
-            All_Occs_Combined=sum(!!rlang::sym(combined_masters_doctorate_var)),
-            All_Occs_Masters=sum(!!rlang::sym(masters_var)),
-            All_Occs_Doctorate=sum(!!rlang::sym(doctorate_var)))
+  filter(occupation_NOC == "All occupations") %>%
+  group_by(age_group, major_field_cip) %>%
+  summarize(
+    All_Occs_Above_Bach = sum(!!rlang::sym(above_bach_var)),
+    All_Occs_PDEG = sum(!!rlang::sym(pdeg_var)),
+    All_Occs_Combined = sum(!!rlang::sym(combined_masters_doctorate_var)),
+    All_Occs_Masters = sum(!!rlang::sym(masters_var)),
+    All_Occs_Doctorate = sum(!!rlang::sym(doctorate_var))
+  )
 
 # Parse NOC codes ----
 # NOC 2021 codes are now 5-digits (compared to 4-digits for prior NOC 2016)
@@ -30,32 +31,60 @@ all_occupations_summary <- data %>%
 # [3] "All occupations"
 
 data_working <- data %>%
-  mutate(NOC_1 = ifelse(str_detect(occupation_NOC,"^\\d{1,5} "),str_sub(occupation_NOC,1,1),NA),
-         NOC_2 = ifelse(str_detect(occupation_NOC,"^\\d{2,5} "),str_sub(occupation_NOC,1,2),NA),
-         NOC_3 = ifelse(str_detect(occupation_NOC,"^\\d{3,5} "),str_sub(occupation_NOC,1,3),NA),
-         NOC_4 = ifelse(str_detect(occupation_NOC,"^\\d{4,5} "),str_sub(occupation_NOC,1,4),NA),
-         NOC_5 = ifelse(str_detect(occupation_NOC,"^\\d{5} "),str_sub(occupation_NOC,1,5),NA)) %>%
-  filter(!(is.na(NOC_1) & is.na(NOC_2) & is.na(NOC_3) & is.na(NOC_4) & is.na(NOC_5)))
+  mutate(
+    NOC_1 = ifelse(
+      str_detect(occupation_NOC, "^\\d{1,5} "),
+      str_sub(occupation_NOC, 1, 1),
+      NA
+    ),
+    NOC_2 = ifelse(
+      str_detect(occupation_NOC, "^\\d{2,5} "),
+      str_sub(occupation_NOC, 1, 2),
+      NA
+    ),
+    NOC_3 = ifelse(
+      str_detect(occupation_NOC, "^\\d{3,5} "),
+      str_sub(occupation_NOC, 1, 3),
+      NA
+    ),
+    NOC_4 = ifelse(
+      str_detect(occupation_NOC, "^\\d{4,5} "),
+      str_sub(occupation_NOC, 1, 4),
+      NA
+    ),
+    NOC_5 = ifelse(
+      str_detect(occupation_NOC, "^\\d{5} "),
+      str_sub(occupation_NOC, 1, 5),
+      NA
+    )
+  ) %>%
+  filter(
+    !(is.na(NOC_1) & is.na(NOC_2) & is.na(NOC_3) & is.na(NOC_4) & is.na(NOC_5))
+  )
 
 # Summary table by 4D NOC ----
 NOC_4_summary <- data_working %>%
   filter(!is.na(NOC_4) & is.na(NOC_5)) %>%
-  group_by(age_group,major_field_cip) %>%
-  summarize(NOC4_Above_Bach=sum(!!rlang::sym(above_bach_var)),
-            NOC4_PDEG=sum(!!rlang::sym(pdeg_var)),
-            NOC4_Combined=sum(!!rlang::sym(combined_masters_doctorate_var)),
-            NOC4_Masters=sum(!!rlang::sym(masters_var)),
-            NOC4_Doctorate=sum(!!rlang::sym(doctorate_var)))
+  group_by(age_group, major_field_cip) %>%
+  summarize(
+    NOC4_Above_Bach = sum(!!rlang::sym(above_bach_var)),
+    NOC4_PDEG = sum(!!rlang::sym(pdeg_var)),
+    NOC4_Combined = sum(!!rlang::sym(combined_masters_doctorate_var)),
+    NOC4_Masters = sum(!!rlang::sym(masters_var)),
+    NOC4_Doctorate = sum(!!rlang::sym(doctorate_var))
+  )
 
 # Summary table by 5D NOC ----
 NOC_5_summary_1 <- data_working %>%
   filter(!is.na(NOC_5)) %>%
-  group_by(age_group,major_field_cip) %>%
-  summarize(NOC5_Above_Bach=sum(!!rlang::sym(above_bach_var)),
-            NOC5_PDEG=sum(!!rlang::sym(pdeg_var)),
-            NOC5_Combined=sum(!!rlang::sym(combined_masters_doctorate_var)),
-            NOC5_Masters=sum(!!rlang::sym(masters_var)),
-            NOC5_Doctorate=sum(!!rlang::sym(doctorate_var)))
+  group_by(age_group, major_field_cip) %>%
+  summarize(
+    NOC5_Above_Bach = sum(!!rlang::sym(above_bach_var)),
+    NOC5_PDEG = sum(!!rlang::sym(pdeg_var)),
+    NOC5_Combined = sum(!!rlang::sym(combined_masters_doctorate_var)),
+    NOC5_Masters = sum(!!rlang::sym(masters_var)),
+    NOC5_Doctorate = sum(!!rlang::sym(doctorate_var))
+  )
 
 
 # Impute NOC 5 counts ----
@@ -66,23 +95,46 @@ NOC_5_summary_1 <- data_working %>%
 
 NOC_4 <- data_working %>%
   filter(!is.na(NOC_4) & is.na(NOC_5)) %>%
-  select(-NOC_1,-NOC_2,-NOC_3,-NOC_5) %>%
-  rename(NOC4_Total:=!!total_var,
-         NOC4_Above_Bach:=!!above_bach_var,
-         NOC4_PDEG:=!!pdeg_var,
-         NOC4_Combined:=!!combined_masters_doctorate_var,
-         NOC4_Masters:=!!masters_var,
-         NOC4_Doctorate:=!!doctorate_var) %>%
-  select(age_group,major_field_cip,NOC_4,NOC4_Total,NOC4_Above_Bach,NOC4_PDEG,NOC4_Masters,NOC4_Doctorate,NOC4_Combined)
+  select(-NOC_1, -NOC_2, -NOC_3, -NOC_5) %>%
+  rename(
+    NOC4_Total := !!total_var,
+    NOC4_Above_Bach := !!above_bach_var,
+    NOC4_PDEG := !!pdeg_var,
+    NOC4_Combined := !!combined_masters_doctorate_var,
+    NOC4_Masters := !!masters_var,
+    NOC4_Doctorate := !!doctorate_var
+  ) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC4_Total,
+    NOC4_Above_Bach,
+    NOC4_PDEG,
+    NOC4_Masters,
+    NOC4_Doctorate,
+    NOC4_Combined
+  )
 
 data_fill_by_noc <- data_working %>%
   filter(!is.na(NOC_5)) %>%
-  select(age_group,major_field_cip,NOC_4,NOC_5, occupation_NOC,
-         Total:=!!total_var, !!rlang::sym(above_bach_var),!!rlang::sym(pdeg_var),!!rlang::sym(masters_var),!!rlang::sym(doctorate_var),Combined:=!!combined_masters_doctorate_var) %>%
-  left_join(NOC_4, by=c("age_group","major_field_cip","NOC_4"))
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    Total := !!total_var,
+    !!rlang::sym(above_bach_var),
+    !!rlang::sym(pdeg_var),
+    !!rlang::sym(masters_var),
+    !!rlang::sym(doctorate_var),
+    Combined := !!combined_masters_doctorate_var
+  ) %>%
+  left_join(NOC_4, by = c("age_group", "major_field_cip", "NOC_4"))
 
 data_fill_by_noc_list <- data_fill_by_noc %>%
-  group_by(age_group,major_field_cip,NOC_4) %>%
+  group_by(age_group, major_field_cip, NOC_4) %>%
   nest()
 
 ## Quick look at number of 4D NOC codes, where 5D sum to more/less than 4D NOC totals
@@ -96,7 +148,13 @@ data_fill_by_noc_list <- data_fill_by_noc %>%
 #   summarize(Count_under=sum(Under),Count_over=sum(Over),Count_even=sum(Even))
 
 # Function for filling in 5D NOCs
-fill_missing_by_NOC <- function(data,col_to_fill,col_total,filler_col,filler_total) {
+fill_missing_by_NOC <- function(
+  data,
+  col_to_fill,
+  col_total,
+  filler_col,
+  filler_total
+) {
   # Create new overall total column as the Total NOC4 count - the NOC5 counts where the credential count is not missing
   ## Sometimes this can result in a negative number due to Census rounding -> To handle this, take the max between the new overall total and 0
   # similarly, create new credential total
@@ -109,97 +167,188 @@ fill_missing_by_NOC <- function(data,col_to_fill,col_total,filler_col,filler_tot
     sum(data = df$Total)
   }
 
-
   data %>%
-    rename(Credential=!!col_to_fill,Cred_Total=!!col_total,Total=!!filler_col,Total_Total=!!filler_total) %>%
+    rename(
+      Credential = !!col_to_fill,
+      Cred_Total = !!col_total,
+      Total = !!filler_col,
+      Total_Total = !!filler_total
+    ) %>%
     nest() %>%
-    mutate(Sum_Total=map_dbl(data,get_Sum_Total)) %>%
+    mutate(Sum_Total = map_dbl(data, get_Sum_Total)) %>%
     unnest_legacy() %>%
-    mutate(New_Total_Total=max(Sum_Total-sum(ifelse(Credential==0,0,Total)),0),
-           New_Cred_Total=max(Cred_Total-sum(Credential),0),
-           New_Credential=ifelse(Credential==0,
-                                 ifelse(New_Total_Total == 0,
-                                        0,
-                                        ifelse(Total > New_Total_Total,
-                                               New_Cred_Total,
-                                               New_Cred_Total*Total/New_Total_Total)),
-                                 Credential))
+    mutate(
+      New_Total_Total = max(
+        Sum_Total - sum(ifelse(Credential == 0, 0, Total)),
+        0
+      ),
+      New_Cred_Total = max(Cred_Total - sum(Credential), 0),
+      New_Credential = ifelse(
+        Credential == 0,
+        ifelse(
+          New_Total_Total == 0,
+          0,
+          ifelse(
+            Total > New_Total_Total,
+            New_Cred_Total,
+            New_Cred_Total * Total / New_Total_Total
+          )
+        ),
+        Credential
+      )
+    )
 }
 
 # ** University certificate or diploma above bachelor level ----
-above_bach <- map_dfr(seq(1:nrow(data_fill_by_noc_list)), ~ fill_missing_by_NOC(unnest_legacy(data_fill_by_noc_list[.x,]),
-                                                                                col_to_fill=above_bach_var,
-                                                                                col_total="NOC4_Above_Bach",
-                                                                                filler_col="Total",
-                                                                                filler_total="NOC4_Total")) %>%
-  select(age_group,major_field_cip, NOC_4, NOC_5, occupation_NOC, New_Above_Bach=New_Credential)
+above_bach <- map_dfr(
+  seq(1:nrow(data_fill_by_noc_list)),
+  ~ fill_missing_by_NOC(
+    unnest_legacy(data_fill_by_noc_list[.x, ]),
+    col_to_fill = above_bach_var,
+    col_total = "NOC4_Above_Bach",
+    filler_col = "Total",
+    filler_total = "NOC4_Total"
+  )
+) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    New_Above_Bach = New_Credential
+  )
 
 # ** Degree in medicine, dentistry, veterinary medicine or optometry ----
-pdeg <- map_dfr(seq(1:nrow(data_fill_by_noc_list)), ~ fill_missing_by_NOC(unnest_legacy(data_fill_by_noc_list[.x,]),
-                                                                          col_to_fill=pdeg_var,
-                                                                          col_total="NOC4_PDEG",
-                                                                          filler_col="Total",
-                                                                          filler_total="NOC4_Total")) %>%
-  select(age_group,major_field_cip, NOC_4, NOC_5, occupation_NOC, New_PDEG=New_Credential)
+pdeg <- map_dfr(
+  seq(1:nrow(data_fill_by_noc_list)),
+  ~ fill_missing_by_NOC(
+    unnest_legacy(data_fill_by_noc_list[.x, ]),
+    col_to_fill = pdeg_var,
+    col_total = "NOC4_PDEG",
+    filler_col = "Total",
+    filler_total = "NOC4_Total"
+  )
+) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    New_PDEG = New_Credential
+  )
 
 # ** Master's ----
-masters <- map_dfr(seq(1:nrow(data_fill_by_noc_list)), ~ fill_missing_by_NOC(unnest_legacy(data_fill_by_noc_list[.x,]),
-                                                                             col_to_fill=masters_var,
-                                                                             col_total="NOC4_Masters",
-                                                                             filler_col="Total",
-                                                                             filler_total="NOC4_Total")) %>%
-  select(age_group,major_field_cip, NOC_4, NOC_5, occupation_NOC, New_Masters=New_Credential)
+masters <- map_dfr(
+  seq(1:nrow(data_fill_by_noc_list)),
+  ~ fill_missing_by_NOC(
+    unnest_legacy(data_fill_by_noc_list[.x, ]),
+    col_to_fill = masters_var,
+    col_total = "NOC4_Masters",
+    filler_col = "Total",
+    filler_total = "NOC4_Total"
+  )
+) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    New_Masters = New_Credential
+  )
 
 # ** Doctorate ----
-doctorate <- map_dfr(seq(1:nrow(data_fill_by_noc_list)), ~ fill_missing_by_NOC(unnest_legacy(data_fill_by_noc_list[.x,]),
-                                                                               col_to_fill=doctorate_var,
-                                                                               col_total="NOC4_Doctorate",
-                                                                               filler_col="Total",
-                                                                               filler_total="NOC4_Total")) %>%
-  select(age_group,major_field_cip, NOC_4, NOC_5, occupation_NOC, New_Doctorate=New_Credential)
+doctorate <- map_dfr(
+  seq(1:nrow(data_fill_by_noc_list)),
+  ~ fill_missing_by_NOC(
+    unnest_legacy(data_fill_by_noc_list[.x, ]),
+    col_to_fill = doctorate_var,
+    col_total = "NOC4_Doctorate",
+    filler_col = "Total",
+    filler_total = "NOC4_Total"
+  )
+) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    New_Doctorate = New_Credential
+  )
 
 # ** Combined ----
-combined <- map_dfr(seq(1:nrow(data_fill_by_noc_list)), ~ fill_missing_by_NOC(unnest_legacy(data_fill_by_noc_list[.x,]),
-                                                                              col_to_fill="Combined",
-                                                                              col_total="NOC4_Combined",
-                                                                              filler_col="Total",
-                                                                              filler_total="NOC4_Total")) %>%
-  select(age_group,major_field_cip, NOC_4, NOC_5, occupation_NOC, New_Combined=New_Credential)
+combined <- map_dfr(
+  seq(1:nrow(data_fill_by_noc_list)),
+  ~ fill_missing_by_NOC(
+    unnest_legacy(data_fill_by_noc_list[.x, ]),
+    col_to_fill = "Combined",
+    col_total = "NOC4_Combined",
+    filler_col = "Total",
+    filler_total = "NOC4_Total"
+  )
+) %>%
+  select(
+    age_group,
+    major_field_cip,
+    NOC_4,
+    NOC_5,
+    occupation_NOC,
+    New_Combined = New_Credential
+  )
 
 # ** Join new counts ----
-new_noc_counts <- left_join(above_bach,pdeg,by=c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")) %>%
-  left_join(combined,by=c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")) %>%
-  left_join(masters,by=c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")) %>%
-  left_join(doctorate,by=c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC"))
+new_noc_counts <- left_join(
+  above_bach,
+  pdeg,
+  by = c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")
+) %>%
+  left_join(
+    combined,
+    by = c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")
+  ) %>%
+  left_join(
+    masters,
+    by = c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")
+  ) %>%
+  left_join(
+    doctorate,
+    by = c("age_group", "major_field_cip", "NOC_4", "NOC_5", "occupation_NOC")
+  )
 
 
 print("num of NEW NOC4 Masters != 0")
-new_noc_counts %>% filter(New_Masters!=0) %>% tally() %>% pull(n) %>% print()
+new_noc_counts %>% filter(New_Masters != 0) %>% tally() %>% pull(n) %>% print()
 
 # New Summary table by 5D NOC ----
 NOC_5_summary_2 <- new_noc_counts %>%
-  group_by(age_group,major_field_cip) %>%
-  summarize(NEW_NOC4_Above_Bach=sum(New_Above_Bach),
-            NEW_NOC4_PDEG=sum(New_PDEG),
-            NEW_NOC4_Combined=sum(New_Combined),
-            NEW_NOC4_Masters=sum(New_Masters),
-            NEW_NOC4_Doctorate=sum(New_Doctorate))
+  group_by(age_group, major_field_cip) %>%
+  summarize(
+    NEW_NOC4_Above_Bach = sum(New_Above_Bach),
+    NEW_NOC4_PDEG = sum(New_PDEG),
+    NEW_NOC4_Combined = sum(New_Combined),
+    NEW_NOC4_Masters = sum(New_Masters),
+    NEW_NOC4_Doctorate = sum(New_Doctorate)
+  )
 
 # Combine summary tables ----
 compare_summaries <- all_occupations_summary %>%
-  left_join(NOC_4_summary,by=c("age_group","major_field_cip")) %>%
-  left_join(NOC_5_summary_1,by=c("age_group","major_field_cip")) %>%
-  left_join(NOC_5_summary_2,by=c("age_group","major_field_cip"))
+  left_join(NOC_4_summary, by = c("age_group", "major_field_cip")) %>%
+  left_join(NOC_5_summary_1, by = c("age_group", "major_field_cip")) %>%
+  left_join(NOC_5_summary_2, by = c("age_group", "major_field_cip"))
 
 # add total row
 compare_summaries <- compare_summaries %>%
-  bind_rows(compare_summaries %>%
-              ungroup() %>%
-              select(-age_group,-major_field_cip) %>%
-              summarize_all(sum) %>%
-              mutate(age_group="Total", major_field_cip="Total"))
+  bind_rows(
+    compare_summaries %>%
+      ungroup() %>%
+      select(-age_group, -major_field_cip) %>%
+      summarize_all(sum) %>%
+      mutate(age_group = "Total", major_field_cip = "Total")
+  )
 
 # Save files ----
-write_csv(new_noc_counts,newcounts_fn)
-write_csv(compare_summaries,summary_fn)
-
+write_csv(new_noc_counts, newcounts_fn)
+write_csv(compare_summaries, summary_fn)

--- a/R/prep-for-ptib-run.R
+++ b/R/prep-for-ptib-run.R
@@ -1,5 +1,5 @@
 # ******************************************************************************
-# After running the regular and QI model runs, prep for ptib run.  
+# After running the regular and QI model runs, prep for ptib run.
 # ******************************************************************************
 # rm(list = ls())
 library(tidyverse)
@@ -13,15 +13,17 @@ db_config <- config::get("decimal")
 my_schema <- config::get("myschema")
 # ---- Connection to decimal ----
 db_config <- config::get("decimal")
-decimal_con <- dbConnect(odbc::odbc(),
-                 Driver = db_config$driver,
-                 Server = db_config$server,
-                 Database = db_config$database,
-                 Trusted_Connection = "True")
+decimal_con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 # initiate flags
-regular_run <-  F
+regular_run <- F
 qi_run <- F
-ptib_run <-  T
+ptib_run <- T
 
 
 # ---- Required tables ----
@@ -41,7 +43,7 @@ required_tables <- c(
 for (table_name in required_tables) {
   # Build SQL statement
   full_table_name <- SQL(glue::glue('"{my_schema}"."{table_name}"'))
-  
+
   # Assert that the table exists in the database
   assert_that(
     dbExistsTable(decimal_con, full_table_name),
@@ -51,30 +53,125 @@ for (table_name in required_tables) {
 
 
 # ---- Clean environment ----
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_BGS_Data_Final', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_BGS_Data_Final];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_Cohorts_Recoded', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_Cohorts_Recoded];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.t_dacso_data_part_1_stepa', 'U') IS NOT NULL DROP TABLE [{my_schema}].[t_dacso_data_part_1_stepa];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.t_dacso_data_part_1', 'U') IS NOT NULL DROP TABLE [{my_schema}].[t_dacso_data_part_1];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.infoware_c_outc_clean_short_resp', 'U') IS NOT NULL DROP TABLE [{my_schema}].[infoware_c_outc_clean_short_resp];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_TRD_DATA', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_TRD_DATA];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.TRD_Graduates', 'U') IS NOT NULL DROP TABLE [{my_schema}].[TRD_Graduates];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.Credential_Non_Dup', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Credential_Non_Dup];"))  # why not we remove it but load it at the begginning
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioAgeAtGradCIP4', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioAgeAtGradCIP4];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioByGender', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioByGender];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioByGender_year', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioByGender_year];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN_history', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN_history];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.population_projections', 'U') IS NOT NULL DROP TABLE [{my_schema}].[population_projections];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.tbl_Program_Projection_Input', 'U') IS NOT NULL DROP TABLE [{my_schema}].[tbl_Program_Projection_Input];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.Cohort_Program_Distributions_Projected', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Cohort_Program_Distributions_Projected];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_PSSM_Credential_Grouping_Appendix', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_PSSM_Credential_Grouping_Appendix];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.T_LCP2_LCP4', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_LCP2_LCP4];"))
-dbExecute(decimal_con, glue::glue("IF OBJECT_ID('{my_schema}.Cohort_Program_Distributions', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Cohort_Program_Distributions];"))
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_BGS_Data_Final', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_BGS_Data_Final];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_Cohorts_Recoded', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_Cohorts_Recoded];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.t_dacso_data_part_1_stepa', 'U') IS NOT NULL DROP TABLE [{my_schema}].[t_dacso_data_part_1_stepa];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.t_dacso_data_part_1', 'U') IS NOT NULL DROP TABLE [{my_schema}].[t_dacso_data_part_1];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.infoware_c_outc_clean_short_resp', 'U') IS NOT NULL DROP TABLE [{my_schema}].[infoware_c_outc_clean_short_resp];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_TRD_DATA', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_TRD_DATA];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.TRD_Graduates', 'U') IS NOT NULL DROP TABLE [{my_schema}].[TRD_Graduates];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.Credential_Non_Dup', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Credential_Non_Dup];"
+  )
+) # why not we remove it but load it at the begginning
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioAgeAtGradCIP4', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioAgeAtGradCIP4];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioByGender', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioByGender];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatioByGender_year', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatioByGender_year];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN_history', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN_history];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.population_projections', 'U') IS NOT NULL DROP TABLE [{my_schema}].[population_projections];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.tbl_Program_Projection_Input', 'U') IS NOT NULL DROP TABLE [{my_schema}].[tbl_Program_Projection_Input];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.Cohort_Program_Distributions_Projected', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Cohort_Program_Distributions_Projected];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_PSSM_Credential_Grouping_Appendix', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_PSSM_Credential_Grouping_Appendix];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.T_LCP2_LCP4', 'U') IS NOT NULL DROP TABLE [{my_schema}].[T_LCP2_LCP4];"
+  )
+)
+dbExecute(
+  decimal_con,
+  glue::glue(
+    "IF OBJECT_ID('{my_schema}.Cohort_Program_Distributions', 'U') IS NOT NULL DROP TABLE [{my_schema}].[Cohort_Program_Distributions];"
+  )
+)
 
 
 # ----  Copy tables required for re-run ----
 # copy those tables. those tables (Credential_Non_Dup) are changed during the steps so it needs to copy again from scratch.
-copy_tables = c(
+copy_tables <- c(
   # '[dbo]."T_bgs_data_final_for_outcomesmatching"',
   # '[IDIR\\ALOWERY]."Labour_Supply_Distribution_Stat_Can"',
   # '[IDIR\\ALOWERY]."Occupation_Distributions_Stat_Can"',
@@ -82,45 +179,52 @@ copy_tables = c(
 )
 
 dbBegin(decimal_con)
-tryCatch({
-  for (table in copy_tables) {
-    # Extract the part after the dot
-    table_short <- str_extract(table, '(?<=\\.)"[^"]+"') %>% str_remove_all("\"")
-    # must have the SQL to make dbExistsTable work
-    # Some tables will be changed by the code so it is better to recreate them.
-    # if (!dbExistsTable(decimal_con, SQL(glue::glue("{my_schema}.{table_short}")))){
-    drop_statement <- glue::glue(
-      "IF OBJECT_ID('{my_schema}.{table_short}', 'U') IS NOT NULL
+tryCatch(
+  {
+    for (table in copy_tables) {
+      # Extract the part after the dot
+      table_short <- str_extract(table, '(?<=\\.)"[^"]+"') %>%
+        str_remove_all("\"")
+      # must have the SQL to make dbExistsTable work
+      # Some tables will be changed by the code so it is better to recreate them.
+      # if (!dbExistsTable(decimal_con, SQL(glue::glue("{my_schema}.{table_short}")))){
+      drop_statement <- glue::glue(
+        "IF OBJECT_ID('{my_schema}.{table_short}', 'U') IS NOT NULL
     DROP TABLE [{my_schema}].[{table_short}];"
-    )
-    dbExecute(decimal_con, drop_statement)
-    
-    # -- Create the table by copying data into it
-    copy_statement <- glue::glue('SELECT *
-               INTO [{my_schema}].{table_short}
-               FROM {table};')
-    dbExecute(decimal_con, copy_statement)
-    # }
-    
-  }
-  dbCommit(decimal_con)  # Commit transaction if all deletions succeed
-  print("All tables copied successfully.")
-}, error = function(e) {
-  dbRollback(decimal_con)  # Rollback if there's an error
-  print(paste("Error:", e$message))
-}, finally = {
-  dbDisconnect(decimal_con)
-})
+      )
+      dbExecute(decimal_con, drop_statement)
 
-decimal_con <- dbConnect(odbc::odbc(),
-                         Driver = db_config$driver,
-                         Server = db_config$server,
-                         Database = db_config$database,
-                         Trusted_Connection = "True")
+      # -- Create the table by copying data into it
+      copy_statement <- glue::glue(
+        'SELECT *
+               INTO [{my_schema}].{table_short}
+               FROM {table};'
+      )
+      dbExecute(decimal_con, copy_statement)
+      # }
+    }
+    dbCommit(decimal_con) # Commit transaction if all deletions succeed
+    print("All tables copied successfully.")
+  },
+  error = function(e) {
+    dbRollback(decimal_con) # Rollback if there's an error
+    print(paste("Error:", e$message))
+  },
+  finally = {
+    dbDisconnect(decimal_con)
+  }
+)
+
+decimal_con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 
 # ---- 5. re-run step by step ----
-
 
 # List of R file paths
 ptib_run_files <- c(
@@ -145,8 +249,7 @@ ptib_run_files <- c(
 
 
 print(glue::glue("ptib model run flag: {ptib_run}"))
-if (regular_run != T & qi_run != T & ptib_run ==T ) {
-  
+if (regular_run != T & qi_run != T & ptib_run == T) {
   # Loop through each file, calling time_execution for each
   for (file_path in ptib_run_files) {
     print(glue::glue("regular model run flag: {regular_run}"))
@@ -154,8 +257,7 @@ if (regular_run != T & qi_run != T & ptib_run ==T ) {
     print(glue::glue("ptib model furn flag: {ptib_run}"))
     time_execution(file_path)
   }
-  
-} 
+}
 
 
 # ---- Disconnect ----

--- a/R/run-imputation-by-region.R
+++ b/R/run-imputation-by-region.R
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 # ******************************************************************************
-# Graduate NOC imputations on Stat Can data  
+# Graduate NOC imputations on Stat Can data
 # ******************************************************************************
 
 # ---- libraries and global variables
@@ -23,11 +23,13 @@ library(janitor)
 
 # ----- Connection to decimal ----
 db_config <- config::get("decimal")
-con <- dbConnect(odbc(),
-                 Driver = db_config$driver,
-                 Server = db_config$server,
-                 Database = db_config$database,
-                 Trusted_Connection = "True")
+con <- dbConnect(
+  odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 my_schema <- config::get("myschema")
 
@@ -37,7 +39,10 @@ my_schema <- config::get("myschema")
 dbExistsTable(con, SQL(glue::glue('"{my_schema}"."STAT_CAN"')))
 
 # ---- Read from decimal ----
-stat_can_data_raw <- dbReadTable(con, SQL(glue::glue('"{my_schema}"."STAT_CAN"')))
+stat_can_data_raw <- dbReadTable(
+  con,
+  SQL(glue::glue('"{my_schema}"."STAT_CAN"'))
+)
 
 # ---- Disconnect ----
 dbDisconnect(con)
@@ -49,28 +54,51 @@ stat_can_data_raw %>% count(geography)
 # create region variable based off geography
 # note formatting/naming can change within stat can data; review below (order important)
 stat_can_data <- stat_can_data_raw %>%
-  mutate(region=case_when(str_detect(geography,"Canada") ~ "Canada",
-                          str_detect(geography,"BC excluding") ~ "BC excluding Vancouver Island Coast and Lower Mainland",
-                          str_detect(geography,"Vancouver Island and Coast") ~ "Vancouver Island and Coast",
-                          str_detect(geography,"Lower Mainland") ~ "Lower Mainland - Southwest",
-                          (str_detect(geography,"Thompson") & str_detect(geography,"Okanagan and Kootenay")) ~ "Thompson - Okanagan and Kootenay",
-                          (str_detect(geography,"Thompson") & str_detect(geography,"Okanagan")) ~ "Thompson - Okanagan",
-                          str_detect(geography,"Cariboo") ~ "Cariboo",
-                          str_detect(geography,"North Coast, Nechako and Northeast") ~ "North Coast - Nechako and Northeast",
-                          str_detect(geography,"North Coast, Nechako") ~ "North Coast and Nechako",
-                          str_detect(geography,"British Columbia") ~ "British Columbia",
-                          str_detect(geography,"Kootenay") ~ "Kootenay",
-                          TRUE ~ "missing"))
+  mutate(
+    region = case_when(
+      str_detect(geography, "Canada") ~ "Canada",
+      str_detect(
+        geography,
+        "BC excluding"
+      ) ~ "BC excluding Vancouver Island Coast and Lower Mainland",
+      str_detect(
+        geography,
+        "Vancouver Island and Coast"
+      ) ~ "Vancouver Island and Coast",
+      str_detect(geography, "Lower Mainland") ~ "Lower Mainland - Southwest",
+      (str_detect(geography, "Thompson") &
+        str_detect(
+          geography,
+          "Okanagan and Kootenay"
+        )) ~ "Thompson - Okanagan and Kootenay",
+      (str_detect(geography, "Thompson") &
+        str_detect(geography, "Okanagan")) ~ "Thompson - Okanagan",
+      str_detect(geography, "Cariboo") ~ "Cariboo",
+      str_detect(
+        geography,
+        "North Coast, Nechako and Northeast"
+      ) ~ "North Coast - Nechako and Northeast",
+      str_detect(geography, "North Coast, Nechako") ~ "North Coast and Nechako",
+      str_detect(geography, "British Columbia") ~ "British Columbia",
+      str_detect(geography, "Kootenay") ~ "Kootenay",
+      TRUE ~ "missing"
+    )
+  )
 # check
-stat_can_data %>% filter(region=="missing") # expect 0 rows
-stat_can_data %>% count(region,geography) # review regions
+stat_can_data %>% filter(region == "missing") # expect 0 rows
+stat_can_data %>% count(region, geography) # review regions
 
 # review age groups and major fields total variable names
-stat_can_data %>% count(age_group); stat_can_data %>% count(major_field_cip)
+stat_can_data %>% count(age_group)
+stat_can_data %>% count(major_field_cip)
 
 # filter out totals from age and study fields
 stat_can_data <- stat_can_data %>%
-  filter(age_group != "Total - population 17 to 64 years old" & major_field_cip != "Total - Major Field of study (BC Program Cluster aggregation of CIP 2016)")
+  filter(
+    age_group != "Total - population 17 to 64 years old" &
+      major_field_cip !=
+        "Total - Major Field of study (BC Program Cluster aggregation of CIP 2016)"
+  )
 
 # ---- Declare credential variables of interest ----
 above_bach_var <- "university_certificate_or_diploma_above_bachelor_level"
@@ -84,10 +112,14 @@ total_var <- "total_highest_certificate_diploma_or_degree"
 lan <- config::get("lan")
 regions <- stat_can_data %>% pull(region) %>% unique()
 
-for(i in regions) {
+for (i in regions) {
   print(i)
-  newcounts_fn=glue::glue("{lan}/data/statcan/output/",i," - new counts.csv")
-  summary_fn=glue::glue("{lan}/data/statcan/output/",i," - summary.csv")
-  data <- stat_can_data %>% filter(region==i)
-  source(here::here("R","noc-imputation.R"))
+  newcounts_fn <- glue::glue(
+    "{lan}/data/statcan/output/",
+    i,
+    " - new counts.csv"
+  )
+  summary_fn <- glue::glue("{lan}/data/statcan/output/", i, " - summary.csv")
+  data <- stat_can_data %>% filter(region == i)
+  source(here::here("R", "noc-imputation.R"))
 }

--- a/R/run_all_three_model_runs.r
+++ b/R/run_all_three_model_runs.r
@@ -1,22 +1,21 @@
 # Copyright 2024 Province of British Columbia
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
 # *********************************************************************************
-# 
+#
 # run three model runs
 # clear objects from workspace in the "Environment" page before run this script
 # variable or data only available within each "source" file scope
 # *********************************************************************************
-
 
 library(tidyverse)
 library(RODBC)
@@ -27,7 +26,7 @@ library(RJDBC)
 library(futile.logger)
 source("./R/utils.R") # for time_execution function
 
-# make sure vpn is on, and the lan is available. Or switch to safepath approach. Otherwise, the data loading does not work without error. 
+# make sure vpn is on, and the lan is available. Or switch to safepath approach. Otherwise, the data loading does not work without error.
 
 # Since futile.logger uses a global configuration, it’s best to set up the log file and level outside the time_execution function, especially if you plan to call this function in a loop. This way, the logging configuration applies across all function calls in the loop.
 # Set up logging to a specified file and set the threshold
@@ -44,10 +43,10 @@ flog.threshold(INFO, name = "file_logger")
 # load_data_files <- c(
 #   "./R/load-outcomes-data.R"
 # )
-# 
+#
 # for (rawdata_file_path in load_data_files) {
 #   print(paste(Sys.time(), "Starting:", rawdata_file_path))
-# 
+#
 #   tryCatch({
 #     time_execution(rawdata_file_path)
 #   }, error = function(e) {
@@ -57,7 +56,7 @@ flog.threshold(INFO, name = "file_logger")
 # }
 ###########################################################################################
 
-# every time when we have new data or new parameters, rerun following code. 
+# every time when we have new data or new parameters, rerun following code.
 # List of R file paths
 three_model_run_files <- c(
   "./R/prep-for-fresh-run.R",
@@ -66,7 +65,7 @@ three_model_run_files <- c(
 )
 
 # initiate flags
-regular_run <-  T
+regular_run <- T
 qi_run <- F
 ptib_run <- F
 
@@ -76,22 +75,33 @@ start_time0 <- Sys.time()
 for (file_path0 in three_model_run_files) {
   print(paste(Sys.time(), "Starting:", file_path0))
 
-  tryCatch({
-    time_execution(file_path0)
-  }, error = function(e) {
-    flog.error(paste("Error processing file:", file_path0, "-", e$message), name = "file_logger")
-    stop()
-  })
+  tryCatch(
+    {
+      time_execution(file_path0)
+    },
+    error = function(e) {
+      flog.error(
+        paste("Error processing file:", file_path0, "-", e$message),
+        name = "file_logger"
+      )
+      stop()
+    }
+  )
 }
 # end_time0 <- Sys.time()
 # elapsed0 <- end_time0 - start_time0
 print(paste(Sys.time(), glue::glue("Complete three model runs ......")))
-flog.info(paste(Sys.time(), glue::glue("Complete three model runs ......")), name = "file_logger")
+flog.info(
+  paste(Sys.time(), glue::glue("Complete three model runs ......")),
+  name = "file_logger"
+)
 
 
 # now that all 3 models have run, complete the final step of producing the report
 source(glue::glue("./R/08-create-final-reports.R"))
 
 print(paste(Sys.time(), glue::glue("Excel report created ......")))
-flog.info(paste(Sys.time(), glue::glue("Excel report created ......")), name = "file_logger")
-
+flog.info(
+  paste(Sys.time(), glue::glue("Excel report created ......")),
+  name = "file_logger"
+)

--- a/R/zz-adhoc-outputs-lf.R
+++ b/R/zz-adhoc-outputs-lf.R
@@ -1,4 +1,4 @@
-## this is an ad-hoc file, meant only to fix a couple of expr1s for 5 digit NOCs that were incorrectly coded in a previous iteration 
+## this is an ad-hoc file, meant only to fix a couple of expr1s for 5 digit NOCs that were incorrectly coded in a previous iteration
 
 # ---- Configure LAN and file paths ----
 db_config <- config::get("decimal")
@@ -8,14 +8,16 @@ my_schema <- config::get("myschema")
 
 # ---- Connection to decimal ----
 db_config <- config::get("decimal")
-decimal_con <- dbConnect(odbc::odbc(),
-                         Driver = db_config$driver,
-                         Server = db_config$server,
-                         Database = db_config$database,
-                         Trusted_Connection = "True")
+decimal_con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 
-# model 
+# model
 tmp_model <- tibble(dbGetQuery(
   decimal_con,
   "SELECT *
@@ -23,15 +25,18 @@ tmp_model <- tibble(dbGetQuery(
   "
 ))
 
-tmp_model_fixed <- tmp_model %>% 
+tmp_model_fixed <- tmp_model %>%
   mutate(
-    Expr1 = 
-    case_when(
+    Expr1 = case_when(
       NOC_Level == 5 ~ paste0(
-        Age_Group_Rollup_Label, '-', NOC, '-', Current_Region_PSSM_Code_Rollup
+        Age_Group_Rollup_Label,
+        '-',
+        NOC,
+        '-',
+        Current_Region_PSSM_Code_Rollup
       ),
       TRUE ~ Expr1
-      )
+    )
   )
 
 # check
@@ -43,9 +48,13 @@ tmp_model_fixed %>% count(Expr1) %>% arrange(desc(n))
 tmp_model_fixed %>% count(Expr1) %>% count()
 
 # save
-dbWriteTable(decimal_con,  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_model"'), tmp_model_fixed)
+dbWriteTable(
+  decimal_con,
+  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_model"'),
+  tmp_model_fixed
+)
 
-# QI 
+# QI
 tmp_qi <- tibble(dbGetQuery(
   decimal_con,
   "SELECT *
@@ -53,15 +62,18 @@ tmp_qi <- tibble(dbGetQuery(
   "
 ))
 
-tmp_qi_fixed <- tmp_qi %>% 
+tmp_qi_fixed <- tmp_qi %>%
   mutate(
-    Expr1 = 
-      case_when(
-        NOC_Level == 5 ~ paste0(
-          Age_Group_Rollup_Label, '-', NOC, '-', Current_Region_PSSM_Code_Rollup
-        ),
-        TRUE ~ Expr1
-      )
+    Expr1 = case_when(
+      NOC_Level == 5 ~ paste0(
+        Age_Group_Rollup_Label,
+        '-',
+        NOC,
+        '-',
+        Current_Region_PSSM_Code_Rollup
+      ),
+      TRUE ~ Expr1
+    )
   )
 
 # check
@@ -73,7 +85,11 @@ tmp_qi_fixed %>% count(Expr1) %>% arrange(desc(n))
 tmp_qi_fixed %>% count(Expr1) %>% count()
 
 # save
-dbWriteTable(decimal_con,  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_qi"'), tmp_qi_fixed)
+dbWriteTable(
+  decimal_con,
+  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_qi"'),
+  tmp_qi_fixed
+)
 
 
 # tmp_tbl_Model_Inc_Private_Inst
@@ -84,15 +100,18 @@ tmp_tbl_Model_Inc_Private_Inst <- tibble(dbGetQuery(
   "
 ))
 
-tmp_tbl_Model_Inc_Private_Inst_fixed <- tmp_tbl_Model_Inc_Private_Inst %>% 
+tmp_tbl_Model_Inc_Private_Inst_fixed <- tmp_tbl_Model_Inc_Private_Inst %>%
   mutate(
-    Expr1 = 
-      case_when(
-        NOC_Level == 5 ~ paste0(
-          Age_Group_Rollup_Label, '-', NOC, '-', Current_Region_PSSM_Code_Rollup
-        ),
-        TRUE ~ Expr1
-      )
+    Expr1 = case_when(
+      NOC_Level == 5 ~ paste0(
+        Age_Group_Rollup_Label,
+        '-',
+        NOC,
+        '-',
+        Current_Region_PSSM_Code_Rollup
+      ),
+      TRUE ~ Expr1
+    )
   )
 
 # check
@@ -104,8 +123,11 @@ tmp_tbl_Model_Inc_Private_Inst_fixed %>% count(Expr1) %>% arrange(desc(n))
 tmp_tbl_Model_Inc_Private_Inst_fixed %>% count(Expr1) %>% count()
 
 # save
-dbWriteTable(decimal_con,  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_Model_Inc_Private_Inst"'), tmp_tbl_Model_Inc_Private_Inst_fixed)
-
+dbWriteTable(
+  decimal_con,
+  name = SQL('"IDIR\\LFREDRIC"."tmp_tbl_Model_Inc_Private_Inst"'),
+  tmp_tbl_Model_Inc_Private_Inst_fixed
+)
 
 
 ## create internal table for Brett
@@ -152,4 +174,7 @@ ORDER BY  2, 4, 6
 "
 
 internal <- dbGetQuery(decimal_con, qry)
-internal %>% write_csv(glue::glue("{lan}/development/work/adhoc-outputs/internal-occs-20240926.csv"))
+internal %>%
+  write_csv(glue::glue(
+    "{lan}/development/work/adhoc-outputs/internal-occs-20240926.csv"
+  ))

--- a/R/zz-adhoc-outputs.R
+++ b/R/zz-adhoc-outputs.R
@@ -1,5 +1,5 @@
 # ******************************************************************************
-# This script is for updating adhoc outputs 
+# This script is for updating adhoc outputs
 # ******************************************************************************
 
 # ---- Rollup NOCs ----
@@ -9,43 +9,66 @@ library(tidyverse)
 ## ---- Configure LAN Paths ----
 lan <- config::get("lan")
 folder_path <- glue::glue("{lan}/reports-final/drafts/draft_releases_2021_noc/")
-input_draft_file <- glue::glue(folder_path,"public_release_static_no_ptib.csv")
+input_draft_file <- glue::glue(folder_path, "public_release_static_no_ptib.csv")
 
 ## ---- Read draft data file ----
 draft_data <- read_csv(input_draft_file)
 
 ## ---- Get lookups ----
-T_NOC_Broad_Categories <- 
-  readr::read_csv(glue::glue("{lan}/development/csv/gh-source/lookups/02/T_NOC_Broad_Categories_Updated.csv"), col_types = cols(.default = col_guess())) %>%
+T_NOC_Broad_Categories <-
+  readr::read_csv(
+    glue::glue(
+      "{lan}/development/csv/gh-source/lookups/02/T_NOC_Broad_Categories_Updated.csv"
+    ),
+    col_types = cols(.default = col_guess())
+  ) %>%
   janitor::clean_names(case = "all_caps")
 
 ## ---- Create sub NOCs ----
-data <- draft_data %>% 
-  mutate(NOC_1 = ifelse(NOC=="99998","N/A",str_sub(NOC,1,1)),
-         NOC_2 = ifelse(NOC=="99998","N/A",str_sub(NOC,1,2)),
-         NOC_3 = ifelse(NOC=="99998","N/A",str_sub(NOC,1,3)),
-         NOC_4 = ifelse(NOC=="99998","N/A",str_sub(NOC,1,4))) %>% 
+data <- draft_data %>%
+  mutate(
+    NOC_1 = ifelse(NOC == "99998", "N/A", str_sub(NOC, 1, 1)),
+    NOC_2 = ifelse(NOC == "99998", "N/A", str_sub(NOC, 1, 2)),
+    NOC_3 = ifelse(NOC == "99998", "N/A", str_sub(NOC, 1, 3)),
+    NOC_4 = ifelse(NOC == "99998", "N/A", str_sub(NOC, 1, 4))
+  ) %>%
   select(-starts_with("Current_Region"))
 
 ## ---- Get results by NOC digit ----
 ### 1 digit ----
-data_1_NOC <- data %>% 
-  left_join(T_NOC_Broad_Categories %>%
-              mutate(BROAD_CATEGORY_CODE=as.character(BROAD_CATEGORY_CODE)) %>%
-              select(BROAD_CATEGORY_CODE,BROAD_CATEGORY_ENGLISH_NAME) %>% distinct(),by=c("NOC_1"="BROAD_CATEGORY_CODE")) %>%
-  group_by(Age_Group_Rollup_Label,NOC_1,BROAD_CATEGORY_ENGLISH_NAME) %>% 
-  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>% ungroup()
+data_1_NOC <- data %>%
+  left_join(
+    T_NOC_Broad_Categories %>%
+      mutate(BROAD_CATEGORY_CODE = as.character(BROAD_CATEGORY_CODE)) %>%
+      select(BROAD_CATEGORY_CODE, BROAD_CATEGORY_ENGLISH_NAME) %>%
+      distinct(),
+    by = c("NOC_1" = "BROAD_CATEGORY_CODE")
+  ) %>%
+  group_by(Age_Group_Rollup_Label, NOC_1, BROAD_CATEGORY_ENGLISH_NAME) %>%
+  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>%
+  ungroup()
 
-write_csv(data_1_NOC,glue::glue(folder_path,"public_release_static_no_ptib_1_digit_rollup.csv"))
+write_csv(
+  data_1_NOC,
+  glue::glue(folder_path, "public_release_static_no_ptib_1_digit_rollup.csv")
+)
 
 ### 2 digits ----
-data_2_NOC <- data %>% 
-  left_join(T_NOC_Broad_Categories %>%
-              select(MAJOR_GROUP_CODE,MAJOR_GROUP_ENGLISH_NAME) %>% distinct(),by=c("NOC_2"="MAJOR_GROUP_CODE")) %>%
-  group_by(Age_Group_Rollup_Label,NOC_2,MAJOR_GROUP_ENGLISH_NAME) %>% 
-  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>% ungroup()
+data_2_NOC <- data %>%
+  left_join(
+    T_NOC_Broad_Categories %>%
+      select(MAJOR_GROUP_CODE, MAJOR_GROUP_ENGLISH_NAME) %>%
+      distinct(),
+    by = c("NOC_2" = "MAJOR_GROUP_CODE")
+  ) %>%
+  group_by(Age_Group_Rollup_Label, NOC_2, MAJOR_GROUP_ENGLISH_NAME) %>%
+  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>%
+  ungroup()
 
-write_csv(data_2_NOC,glue::glue(folder_path,"public_release_static_no_ptib_2_digit_rollup.csv"))
+write_csv(
+  data_2_NOC,
+  glue::glue(folder_path, "public_release_static_no_ptib_2_digit_rollup.csv")
+)
 
 # ******************************************************************************
 # ---- Rollup NOCs custom groupings ----
@@ -64,52 +87,79 @@ folder_path <- glue::glue("{lan}/development/work/adhoc-outputs/")
 
 ## ---- Connection to database ----
 db_config <- config::get("decimal")
-decimal_con <- dbConnect(odbc::odbc(),
-                         Driver = db_config$driver,
-                         Server = db_config$server,
-                         Database = db_config$database,
-                         Trusted_Connection = "True")
+decimal_con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 ## ---- Read draft data files ----
-public_data <-  tbl(decimal_con, dbplyr::in_schema(sql('"IDIR\\ALOWERY"'), "qry_10a_Model_Public_Release_Union")) %>% collect()
-tbl_model <- tbl(decimal_con, dbplyr::in_schema(sql('"IDIR\\ALOWERY"'), "tmp_tbl_Model")) %>% collect()
+public_data <- tbl(
+  decimal_con,
+  dbplyr::in_schema(
+    sql('"IDIR\\ALOWERY"'),
+    "qry_10a_Model_Public_Release_Union"
+  )
+) %>%
+  collect()
+tbl_model <- tbl(
+  decimal_con,
+  dbplyr::in_schema(sql('"IDIR\\ALOWERY"'), "tmp_tbl_Model")
+) %>%
+  collect()
 
 ## ---- Read lookup file ----
-noc_rollup <- read_csv(glue::glue(folder_path,"brett_custom_noc_rollup.csv"))
+noc_rollup <- read_csv(glue::glue(folder_path, "brett_custom_noc_rollup.csv"))
 
 ## Public data ----
 ### ---- Create sub NOCs public data ----
-public_data_prep <- public_data %>% 
-  mutate(NOC_2 = ifelse(NOC=="99998","N/A",str_sub(NOC,1,2))) %>% 
-  left_join(noc_rollup, by="NOC_2") %>% 
-  select(-starts_with("Current_Region"),-Expr1,-ENGLISH_NAME,-NOC)
+public_data_prep <- public_data %>%
+  mutate(NOC_2 = ifelse(NOC == "99998", "N/A", str_sub(NOC, 1, 2))) %>%
+  left_join(noc_rollup, by = "NOC_2") %>%
+  select(-starts_with("Current_Region"), -Expr1, -ENGLISH_NAME, -NOC)
 
 ### ---- Get results by custom 2-digit NOC rollup ----
-public_data_custom_NOC <- public_data_prep %>% 
-  group_by(Age_Group_Rollup_Label,NOC_Custom_Group) %>% 
-  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>% ungroup()
+public_data_custom_NOC <- public_data_prep %>%
+  group_by(Age_Group_Rollup_Label, NOC_Custom_Group) %>%
+  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>%
+  ungroup()
 
-write_csv(public_data_custom_NOC,glue::glue(folder_path,"public_data_custom_NOC_rollup_20240925.csv"))
+write_csv(
+  public_data_custom_NOC,
+  glue::glue(folder_path, "public_data_custom_NOC_rollup_20240925.csv")
+)
 
 ## Full Model ----
 ### ---- Create sub NOCs full model data ----
-model_data_prep <- tbl_model %>% 
-  filter(Current_Region_PSSM_Code_Rollup==5900) %>% 
-  # mutate(NOC_level = str_length(NOC)) %>% 
-  # filter(NOC_level==2) %>% 
-  filter(NOC_Level==2) %>% 
-  left_join(noc_rollup, by=c("NOC"="NOC_2")) %>% 
-  select(-starts_with("Current_Region"),-Expr1,-ENGLISH_NAME,-NOC,-NOC_Level)
+model_data_prep <- tbl_model %>%
+  filter(Current_Region_PSSM_Code_Rollup == 5900) %>%
+  # mutate(NOC_level = str_length(NOC)) %>%
+  # filter(NOC_level==2) %>%
+  filter(NOC_Level == 2) %>%
+  left_join(noc_rollup, by = c("NOC" = "NOC_2")) %>%
+  select(
+    -starts_with("Current_Region"),
+    -Expr1,
+    -ENGLISH_NAME,
+    -NOC,
+    -NOC_Level
+  )
 
 ### ---- Get results by custom 2-digit NOC rollup ----
-model_data_custom_NOC <- model_data_prep %>% 
-  group_by(Age_Group_Rollup_Label,NOC_Custom_Group) %>% 
-  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>% ungroup()
+model_data_custom_NOC <- model_data_prep %>%
+  group_by(Age_Group_Rollup_Label, NOC_Custom_Group) %>%
+  summarise(across(where(is.numeric), ~ sum(.x, na.rm = TRUE))) %>%
+  ungroup()
 
-write_csv(public_data_custom_NOC,glue::glue(folder_path,"full_model_data_custom_NOC_rollup_20240925.csv"))
+write_csv(
+  public_data_custom_NOC,
+  glue::glue(folder_path, "full_model_data_custom_NOC_rollup_20240925.csv")
+)
 
 ## ---- Clean up ----
 dbDisconnect(decimal_con)
-rm(list=ls())
+rm(list = ls())
 
 # ******************************************************************************

--- a/R/zz-graduate-historical-forecasted.R
+++ b/R/zz-graduate-historical-forecasted.R
@@ -16,32 +16,55 @@ source("./sql/zz-historical/historical-projections.R")
 
 # ---- Connection to decimal ----
 db_config <- config::get("decimal")
-decimal_con <- dbConnect(odbc::odbc(),
-                         Driver = db_config$driver,
-                         Server = db_config$server,
-                         Database = db_config$database,
-                         Trusted_Connection = "True")
+decimal_con <- dbConnect(
+  odbc::odbc(),
+  Driver = db_config$driver,
+  Server = db_config$server,
+  Database = db_config$database,
+  Trusted_Connection = "True"
+)
 
 # ---- Check for required data tables ----
 # Derived tables
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."Cohort_Program_Distributions"')))
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."Graduate_Projections"')))
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."Cohort_Program_Distributions"'))
+)
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."Graduate_Projections"'))
+)
 
 # Lookups
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_LCP4_CD"')))
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_LCIP4_CRED"')))
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_PSSM_Credential"')))
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_LCP4_CD"'))
+)
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_LCIP4_CRED"'))
+)
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."T_Exclude_from_Projections_PSSM_Credential"'))
+)
 dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."tbl_Age_Groups"')))
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."tbl_Age_Groups_Rollup"')))
-dbExistsTable(decimal_con, SQL(glue::glue('"{my_schema}"."T_PSSM_Credential_Grouping_Appendix"')))
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."tbl_Age_Groups_Rollup"'))
+)
+dbExistsTable(
+  decimal_con,
+  SQL(glue::glue('"{my_schema}"."T_PSSM_Credential_Grouping_Appendix"'))
+)
 
 
-# ---- Q_1 Series ---- 
-dbExecute(decimal_con, Q_1_Grad_Projections_by_Age_by_Program) 
-dbExecute(decimal_con, Q_1c_Grad_Projections_by_Program) 
+# ---- Q_1 Series ----
+dbExecute(decimal_con, Q_1_Grad_Projections_by_Age_by_Program)
+dbExecute(decimal_con, Q_1c_Grad_Projections_by_Program)
 
 # ---- Final Table ----
-dbGetQuery(decimal_con, qry99_Presentations_Graduates_Appendix) %>% 
+dbGetQuery(decimal_con, qry99_Presentations_Graduates_Appendix) %>%
   mutate(across(where(is.numeric), round))
 
 # drop tables
@@ -49,11 +72,12 @@ dbExecute(decimal_con, "DROP TABLE Q_1_Grad_Projections_by_Age_by_Program")
 dbExecute(decimal_con, "DROP TABLE Q_1c_Grad_Projections_by_Program")
 
 
-# historical numbers - bringing into R instead of multiple queries 
+# historical numbers - bringing into R instead of multiple queries
 
 grads <- tibble(dbGetQuery(
   decimal_con,
-  glue::glue('
+  glue::glue(
+    '
    SELECT 
 	t1.age_group,
     t4.age_group_rollup_label,
@@ -69,12 +93,12 @@ grads <- tibble(dbGetQuery(
 	ON t3.age_group_rollup = t4.age_group_rollup
              '
   )
-)
-)
+))
 
 grads_proj <- tibble(dbGetQuery(
   decimal_con,
-  glue::glue('
+  glue::glue(
+    '
    SELECT 
 	t1.age_group,
     t4.age_group_rollup_label,
@@ -90,18 +114,22 @@ grads_proj <- tibble(dbGetQuery(
 	ON t3.age_group_rollup = t4.age_group_rollup
              '
   )
-)
-)
+))
 
-grads %>% 
-  filter(year>='2023/2024', !grepl('Apprenticeship', pssm_credential_name)) %>% 
-  all.equal(grads_proj %>% filter(!grepl('Apprenticeship', pssm_credential_name)))
+grads %>%
+  filter(
+    year >= '2023/2024',
+    !grepl('Apprenticeship', pssm_credential_name)
+  ) %>%
+  all.equal(
+    grads_proj %>% filter(!grepl('Apprenticeship', pssm_credential_name))
+  )
 
 grads %>% filter(year == '2023/2024')
 grads_proj %>% filter(year == '2023/2024')
 
 # fill in missing years
-grads_completed <-  grads %>% 
+grads_completed <- grads %>%
   arrange(pssm_credential_name, age_group, year) %>%
   complete(pssm_credential_name, age_group, year) %>%
   group_by(pssm_credential_name, age_group) %>%
@@ -109,29 +137,36 @@ grads_completed <-  grads %>%
 
 grads_completed %>% View()
 
-grads_completed %>% filter(pssm_credential_name == 'Apprenticeship') %>% 
-  filter(age_group_rollup_label == '17 to 29') %>% 
-  filter(year>='2023/2024')
+grads_completed %>%
+  filter(pssm_credential_name == 'Apprenticeship') %>%
+  filter(age_group_rollup_label == '17 to 29') %>%
+  filter(year >= '2023/2024')
 
-grads_by_age_cred <- grads_completed %>% 
-  filter(year>='2018/2019') %>% 
-  group_by(age_group_rollup_label, pssm_credential_name, year) %>% 
-  summarise(n = round(sum(graduates, drop.na=TRUE), 0)) %>% 
-  pivot_wider(id_cols = c('age_group_rollup_label', 'pssm_credential_name'), names_from = 'year', values_from = 'n') %>% 
-  arrange(pssm_credential_name, age_group_rollup_label) %>% 
+grads_by_age_cred <- grads_completed %>%
+  filter(year >= '2018/2019') %>%
+  group_by(age_group_rollup_label, pssm_credential_name, year) %>%
+  summarise(n = round(sum(graduates, drop.na = TRUE), 0)) %>%
+  pivot_wider(
+    id_cols = c('age_group_rollup_label', 'pssm_credential_name'),
+    names_from = 'year',
+    values_from = 'n'
+  ) %>%
+  arrange(pssm_credential_name, age_group_rollup_label) %>%
   filter(!is.na(age_group_rollup_label))
-  
 
 
-grads_completed %>% 
-  mutate(year = as.numeric(str_sub(year, 1,4))) %>% 
-  group_by(pssm_credential_name, year) %>% 
-  summarize(n = sum(graduates)) %>% # View() 
-  ggplot(aes(x = year, y=n, color=pssm_credential_name)) +
-  geom_line()+
+grads_completed %>%
+  mutate(year = as.numeric(str_sub(year, 1, 4))) %>%
+  group_by(pssm_credential_name, year) %>%
+  summarize(n = sum(graduates)) %>% # View()
+  ggplot(aes(x = year, y = n, color = pssm_credential_name)) +
+  geom_line() +
   geom_vline(aes(xintercept = 2023))
 
 
-grads_by_age_cred %>% write_csv(
-  glue::glue('{lan}\\development\\work\\adhoc-outputs\\graduate_projections_include_historical_no_ptib.csv')
-)
+grads_by_age_cred %>%
+  write_csv(
+    glue::glue(
+      '{lan}\\development\\work\\adhoc-outputs\\graduate_projections_include_historical_no_ptib.csv'
+    )
+  )

--- a/sql/01-credential-analysis/credential-non-dup-psi_visa_status.R
+++ b/sql/01-credential-analysis/credential-non-dup-psi_visa_status.R
@@ -1,12 +1,10 @@
-
-
 # ---- CredentialSupVars_VisaStatus_Cleaning_check ----
-CredentialSupVars_VisaStatus_Cleaning_check <-"
+CredentialSupVars_VisaStatus_Cleaning_check <- "
 SELECT PSI_VISA_STATUS, count(*) FROM CredentialSupVars GROUP BY PSI_VISA_STATUS"
 
 # ---- CredentialSupVars_VisaStatus_1 ----
 CredentialSupVars_VisaStatus_Cleaning_1 <-
-"SELECT credential_non_dup.id,
+  "SELECT credential_non_dup.id,
        credential_non_dup.encrypted_true_pen,
        credential_non_dup.psi_student_number,
        credential_non_dup.psi_school_year,
@@ -25,7 +23,7 @@ FROM   credentialsupvars
                ON credentialsupvars.id = credential_non_dup.id "
 
 # ---- CredentialSupVars_VisaStatus_2 ----
-CredentialSupVars_VisaStatus_Cleaning_2 <-"
+CredentialSupVars_VisaStatus_Cleaning_2 <- "
 UPDATE  Credential_Non_Dup_VisaStatus_Cleaning_Step1
 SET     PSI_VISA_STATUS = CredentialSupVarsFromEnrolment.PSI_VISA_STATUS
 FROM    Credential_Non_Dup_VisaStatus_Cleaning_Step1 
@@ -38,7 +36,7 @@ AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_CREDENTIAL_PROGRAM_DESC
 AND     Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_SCHOOL_YEAR = CredentialSupVarsFromEnrolment.PSI_SCHOOL_YEAR"
 
 # ---- CredentialSupVars_VisaStatus_3 ----
-CredentialSupVars_VisaStatus_Cleaning_3 <-"
+CredentialSupVars_VisaStatus_Cleaning_3 <- "
 UPDATE  credential_non_dup_visastatus_cleaning_step1
 SET     psi_visa_status = credentialsupvarsfromenrolment.psi_visa_status
 FROM    credential_non_dup_visastatus_cleaning_step1
@@ -52,7 +50,7 @@ AND     credential_non_dup_visastatus_cleaning_step1.psi_school_year = credentia
 
 
 # ---- CredentialSupVars_VisaStatus_4 ----
-CredentialSupVars_VisaStatus_Cleaning_4 <-"
+CredentialSupVars_VisaStatus_Cleaning_4 <- "
 UPDATE    Credential_Non_Dup_VisaStatus_Cleaning_Step1
 SET       PSI_VISA_STATUS = CredentialSupVarsFromEnrolment.PSI_VISA_STATUS
 FROM      Credential_Non_Dup_VisaStatus_Cleaning_Step1 
@@ -64,7 +62,7 @@ ON        Credential_Non_Dup_VisaStatus_Cleaning_Step1.ENCRYPTED_TRUE_PEN = Cred
 WHERE     (Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_VISA_STATUS IS NULL)"
 
 # ---- CredentialSupVars_VisaStatus_5 ----
-CredentialSupVars_VisaStatus_Cleaning_5 <-"
+CredentialSupVars_VisaStatus_Cleaning_5 <- "
 UPDATE    CredentialSupVars
 SET       PSI_VISA_STATUS = Credential_Non_Dup_VisaStatus_Cleaning_Step1.PSI_VISA_STATUS
 FROM      CredentialSupVars 
@@ -72,32 +70,10 @@ INNER JOIN Credential_Non_Dup_VisaStatus_Cleaning_Step1 ON CredentialSupVars.ID 
 WHERE     (CredentialSupVars.PSI_VISA_STATUS IS NULL) 
 OR        (CredentialSupVars.PSI_VISA_STATUS IN ('', ' ', '(Unspecified)'))"
 
-                        
+
 # ---- CredentialSupVars_VisaStatus_6 ----
-CredentialSupVars_VisaStatus_Cleaning_6 <-"
+CredentialSupVars_VisaStatus_Cleaning_6 <- "
 UPDATE      Credential_Non_Dup
 SET         PSI_VISA_STATUS = CredentialSupVars.PSI_VISA_STATUS
 FROM        Credential_Non_Dup 
 INNER JOIN  CredentialSupVars ON Credential_Non_Dup.id = CredentialSupVars.ID"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/sql/01-credential-analysis/credential-sup-vars-from-enrolment.R
+++ b/sql/01-credential-analysis/credential-sup-vars-from-enrolment.R
@@ -33,8 +33,8 @@ INTO    tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
 FROM    tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2 
 INNER JOIN STP_Enrolment_Valid 
   ON tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step2.ID = STP_Enrolment_Valid.ID"
-                         
-# ---- qry05_CredentialSupVars_From_Enrolment ----                    
+
+# ---- qry05_CredentialSupVars_From_Enrolment ----
 qry05_CredentialSupVars_From_Enrolment <- "                         
 ALTER TABLE tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
 ADD CONSTRAINT tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3_PK_ID
@@ -64,9 +64,9 @@ GROUP BY      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID,
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE,
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER,
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_ENROLMENT_SEQUENCE"
-                    
 
-# ---- qry07_CredentialSupVars_From_Enrolment ----    
+
+# ---- qry07_CredentialSupVars_From_Enrolment ----
 qry07_CredentialSupVars_From_Enrolment <- "    
 SELECT          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID, 
                 tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER, 
@@ -81,9 +81,9 @@ FROM            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
 INNER JOIN      RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE 
   ON            tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER = RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE.PSI_STUDENT_NUMBER 
   AND           tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE = RW_TEST_CRED_EPENS_NOT_MATCHED_ID_PSICODE.PSI_CODE"
-                         
-                         
-# ---- qry08_CredentialSupVars_From_Enrolment ----                         
+
+
+# ---- qry08_CredentialSupVars_From_Enrolment ----
 qry08_CredentialSupVars_From_Enrolment <- "
 SELECT        tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.ID AS EnrolmentID, 
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER, 
@@ -99,8 +99,8 @@ FROM          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3
 INNER JOIN    RW_TEST_CRED_NULLEPENS_TO_MATCH 
   ON          tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_STUDENT_NUMBER = RW_TEST_CRED_NULLEPENS_TO_MATCH.PSI_STUDENT_NUMBER 
   AND         tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step3.PSI_CODE = RW_TEST_CRED_NULLEPENS_TO_MATCH.PSI_CODE"
-    
-# ---- qry09_CredentialSupVars_From_Enrolment ----                     
+
+# ---- qry09_CredentialSupVars_From_Enrolment ----
 qry09_CredentialSupVars_From_Enrolment <- "
 SELECT     ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, MAX(PSI_SCHOOL_YEAR) AS MaxSchoolYear
 INTO       tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step4
@@ -178,4 +178,3 @@ GROUP BY      tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.ID,
 						  tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_CODE,
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_STUDENT_NUMBER,
               tmp_tbl_Enrol_ID_EPEN_For_Cred_Join_step6.PSI_ENROLMENT_SEQUENCE"
-                         

--- a/sql/01-credential-preprocessing/01a-credential-preprocessing.R
+++ b/sql/01-credential-preprocessing/01a-credential-preprocessing.R
@@ -16,8 +16,8 @@ qry00d_SetPKeyinSTPCredential <- "
   ADD CONSTRAINT STP_Credential_PK_ID PRIMARY KEY (ID)"
 
 
-# ---- qry01_ExtractAllID_into_STP_Credential_Record_Type ---- 
-qry01_ExtractAllID_into_STP_Credential_Record_Type <-"
+# ---- qry01_ExtractAllID_into_STP_Credential_Record_Type ----
+qry01_ExtractAllID_into_STP_Credential_Record_Type <- "
   CREATE TABLE [STP_Credential_Record_Type] (
   [ID] int NOT NULL,
   [ENCRYPTED_TRUE_PEN] varchar(50),
@@ -30,7 +30,7 @@ qry01_ExtractAllID_into_STP_Credential_Record_Type <-"
   FROM STP_Credential;"
 
 
-# ---- qry02a_Record_With_PEN_Or_STUID ---- 
+# ---- qry02a_Record_With_PEN_Or_STUID ----
 qry02a_Record_With_PEN_Or_STUID <- "SELECT      id, PSI_STUDENT_NUMBER, PSI_CODE, ENCRYPTED_TRUE_PEN
 INTO       tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID
 FROM       STP_Credential
@@ -39,7 +39,7 @@ AND        PSI_CODE NOT IN ('', ' ', '(Unspecified)'))
 OR (ENCRYPTED_TRUE_PEN NOT IN ('', ' ', '(Unspecified)'));"
 
 
-# ---- qry02b_Drop_No_PEN_Or_No_STUID ---- 
+# ---- qry02b_Drop_No_PEN_Or_No_STUID ----
 qry02b_Drop_No_PEN_Or_No_STUID <- "
 SELECT STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_STUDENT_NUMBER
 INTO Drop_Cred_No_PEN_or_No_STUID
@@ -49,7 +49,7 @@ ON tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID.ID = STP_Credential.ID
 WHERE (((tmp_tbl_qry02a_Cred_Record_With_PEN_or_STUID.ID) Is Null));"
 
 
-# ---- qry02c_Update_Drop_No_PEN_or_No_STUID.SQL ---- 
+# ---- qry02c_Update_Drop_No_PEN_or_No_STUID.SQL ----
 qry02c_Update_Drop_No_PEN_or_No_STUID <- "
 UPDATE    STP_Credential_Record_Type
 SET       RecordStatus = 1
@@ -58,7 +58,7 @@ INNER JOIN Drop_Cred_No_PEN_or_No_STUID
 ON STP_Credential_Record_Type.ID = Drop_Cred_No_PEN_or_No_STUID.ID;"
 
 
-# ---- qry03a_Drop_Record_Developmental ---- 
+# ---- qry03a_Drop_Record_Developmental ----
 qry03a_Drop_Record_Developmental <- "
 SELECT    ID, ENCRYPTED_TRUE_PEN,  PSI_CODE, PSI_STUDENT_NUMBER, PSI_CREDENTIAL_CATEGORY, LEFT(STP_CREDENTIAL.PSI_CREDENTIAL_CIP, 2) AS CIP2, PSI_CREDENTIAL_LEVEL
 INTO      Drop_Cred_Developmental
@@ -66,7 +66,7 @@ FROM      STP_Credential
 WHERE     PSI_CREDENTIAL_LEVEL = 'DEVELOPMENTAL';"
 
 
-# ---- qry03b_Update_Drop_Record_Developmental ---- 
+# ---- qry03b_Update_Drop_Record_Developmental ----
 qry03b_Update_Drop_Record_Developmental <- "
 UPDATE    STP_Credential_Record_Type
 SET       RecordStatus = 2
@@ -75,7 +75,7 @@ INNER JOIN Drop_Cred_Developmental
   ON STP_Credential_Record_Type.ID = Drop_Cred_Developmental.ID
 WHERE STP_Credential_Record_Type.RecordStatus is null;"
 
-# ---- qry03c_create_table_EnrolmentSkillsBasedCourse ---- 
+# ---- qry03c_create_table_EnrolmentSkillsBasedCourse ----
 qry03c_create_table_EnrolmentSkillsBasedCourse <- "
 SELECT    STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
           LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
@@ -89,7 +89,7 @@ GROUP BY STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.P
                       STP_Enrolment.PSI_CREDENTIAL_CATEGORY, STP_Enrolment.PSI_STUDY_LEVEL, STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
 
 
-# ---- qry03d_create_table_Suspect_Skills_Based ---- 
+# ---- qry03d_create_table_Suspect_Skills_Based ----
 qry03d_create_table_Suspect_Skills_Based <- "
 SELECT    STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_STUDENT_NUMBER, STP_Credential.PSI_SCHOOL_YEAR,
           STP_Credential.PSI_CODE, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, LEFT(STP_Credential.PSI_CREDENTIAL_CIP,2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, 
@@ -100,7 +100,7 @@ INNER JOIN STP_Credential
   ON STP_Credential_Record_Type.ID = STP_Credential.ID
 WHERE    (STP_Credential_Record_Type.RecordStatus IS NULL);"
 
-# ---- qry03e_Find_Suspect_Skills_Based ---- 
+# ---- qry03e_Find_Suspect_Skills_Based ----
 qry03e_Find_Suspect_Skills_Based <- "
 SELECT    tmp_tbl_Cred_Suspect_Skills_Based.ID, tmp_tbl_Cred_Suspect_Skills_Based.ENCRYPTED_TRUE_PEN, tmp_tbl_Cred_Suspect_Skills_Based.PSI_CODE,  tmp_tbl_Cred_Suspect_Skills_Based.PSI_STUDENT_NUMBER,
           tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, tmp_tbl_Cred_Suspect_Skills_Based.CIP2, 
@@ -115,7 +115,7 @@ INNER JOIN tmp_tbl_EnrolmentSkillsBasedCourses
   AND tmp_tbl_Cred_Suspect_Skills_Based.PSI_CREDENTIAL_LEVEL = tmp_tbl_EnrolmentSkillsBasedCourses.PSI_STUDY_LEVEL;"
 
 
-# ---- qry03f_Update_Suspect_Skills_Based ---- 
+# ---- qry03f_Update_Suspect_Skills_Based ----
 qry03f_Update_Suspect_Skills_Based <- "
 UPDATE    STP_Credential_Record_Type
 SET       RecordStatus = 6
@@ -124,7 +124,7 @@ INNER JOIN STP_Credential_Record_Type
   ON Cred_Suspect_Skills_Based.ID = STP_Credential_Record_Type.ID
 WHERE STP_Credential_Record_Type.RecordStatus IS NULL;"
 
-# ---- qry03g_Drop_Developmental_Credential_CIPS ---- 
+# ---- qry03g_Drop_Developmental_Credential_CIPS ----
 qry03g_Drop_Developmental_Credential_CIPS <- "
 SELECT    STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_STUDENT_NUMBER, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
           LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, STP_Credential_Record_Type.RecordStatus
@@ -135,7 +135,7 @@ INNER JOIN STP_Credential_Record_Type
 WHERE     (LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) IN ('21', '32', '33', '34', '35', '36', '37', '53', '89')) 
   AND (STP_Credential_Record_Type.RecordStatus IS NULL);"
 
-# ---- qry03g2_Drop_Developmental_Credential_CIPS ---- 
+# ---- qry03g2_Drop_Developmental_Credential_CIPS ----
 qry03g2_Drop_Developmental_Credential_CIPS <- "
 UPDATE Drop_Developmental_PSI_CREDENTIAL_CIPS
    SET Keep = 'Yes'
@@ -144,7 +144,7 @@ UPDATE Drop_Developmental_PSI_CREDENTIAL_CIPS
     OR (PSI_CODE = 'NIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'Coastal Forest Resource')
     OR (PSI_CODE = 'NIC' AND PSI_CREDENTIAL_PROGRAM_DESCRIPTION = 'Underground Mining Essentials');"
 
-# ---- qry03h_Update_Developmental_CIPs ---- 
+# ---- qry03h_Update_Developmental_CIPs ----
 qry03h_Update_Developmental_CIPs <- "
 UPDATE    STP_Credential_Record_Type
 SET       RecordStatus = 7
@@ -154,7 +154,7 @@ INNER JOIN Drop_Developmental_PSI_CREDENTIAL_CIPS
 WHERE STP_Credential_Record_Type.RecordStatus IS NULL and Drop_Developmental_PSI_CREDENTIAL_CIPS.Keep IS Null;"
 
 
-# ---- qry03i_Drop_RecommendationForCert ---- 
+# ---- qry03i_Drop_RecommendationForCert ----
 qry03i_Drop_RecommendationForCert <- "
 SELECT      STP_Credential.ID, STP_Credential.ENCRYPTED_TRUE_PEN, STP_Credential.PSI_CODE, STP_Credential.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
                          LEFT(STP_Credential.PSI_CREDENTIAL_CIP, 2) AS CIP2, STP_Credential.PSI_CREDENTIAL_CATEGORY, STP_Credential_Record_Type.RecordStatus
@@ -165,8 +165,8 @@ INNER JOIN STP_Credential_Record_Type
 WHERE        (PSI_CREDENTIAL_CATEGORY = 'RECOMMENDATION FOR CERTIFICATION') AND (STP_Credential_Record_Type.RecordStatus IS NULL);"
 
 
-# ---- qry03j_Update_RecommendationForCert  ---- 
-qry03j_Update_RecommendationForCert  <- "
+# ---- qry03j_Update_RecommendationForCert  ----
+qry03j_Update_RecommendationForCert <- "
 UPDATE    STP_Credential_Record_Type
 SET       RecordStatus = 8
 FROM      STP_Credential_Record_Type 
@@ -175,7 +175,7 @@ INNER JOIN Drop_Cred_RecommendForCert
 WHERE STP_Credential_Record_Type.RecordStatus IS NULL;"
 
 
-# ---- qry04_Update_RecordStatus_Not_Dropped ---- 
+# ---- qry04_Update_RecordStatus_Not_Dropped ----
 qry04_Update_RecordStatus_Not_Dropped <- "
 UPDATE STP_Credential_Record_Type 
 SET STP_Credential_Record_Type.RecordStatus = 0
@@ -186,5 +186,3 @@ RecordTypeSummary <-
   "SELECT RecordStatus, COUNT(*) AS Expr1
 FROM  STP_Credential_Record_Type
 GROUP BY RecordStatus"
-
-

--- a/sql/01-enrolment-preprocessing/01-enrolment-preprocessing-sql.R
+++ b/sql/01-enrolment-preprocessing/01-enrolment-preprocessing-sql.R
@@ -18,7 +18,7 @@ qry00d_SetPKeyinSTPEnrolment <- "
   ADD CONSTRAINT STP_Enrolment_PK_ID PRIMARY KEY (ID)"
 
 
-# ---- qry01_ExtractAllID_into_STP_Enrolment_Record_Type ---- 
+# ---- qry01_ExtractAllID_into_STP_Enrolment_Record_Type ----
 qry01_ExtractAllID_into_STP_Enrolment_Record_Type <- "
    CREATE TABLE STP_Enrolment_Record_Type (
    [ID] int NOT NULL,
@@ -32,7 +32,7 @@ qry01_ExtractAllID_into_STP_Enrolment_Record_Type <- "
    FROM STP_Enrolment;"
 
 
-# ---- qry02a_Record_With_PEN_Or_STUID ---- 
+# ---- qry02a_Record_With_PEN_Or_STUID ----
 qry02a_Record_With_PEN_Or_STUID <- "
 SELECT     id, PSI_STUDENT_NUMBER, PSI_CODE, ENCRYPTED_TRUE_PEN
 INTO       tmp_tbl_qry02a_Record_With_PEN_Or_STUID
@@ -42,7 +42,7 @@ AND        PSI_CODE NOT IN('',' ','(Unspecified)'))
 OR         (ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)'));"
 
 
-# ---- qry02b_Drop_No_PEN_Or_No_STUID ---- 
+# ---- qry02b_Drop_No_PEN_Or_No_STUID ----
 qry02b_Drop_No_PEN_Or_No_STUID <- "
 SELECT      STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_CODE 
 INTO        Drop_No_PEN_or_No_STUID
@@ -52,14 +52,14 @@ RIGHT JOIN  STP_Enrolment
 WHERE       ((tmp_tbl_qry02a_Record_With_PEN_Or_STUID.ID) Is Null);"
 
 
-# ---- qry02c_Update_Drop_No_PEN_Or_No_STUID.SQL ---- 
+# ---- qry02c_Update_Drop_No_PEN_Or_No_STUID.SQL ----
 qry02c_Update_Drop_No_PEN_Or_No_STUID <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       RecordStatus = 1
 FROM      STP_Enrolment_Record_Type INNER JOIN
           Drop_No_PEN_or_No_STUID ON STP_Enrolment_Record_Type.ID = Drop_No_PEN_or_No_STUID.ID;"
 
-# ---- qry03a_Drop_Record_Developmental ---- 
+# ---- qry03a_Drop_Record_Developmental ----
 qry03a_Drop_Record_Developmental <- "
 SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL
 INTO      Drop_Developmental
@@ -67,14 +67,14 @@ FROM      STP_Enrolment
 WHERE     PSI_STUDY_LEVEL = 'DEVELOPMENTAL';"
 
 
-# ---- qry03b_Update_Drop_Record_Developmental ---- 
+# ---- qry03b_Update_Drop_Record_Developmental ----
 qry03b_Update_Drop_Record_Developmental <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       RecordStatus = 2
 FROM      STP_Enrolment_Record_Type INNER JOIN
           Drop_Developmental ON STP_Enrolment_Record_Type.ID = Drop_Developmental.ID;"
 
-# ---- qry03c_Drop_Skills_Based ---- 
+# ---- qry03c_Drop_Skills_Based ----
 qry03c_Drop_Skills_Based <- "
 SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, 
           PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
@@ -84,14 +84,14 @@ WHERE     PSI_CONTINUING_EDUCATION_COURSE_ONLY = 'SKILLS CRS ONLY'
   AND     PSI_STUDY_LEVEL <>'DEVELOPMENTAL'
   AND     PSI_CREDENTIAL_CATEGORY IN ('NONE','OTHER');"
 
-# ---- qry03da_Keep_TeachEd ---- 
+# ---- qry03da_Keep_TeachEd ----
 qry03da_Keep_TeachEd <- "
 UPDATE    Drop_Skills_Based
 SET       KEEP = 'Y'
 WHERE     (PSI_CODE = 'UFV') AND (PSI_PROGRAM_CODE = 'TEACH ED') 
   OR      (PSI_CODE = 'UCFV') AND (PSI_PROGRAM_CODE = 'TEACH ED');"
 
-# ---- qry03d_Update_Drop_Record_Skills_Based ---- 
+# ---- qry03d_Update_Drop_Record_Skills_Based ----
 qry03d_Update_Drop_Record_Skills_Based <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       RecordStatus = 6
@@ -100,7 +100,7 @@ INNER JOIN Drop_Skills_Based
   ON STP_Enrolment_Record_Type.ID = Drop_Skills_Based.ID
 WHERE     RecordStatus is NULL and KEEP IS NULL;"
 
-# ---- qry03d_1_Drop_Continuing_Ed ---- 
+# ---- qry03d_1_Drop_Continuing_Ed ----
 qry03d_1_Drop_Continuing_Ed <- "
 SELECT    ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL
 INTO      Drop_ContinuingEd
@@ -110,7 +110,7 @@ WHERE     (PSI_STUDY_LEVEL <> 'DEVELOPMENTAL'
   AND     PSI_CREDENTIAL_CATEGORY IN ('NONE','OTHER')
   AND     (Left(PSI_CIP_CODE,2) IN ('21', '32', '33', '34', '35', '36','37', '53', '89')));"
 
-# ---- qry03d_2_Update_Drop_Continuing_Ed ---- 
+# ---- qry03d_2_Update_Drop_Continuing_Ed ----
 qry03d_2_Update_Drop_Continuing_Ed <- "
 UPDATE    
 STP_Enrolment_Record_Type
@@ -120,7 +120,7 @@ INNER JOIN Drop_ContinuingEd
 ON        STP_Enrolment_Record_Type.ID = Drop_ContinuingEd.ID
 WHERE     RecordStatus is NULL;"
 
-# ---- qry03d_3_Drop_More_Continuing_Ed ---- 
+# ---- qry03d_3_Drop_More_Continuing_Ed ----
 qry03d_3_Drop_More_Continuing_Ed <- "
 SELECT    STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_CODE, 
           STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(STP_Enrolment.PSI_CIP_CODE, 2) AS CIP2, STP_Enrolment.PSI_PROGRAM_CODE, 
@@ -136,7 +136,7 @@ WHERE     ((STP_Enrolment_Record_Type.RecordStatus IS NULL)
   OR      (STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION LIKE 'CE %')));"
 
 
-# ---- qry03d_4_Updated_Drop_ContinuingEdMore ---- 
+# ---- qry03d_4_Updated_Drop_ContinuingEdMore ----
 qry03d_4_Updated_Drop_ContinuingEdMore <- "
 UPDATE      STP_Enrolment_Record_Type
 SET         STP_Enrolment_Record_Type.RecordStatus = 6
@@ -146,7 +146,7 @@ INNER JOIN  Drop_ContinuingEd_More
 WHERE       STP_Enrolment_Record_Type.RecordStatus is NULL;"
 
 
-# ---- qry03e_Keep_Skills_Based ---- 
+# ---- qry03e_Keep_Skills_Based ----
 qry03e_Keep_Skills_Based <- "
 SELECT      ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, LEFT(PSI_CIP_CODE, 2) AS CIP2, PSI_PROGRAM_CODE, 
             PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
@@ -169,7 +169,7 @@ WHERE      (PSI_CODE = 'SEL'
   OR (PSI_CODE = 'NIC' AND CIP2 IN ('21', '32', '33', '34', '35', '36', '37', '53', '89'));"
 
 
-# ---- qry03f_Update_Keep_Record_Skills_Based ---- 
+# ---- qry03f_Update_Keep_Record_Skills_Based ----
 qry03f_Update_Keep_Record_Skills_Based <- "
 UPDATE      STP_Enrolment_Record_Type
 SET         RecordStatus = 0
@@ -180,7 +180,7 @@ WHERE       STP_Enrolment_Record_Type.RecordStatus IS NULL
 AND         Keep_Skills_Based.Exclude IS NULL;"
 
 
-# ---- qry03fb_Update_Keep_Record_Skills_Based ---- 
+# ---- qry03fb_Update_Keep_Record_Skills_Based ----
 qry03fb_Update_Keep_Record_Skills_Based <- "
 UPDATE      STP_Enrolment_Record_Type
 SET         RecordStatus = 6
@@ -191,7 +191,7 @@ WHERE       STP_Enrolment_Record_Type.RecordStatus IS NULL
   AND       Keep_Skills_Based.Exclude ='Y';"
 
 
-# ---- qry03g_create_table_SkillsBasedCourses ---- 
+# ---- qry03g_create_table_SkillsBasedCourses ----
 qry03g_create_table_SkillsBasedCourses <- "
 SELECT    STP_Enrolment.PSI_CODE, 
           STP_Enrolment.PSI_PROGRAM_CODE, 
@@ -215,7 +215,7 @@ GROUP BY STP_Enrolment.PSI_CODE,
           STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
 
 
-# ---- qry03g_b_Keep_More_Skills_Based ---- 
+# ---- qry03g_b_Keep_More_Skills_Based ----
 qry03g_b_Keep_More_Skills_Based <- "
 SELECT        STP_Enrolment.ID, 
               tmp_tbl_SkillsBasedCourses.PSI_CODE, 
@@ -236,7 +236,7 @@ INNER JOIN    tmp_tbl_SkillsBasedCourses
 WHERE        (tmp_tbl_SkillsBasedCourses.Keep = 'Yes');"
 
 
-# ---- qry03g_c_Update_Keep_More_Skills_Based ---- 
+# ---- qry03g_c_Update_Keep_More_Skills_Based ----
 qry03g_c_Update_Keep_More_Skills_Based <- "
 UPDATE        STP_Enrolment_Record_Type
 SET           RecordStatus = 0
@@ -258,7 +258,7 @@ WHERE (STP_Enrolment.PSI_CODE = 'SEL')
   AND (STP_Enrolment_Record_Type.RecordStatus IS NULL)"
 
 
-# ---- qry03g_d_EnrolCoursesSeen ---- 
+# ---- qry03g_d_EnrolCoursesSeen ----
 qry03g_d_EnrolCoursesSeen <- "
 SELECT  STP_Enrolment.PSI_CODE, 
         STP_Enrolment.PSI_PROGRAM_CODE, 
@@ -279,7 +279,7 @@ GROUP BY STP_Enrolment.PSI_CODE,
         STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY;"
 
 
-# ---- qry03h_create_table_Suspect_Skills_Based ---- 
+# ---- qry03h_create_table_Suspect_Skills_Based ----
 qry03h_create_table_Suspect_Skills_Based <- "
 SELECT      STP_Enrolment.ID, STP_Enrolment.ENCRYPTED_TRUE_PEN,   STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment.PSI_SCHOOL_YEAR, STP_Enrolment.PSI_REGISTRATION_TERM, 
             STP_Enrolment.PSI_CODE, STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, LEFT(STP_Enrolment.PSI_CIP_CODE,2) AS CIP2, STP_Enrolment.PSI_CREDENTIAL_CATEGORY, 
@@ -291,7 +291,7 @@ INNER JOIN  STP_Enrolment
 WHERE    (STP_Enrolment_Record_Type.RecordStatus IS NULL);"
 
 
-# ---- qry03i_Find_Suspect_Skills_Based ---- 
+# ---- qry03i_Find_Suspect_Skills_Based ----
 qry03i_Find_Suspect_Skills_Based <- "
 SELECT    tmp_tbl_Suspect_Skills_Based.ID, tmp_tbl_Suspect_Skills_Based.ENCRYPTED_TRUE_PEN, tmp_tbl_Suspect_Skills_Based.PSI_STUDENT_NUMBER, 
           tmp_tbl_Suspect_Skills_Based.PSI_CODE, tmp_tbl_Suspect_Skills_Based.PSI_PROGRAM_CODE, 
@@ -311,8 +311,8 @@ WHERE (tmp_tbl_SkillsBasedCourses.Keep IS NULL);"
 
 
 # ---- qry03i2_Drop_Suspect_Skills_Based ----
-qry03i2_Drop_Suspect_Skills_Based <- 
-"UPDATE  Suspect_Skills_Based
+qry03i2_Drop_Suspect_Skills_Based <-
+  "UPDATE  Suspect_Skills_Based
 SET  Keep = 'Y'
 FROM  Suspect_Skills_Based 
 INNER JOIN tmp_tbl_SkillsBasedCourses 
@@ -324,7 +324,7 @@ INNER JOIN tmp_tbl_SkillsBasedCourses
   AND Suspect_Skills_Based.PSI_STUDY_LEVEL = tmp_tbl_SkillsBasedCourses.PSI_STUDY_LEVEL
 WHERE (tmp_tbl_SkillsBasedCourses.KEEP = 'Y')"
 
-# ---- qry03j_Update_Suspect_Skills_Based ---- 
+# ---- qry03j_Update_Suspect_Skills_Based ----
 qry03j_Update_Suspect_Skills_Based <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       RecordStatus = 6
@@ -333,7 +333,7 @@ FROM      Suspect_Skills_Based INNER JOIN STP_Enrolment_Record_Type
 WHERE STP_Enrolment_Record_Type.RecordStatus IS NULL AND Suspect_Skills_Based.Keep IS NULL;"
 
 
-# ---- qry03k_Drop_Developmental_CIPS ---- 
+# ---- qry03k_Drop_Developmental_CIPS ----
 qry03k_Drop_Developmental_CIPS <- "SELECT 
  STP_Enrolment.ID,   STP_Enrolment.ENCRYPTED_TRUE_PEN,   STP_Enrolment.PSI_STUDENT_NUMBER,   STP_Enrolment.PSI_CODE,
  STP_Enrolment.PSI_PROGRAM_CODE, STP_Enrolment.PSI_CREDENTIAL_PROGRAM_DESCRIPTION, 
@@ -347,7 +347,7 @@ WHERE     (STP_Enrolment.PSI_CONTINUING_EDUCATION_COURSE_ONLY = 'NOT SKILLS CRS 
 (LEFT(STP_Enrolment.PSI_CIP_CODE, 2) IN ('21', '32','33', '34', '35', '36', '37', '53', '89'));"
 
 
-# ---- qry03k_Update_ID_for_Drop_Dev_Credential_CIP ---- 
+# ---- qry03k_Update_ID_for_Drop_Dev_Credential_CIP ----
 qry03k_Update_ID_for_Drop_Dev_Credential_CIP <- "
 UPDATE  Drop_Developmental_CIPS
 SET     ID = STP_Enrolment.ID
@@ -356,7 +356,7 @@ INNER JOIN STP_Enrolment
   ON    Drop_Developmental_CIPS.ENCRYPTED_TRUE_PEN = STP_Enrolment.ENCRYPTED_TRUE_PEN;"
 
 
-# ---- qry03l_Update_Developmental_CIPs ---- 
+# ---- qry03l_Update_Developmental_CIPs ----
 qry03l_Update_Developmental_CIPs <- "
 UPDATE  STP_Enrolment_Record_Type
 SET     RecordStatus = 7
@@ -367,7 +367,7 @@ WHERE   STP_Enrolment_Record_Type.RecordStatus IS NULL
   AND   Drop_Developmental_CIPS.DO_NOT_EXCLUDE IS Null;"
 
 
-# ---- qry04a_Drop_No_PSI_Transition ---- 
+# ---- qry04a_Drop_No_PSI_Transition ----
 qry04a_Drop_No_PSI_Transition <- "
 SELECT  ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_ENTRY_STATUS
 INTO    Drop_No_Transition
@@ -375,7 +375,7 @@ FROM    STP_Enrolment
 WHERE   PSI_ENTRY_STATUS = 'No Transition';"
 
 
-# ---- qry04b_Update_Drop_No_PSI_Transition ---- 
+# ---- qry04b_Update_Drop_No_PSI_Transition ----
 qry04b_Update_Drop_No_PSI_Transition <- "
 UPDATE  STP_Enrolment_Record_Type
 SET     RecordStatus = 3
@@ -385,7 +385,7 @@ INNER JOIN Drop_No_Transition
 WHERE   STP_Enrolment_Record_Type.RecordStatus is NULL;"
 
 
-# ---- qry05a_Drop_Credential_Only ---- 
+# ---- qry05a_Drop_Credential_Only ----
 qry05a_Drop_Credential_Only <- "
 SELECT ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_ENTRY_STATUS, PSI_MIN_START_DATE, CREDENTIAL_AWARD_DATE
 INTO Drop_Credential_Only
@@ -395,7 +395,7 @@ WHERE (PSI_MIN_START_DATE IN('',' ','(Unspecified)'))
   AND (CREDENTIAL_AWARD_DATE NOT IN('',' ','(Unspecified)'));"
 
 
-# ---- qry05b_Update_Drop_Credential_Only ---- 
+# ---- qry05b_Update_Drop_Credential_Only ----
 qry05b_Update_Drop_Credential_Only <- "
 UPDATE  STP_Enrolment_Record_Type
 SET     RecordStatus = 4
@@ -404,7 +404,7 @@ FROM    STP_Enrolment_Record_Type INNER JOIN
 WHERE   STP_Enrolment_Record_Type.RecordStatus is NULL;"
 
 
-# ---- qry06a_Drop_PSI_Outside_BC ---- 
+# ---- qry06a_Drop_PSI_Outside_BC ----
 qry06a_Drop_PSI_Outside_BC <- "
 SELECT  ID, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, ATTENDING_PSI_OUTSIDE_BC
 INTO    Drop_PSI_Outside_BC
@@ -412,7 +412,7 @@ FROM    STP_Enrolment
 WHERE   ATTENDING_PSI_OUTSIDE_BC = 'Y';"
 
 
-# ---- qry06b_Update_Drop_PSI_Outside_BC ---- 
+# ---- qry06b_Update_Drop_PSI_Outside_BC ----
 qry06b_Update_Drop_PSI_Outside_BC <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       RecordStatus = 5
@@ -420,14 +420,14 @@ FROM      STP_Enrolment_Record_Type INNER JOIN
           Drop_PSI_Outside_BC ON STP_Enrolment_Record_Type.ID = Drop_PSI_Outside_BC.ID
 WHERE STP_Enrolment_Record_Type.RecordStatus is NULL;"
 
-# ---- qry07_Update_RecordStatus_No_Dropped ---- 
+# ---- qry07_Update_RecordStatus_No_Dropped ----
 qry07_Update_RecordStatus_No_Dropped <- "
 UPDATE  STP_Enrolment_Record_Type 
 SET     STP_Enrolment_Record_Type.RecordStatus = 0
 WHERE   STP_Enrolment_Record_Type.RecordStatus Is Null;"
 
 
-# ---- qry08a_Create_Table_STP_Enrolment_Valid ---- 
+# ---- qry08a_Create_Table_STP_Enrolment_Valid ----
 qry08a_Create_Table_STP_Enrolment_Valid <- "
 SELECT  STP_Enrolment.ID, STP_Enrolment.PSI_STUDENT_NUMBER, STP_Enrolment.ENCRYPTED_TRUE_PEN, STP_Enrolment.PSI_SCHOOL_YEAR, 
         STP_Enrolment.PSI_STUDENT_POSTAL_CODE_CURRENT, STP_Enrolment.PSI_ENROLMENT_SEQUENCE, STP_Enrolment.PSI_CODE, 
@@ -439,7 +439,7 @@ INNER JOIN STP_Enrolment_Record_Type
 WHERE     (STP_Enrolment_Record_Type.RecordStatus = 0);"
 
 
-# ---- qry08b_Fix_EPEN_in_STP_Enrolment_Valid ---- 
+# ---- qry08b_Fix_EPEN_in_STP_Enrolment_Valid ----
 qry08b_Fix_EPEN_in_STP_Enrolment_Valid <- "
 UPDATE    STP_Enrolment_Valid
 SET       ENCRYPTED_TRUE_PEN = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.EPEN_FIXED
@@ -449,7 +449,7 @@ INNER JOIN pssm2019.dbo.EPEN_ENRO_FIXES_2019_20
 WHERE     pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.EPEN_FIXED_FLAG = 1;"
 
 
-# ---- qry08c_Fix_Enrol_Sequence_in_STP_Enrolment_Valid ---- 
+# ---- qry08c_Fix_Enrol_Sequence_in_STP_Enrolment_Valid ----
 qry08c_Fix_Enrol_Sequence_in_STP_Enrolment_Valid <- "
 UPDATE    STP_Enrolment_Valid
 SET       PSI_ENROLMENT_SEQUENCE = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.PSI_ENROLMENT_SEQUENCE_FIX
@@ -458,7 +458,7 @@ INNER JOIN pssm2019.dbo.EPEN_ENRO_FIXES_2019_20
   ON STP_Enrolment_Valid.ID = pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.ID
 WHERE     pssm2019.dbo.EPEN_ENRO_FIXES_2019_20.PSI_ENROLMENT_SEQUENCE_FIX <> 'NULL';"
 
-# ---- qry09a_MinEnrolmentPEN ---- 
+# ---- qry09a_MinEnrolmentPEN ----
 qry09a_MinEnrolmentPEN <- "
 SELECT    ENCRYPTED_TRUE_PEN, PSI_SCHOOL_YEAR, MIN(PSI_ENROLMENT_SEQUENCE) AS MinPSIEnrolmentSequence
 INTO      tmp_tbl_qry09a_MinEnrolmentPEN
@@ -466,7 +466,7 @@ FROM      STP_Enrolment_Valid
 GROUP BY  ENCRYPTED_TRUE_PEN, PSI_SCHOOL_YEAR
 HAVING    ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)');"
 
-# ---- qry09b_MinEnrolmentPEN ---- 
+# ---- qry09b_MinEnrolmentPEN ----
 qry09b_MinEnrolmentPEN <- "
 SELECT    STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, 
           STP_Enrolment_Valid.PSI_SCHOOL_YEAR, 
@@ -480,13 +480,13 @@ INNER JOIN STP_Enrolment_Valid
   AND     tmp_tbl_qry09a_MinEnrolmentPEN.MinPSIEnrolmentSequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
 GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
 
-# ---- qry09c_MinEnrolmentPEN ---- 
+# ---- qry09c_MinEnrolmentPEN ----
 qry09c_MinEnrolmentPEN <- "
 SELECT    MinID AS MinOfID
 INTO      MinEnrolment_ID_PEN
 FROM      tmp_tbl_qry09b_MinEnrolmentPEN;"
 
-# ---- qry10a_MinEnrolmentSTUID ---- 
+# ---- qry10a_MinEnrolmentSTUID ----
 qry10a_MinEnrolmentSTUID <- "
 SELECT    PSI_STUDENT_NUMBER, PSI_CODE, PSI_SCHOOL_YEAR, MIN(PSI_ENROLMENT_SEQUENCE) AS MinPSIEnrolmentSequence, ENCRYPTED_TRUE_PEN
 INTO      tmp_tbl_qry10a_MinEnrolmentSTUID
@@ -494,7 +494,7 @@ FROM      STP_Enrolment_Valid
 GROUP BY  PSI_STUDENT_NUMBER, PSI_CODE, PSI_SCHOOL_YEAR, ENCRYPTED_TRUE_PEN
 HAVING    ENCRYPTED_TRUE_PEN IN('',' ','(Unspecified)');"
 
-# ---- qry10b_MinEnrolmentSTUID ---- 
+# ---- qry10b_MinEnrolmentSTUID ----
 qry10b_MinEnrolmentSTUID <- "
 SELECT    STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE , STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE, MIN(STP_Enrolment_Valid.ID) AS MinID
 INTO      tmp_tbl_qry10b_MinEnrolmentSTUID
@@ -506,13 +506,13 @@ INNER JOIN STP_Enrolment_Valid
   AND tmp_tbl_qry10a_MinEnrolmentSTUID.MinPSIEnrolmentSequence = STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
 GROUP BY STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, STP_Enrolment_Valid.PSI_SCHOOL_YEAR, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
 
-# ---- qry10c_MinEnrolmentSTUID ---- 
+# ---- qry10c_MinEnrolmentSTUID ----
 qry10c_MinEnrolmentSTUID <- "
 SELECT    MinID AS MinOfID
 INTO      MinEnrolment_ID_STUID
 FROM      tmp_tbl_qry10b_MinEnrolmentSTUID;"
 
-# ---- qry11a_Update_MinEnrolmentPEN ---- 
+# ---- qry11a_Update_MinEnrolmentPEN ----
 qry11a_Update_MinEnrolmentPEN <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       MinEnrolment = 1
@@ -520,7 +520,7 @@ FROM      MinEnrolment_ID_PEN
 INNER JOIN STP_Enrolment_Record_Type 
   ON MinEnrolment_ID_PEN.MinOfID = STP_Enrolment_Record_Type.ID;"
 
-# ---- qry11b_Update_MinEnrolmentSTUID ---- 
+# ---- qry11b_Update_MinEnrolmentSTUID ----
 qry11b_Update_MinEnrolmentSTUID <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       MinEnrolment = 1
@@ -530,13 +530,13 @@ INNER JOIN STP_Enrolment_Record_Type
 WHERE STP_Enrolment_Record_Type.MinEnrolment = 0
   OR  STP_Enrolment_Record_Type.MinEnrolment IS NULL;"
 
-# ---- qry11c_Update_MinEnrolment_NA ---- 
+# ---- qry11c_Update_MinEnrolment_NA ----
 qry11c_Update_MinEnrolment_NA <- "
 UPDATE STP_Enrolment_Record_Type 
 SET STP_Enrolment_Record_Type.MinEnrolment = 0
 WHERE (((STP_Enrolment_Record_Type.MinEnrolment) Is Null));"
 
-# ---- qry12a_FirstEnrolmentPEN ---- 
+# ---- qry12a_FirstEnrolmentPEN ----
 qry12a_FirstEnrolmentPEN <- "
 SELECT    ENCRYPTED_TRUE_PEN, MIN(PSI_MIN_START_DATE) AS MIN_PSI_MIN_START_DATE
 INTO      tmp_tbl_qry12a_FirstEnrolmentPEN
@@ -544,7 +544,7 @@ FROM      STP_Enrolment_Valid
 GROUP BY  ENCRYPTED_TRUE_PEN
 HAVING    ENCRYPTED_TRUE_PEN NOT IN('',' ','(Unspecified)');"
 
-# ---- qry12b_FirstEnrolmentPEN ---- 
+# ---- qry12b_FirstEnrolmentPEN ----
 qry12b_FirstEnrolmentPEN <- "
 SELECT    STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE, MIN(STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE) AS MinPSI_Enrolment_Sequence
 INTO      tmp_tbl_qry12b_FirstEnrolmentPEN
@@ -554,7 +554,7 @@ INNER JOIN STP_Enrolment_Valid
   AND tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE = STP_Enrolment_Valid.PSI_MIN_START_DATE
 GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, tmp_tbl_qry12a_FirstEnrolmentPEN.MIN_PSI_MIN_START_DATE;"
 
-# ---- qry12c_FirstEnrolmentPEN ---- 
+# ---- qry12c_FirstEnrolmentPEN ----
 qry12c_FirstEnrolmentPEN <- "
 SELECT    MIN(STP_Enrolment_Valid.ID) AS MinID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_MIN_START_DATE,  STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE
 INTO      FirstEnrolment_ID_PEN
@@ -566,7 +566,7 @@ AND tmp_tbl_qry12b_FirstEnrolmentPEN.MinPSI_Enrolment_Sequence = STP_Enrolment_V
 GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_MIN_START_DATE, STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE;"
 
 
-# ---- qry13a_FirstEnrolmentSTUID ---- 
+# ---- qry13a_FirstEnrolmentSTUID ----
 qry13a_FirstEnrolmentSTUID <- "
 SELECT    PSI_STUDENT_NUMBER, PSI_CODE, MIN(PSI_MIN_START_DATE) AS Min_PSI_Min_Start_Date
 INTO      tmp_tbl_qry13a_FirstEnrolment_STUID
@@ -574,7 +574,7 @@ FROM      STP_Enrolment_Valid
 WHERE     ENCRYPTED_TRUE_PEN IN('',' ','(Unspecified)')
 GROUP BY PSI_STUDENT_NUMBER, PSI_CODE;"
 
-# ---- qry13b_FirstEnrolmentSTUID ---- 
+# ---- qry13b_FirstEnrolmentSTUID ----
 qry13b_FirstEnrolmentSTUID <- "
 SELECT    STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date, 
           MIN(STP_Enrolment_Valid.PSI_ENROLMENT_SEQUENCE) AS Min_PSI_Enrolment_Sequence
@@ -586,7 +586,7 @@ INNER JOIN STP_Enrolment_Valid
   AND tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date = STP_Enrolment_Valid.PSI_MIN_START_DATE
 GROUP BY STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE, tmp_tbl_qry13a_FirstEnrolment_STUID.Min_PSI_Min_Start_Date;"
 
-# ---- qry13c_FirstEnrolmentSTUID ---- 
+# ---- qry13c_FirstEnrolmentSTUID ----
 qry13c_FirstEnrolmentSTUID <- "
 SELECT    MIN(STP_Enrolment_Valid.ID) AS MinID, STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE
 INTO      FirstEnrolment_ID_STUID
@@ -598,7 +598,7 @@ INNER JOIN STP_Enrolment_Valid
   AND tmp_tbl_qry13b_FirstEnrolment_STUID.Min_PSI_Min_Start_Date = STP_Enrolment_Valid.PSI_MIN_START_DATE
 GROUP BY STP_Enrolment_Valid.ENCRYPTED_TRUE_PEN, STP_Enrolment_Valid.PSI_STUDENT_NUMBER, STP_Enrolment_Valid.PSI_CODE;"
 
-# ---- qry14a_Update_FirstEnrolmentPEN ---- 
+# ---- qry14a_Update_FirstEnrolmentPEN ----
 qry14a_Update_FirstEnrolmentPEN <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       FirstEnrolment = 1
@@ -608,7 +608,7 @@ INNER JOIN STP_Enrolment_Record_Type
 WHERE     STP_Enrolment_Record_Type.FirstEnrolment IS NULL
     OR    STP_Enrolment_Record_Type.FirstEnrolment = 0;"
 
-# ---- qry14b_Update_FirstEnrolmentSTUID ---- 
+# ---- qry14b_Update_FirstEnrolmentSTUID ----
 qry14b_Update_FirstEnrolmentSTUID <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       FirstEnrolment = 1
@@ -617,7 +617,7 @@ INNER JOIN FirstEnrolment_ID_STUID
   ON STP_Enrolment_Record_Type.ID = FirstEnrolment_ID_STUID.MinID
 WHERE STP_Enrolment_Record_Type.FirstEnrolment IS NULL;"
 
-# ---- qry14c_Update_FirstEnrolmentNA ---- 
+# ---- qry14c_Update_FirstEnrolmentNA ----
 qry14c_Update_FirstEnrolmentNA <- "
 UPDATE    STP_Enrolment_Record_Type
 SET       FirstEnrolment = 0
@@ -625,13 +625,13 @@ WHERE     FirstEnrolment IS NULL;"
 
 # ---- RecordTypeSummary ----
 RecordTypeSummary <-
-"SELECT RecordStatus, COUNT(*) AS Expr1
+  "SELECT RecordStatus, COUNT(*) AS Expr1
 FROM  STP_Enrolment_Record_Type
 GROUP BY RecordStatus
 "
 
 # ---- CheckSkillsBased ---
 CheckSkillsBased <-
-"SELECT PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
+  "SELECT PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY
 FROM  Drop_Skills_Based
 GROUP BY PSI_CODE, PSI_CONTINUING_EDUCATION_COURSE_ONLY, CIP2, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_STUDY_LEVEL, PSI_CREDENTIAL_CATEGORY;"

--- a/sql/01-enrolment-preprocessing/pssm-birthdate-cleaning.R
+++ b/sql/01-enrolment-preprocessing/pssm-birthdate-cleaning.R
@@ -1,6 +1,5 @@
-
 # ---- ----
-qry01_BirthdateCleaning <-  "
+qry01_BirthdateCleaning <- "
 SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE, count(*) as NumBirthdateRecords
 INTO        tmp_BirthDate
 FROM        STP_Enrolment
@@ -17,15 +16,15 @@ GROUP BY    ENCRYPTED_TRUE_PEN
 HAVING      COUNT(*) > 1"
 
 # ---- ----
-qry03_BirthdateCleaning <- 
-"SELECT     ENCRYPTED_TRUE_PEN, MIN(PSI_BIRTHDATE) AS MinPSIBirthdate
+qry03_BirthdateCleaning <-
+  "SELECT     ENCRYPTED_TRUE_PEN, MIN(PSI_BIRTHDATE) AS MinPSIBirthdate
 INTO        tmp_MinPSIBirthdate
 FROM        tmp_BirthDate
 WHERE       PSI_BIRTHDATE NOT IN('',' ', '(Unspecified)')
 GROUP BY    ENCRYPTED_TRUE_PEN"
 
 # ---- ----
-qry04_BirthdateCleaning <-"
+qry04_BirthdateCleaning <- "
 SELECT     ENCRYPTED_TRUE_PEN, MAX(PSI_BIRTHDATE) AS MaxPSIBirthdate
 INTO        tmp_MaxPSIBirthdate
 FROM        tmp_BirthDate
@@ -34,8 +33,8 @@ AND         ENCRYPTED_TRUE_PEN NOT IN('',' ', '(Unspecified)')
 GROUP BY    ENCRYPTED_TRUE_PEN"
 
 # ---- ----
-qry05_BirthdateCleaning <- 
-"UPDATE       tmp_MinPSIBirthdate
+qry05_BirthdateCleaning <-
+  "UPDATE       tmp_MinPSIBirthdate
 SET           NumBirthdateRecords = tmp_BirthDate.NumBirthdateRecords
 FROM          tmp_MinPSIBirthdate 
 INNER JOIN    tmp_BirthDate 
@@ -43,7 +42,7 @@ INNER JOIN    tmp_BirthDate
   AND         tmp_MinPSIBirthdate.MinPSIBirthdate = tmp_BirthDate.PSI_BIRTHDATE"
 
 # ---- ----
-qry06_BirthdateCleaning <-  "
+qry06_BirthdateCleaning <- "
 UPDATE        tmp_MaxPSIBirthdate
 SET           NumBirthdateRecords = tmp_BirthDate.NumBirthdateRecords
 FROM          tmp_MaxPSIBirthdate 
@@ -70,15 +69,15 @@ INNER JOIN    tmp_MaxPSIBirthdate
   ON          tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN = tmp_MaxPSIBirthdate.ENCRYPTED_TRUE_PEN"
 
 # ---- ----
-qry08_BirthdateCleaning <-  
-"UPDATE       tmp_MoreThanOne_Birthdate
+qry08_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
 SET           LastSeenBirthdate = STP_Enrolment.LAST_SEEN_BIRTHDATE
 FROM          tmp_MoreThanOne_Birthdate 
 INNER JOIN    STP_Enrolment 
 ON            tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN = STP_Enrolment.ENCRYPTED_TRUE_PEN"
 
 # ---- ----
-qry09_BirthdateCleaning <-  "
+qry09_BirthdateCleaning <- "
 UPDATE      tmp_MoreThanOne_Birthdate
 SET         UseMaxOrMin_FINAL = CASE 
               WHEN MaxPSIBirthdate = LastSeenBirthdate THEN 'MAX'
@@ -88,26 +87,26 @@ SET         UseMaxOrMin_FINAL = CASE
 FROM        tmp_MoreThanOne_Birthdate"
 
 # ---- ----
-qry10_BirthdateCleaning <- 
-"UPDATE       tmp_MoreThanOne_Birthdate
+qry10_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
 SET                psi_birthdate_cleaned = MinPSIBirthdate
 WHERE        (USEMAXORMIN_FINAL = 'MIN')"
 
 # ---- ----
-qry11_BirthdateCleaning <-  
-"UPDATE       tmp_MoreThanOne_Birthdate
+qry11_BirthdateCleaning <-
+  "UPDATE       tmp_MoreThanOne_Birthdate
 SET                psi_birthdate_cleaned = MaxPSIBirthdate
 WHERE        (USEMAXORMIN_FINAL = 'MAX')"
-               
+
 # ---- ----
-qry12_BirthdateCleaning <-  
-"UPDATE    STP_Enrolment
+qry12_BirthdateCleaning <-
+  "UPDATE    STP_Enrolment
 SET              psi_birthdate_cleaned = tmp_MoreThanOne_Birthdate.psi_birthdate_cleaned
 FROM         STP_Enrolment INNER JOIN
                       tmp_MoreThanOne_Birthdate ON STP_Enrolment.ENCRYPTED_TRUE_PEN = tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN"
 # ---- ----
-qry13_BirthdateCleaning <-  
-"SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
+qry13_BirthdateCleaning <-
+  "SELECT     ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
  INTO            tmp_NullBirthdate
  FROM         tmp_BirthDate
  GROUP BY ENCRYPTED_TRUE_PEN, PSI_BIRTHDATE
@@ -123,7 +122,7 @@ HAVING      (ENCRYPTED_TRUE_PEN NOT IN('', ' ', '(Unspecified)')) AND (PSI_BIRTH
 
 # ---- ----
 qry15_BirthdateCleaning <-
-"SELECT     tmp_NonNullBirthdate.ENCRYPTED_TRUE_PEN, tmp_NonNullBirthdate.PSI_BIRTHDATE
+  "SELECT     tmp_NonNullBirthdate.ENCRYPTED_TRUE_PEN, tmp_NonNullBirthdate.PSI_BIRTHDATE
 INTO        tmp_NullBirthdateCleaned
 FROM        tmp_NonNullBirthdate 
 INNER JOIN  tmp_NullBirthdate 
@@ -135,16 +134,16 @@ UPDATE    tmp_NullBirthdateCleaned
 SET       psi_birthdate_cleaned = tmp_MoreThanOne_Birthdate.psi_birthdate_cleaned
 FROM      tmp_NullBirthdateCleaned 
 INNER JOIN tmp_MoreThanOne_Birthdate 
-ON tmp_NullBirthdateCleaned.ENCRYPTED_TRUE_PEN = tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN"            
+ON tmp_NullBirthdateCleaned.ENCRYPTED_TRUE_PEN = tmp_MoreThanOne_Birthdate.ENCRYPTED_TRUE_PEN"
 
 # ---- ----
-qry17_BirthdateCleaning <-  
-"UPDATE    tmp_NullBirthdateCleaned
+qry17_BirthdateCleaning <-
+  "UPDATE    tmp_NullBirthdateCleaned
 SET              psi_birthdate_cleaned = PSI_BIRTHDATE
 WHERE     (psi_birthdate_cleaned IS NULL)"
 
 # ---- ----
-qry18_BirthdateCleaning <-  "
+qry18_BirthdateCleaning <- "
 UPDATE    STP_Enrolment
 SET       psi_birthdate_cleaned = tmp_NullBirthdateCleaned.psi_birthdate_cleaned
 FROM      STP_Enrolment 
@@ -153,9 +152,9 @@ INNER JOIN  tmp_NullBirthdateCleaned
 WHERE     (STP_Enrolment.psi_birthdate_cleaned IS NULL) 
 OR        (STP_Enrolment.psi_birthdate_cleaned IN('', ' ', '(Unspecified)'))"
 
-# ---- ----               
-qry19_BirthdateCleaning <-  
- "UPDATE    STP_Enrolment
+# ---- ----
+qry19_BirthdateCleaning <-
+  "UPDATE    STP_Enrolment
  SET         psi_birthdate_cleaned = PSI_BIRTHDATE
 WHERE       ((psi_birthdate_cleaned IS NULL) AND (NOT (PSI_BIRTHDATE IS NULL)))
 OR          ((psi_birthdate_cleaned IN( '',' ', '(Unspecified)'))   AND (NOT (PSI_BIRTHDATE IS NULL)))
@@ -164,8 +163,8 @@ OR          ((psi_birthdate_cleaned IN( '',' ', '(Unspecified)'))   AND (PSI_BIR
 
 
 # ---- ----
-qry20_BirthdateCleaning <-  
-"SELECT     PSI_STUDENT_NUMBER, PSI_BIRTHDATE, psi_birthdate_cleaned, PSI_CODE, COUNT(*) AS Expr1
+qry20_BirthdateCleaning <-
+  "SELECT     PSI_STUDENT_NUMBER, PSI_BIRTHDATE, psi_birthdate_cleaned, PSI_CODE, COUNT(*) AS Expr1
 INTO            tmp_TEST_multi_birthdate
 FROM         STP_Enrolment
 WHERE     (ENCRYPTED_TRUE_PEN IN( ' ', '(Unspecified)'))
@@ -173,9 +172,8 @@ GROUP BY PSI_STUDENT_NUMBER, PSI_BIRTHDATE, psi_birthdate_cleaned, PSI_CODE
 HAVING      (PSI_BIRTHDATE NOT IN( '',' ', '(Unspecified)')) AND (PSI_STUDENT_NUMBER NOT IN( '',' ', '(Unspecified)')) AND (PSI_CODE NOT IN( '',' ', '(Unspecified)'))"
 
 # ---- ----
-qry21_BirthdateCleaning <-  
-"SELECT     PSI_STUDENT_NUMBER, PSI_CODE, COUNT(*) AS Expr1
+qry21_BirthdateCleaning <-
+  "SELECT     PSI_STUDENT_NUMBER, PSI_CODE, COUNT(*) AS Expr1
 FROM         tmp_TEST_multi_birthdate
 GROUP BY    PSI_STUDENT_NUMBER, PSI_CODE
 HAVING      (COUNT(*) > 1)"
-

--- a/sql/01d-enrolment-analysis/01d-enrolment-analysis.R
+++ b/sql/01d-enrolment-analysis/01d-enrolment-analysis.R
@@ -1,4 +1,4 @@
-# ---- qry01a_MinEnrolmentSupVar ---- 
+# ---- qry01a_MinEnrolmentSupVar ----
 qry01a_MinEnrolmentSupVar <- "
 SELECT    STP_Enrolment.ID, STP_Enrolment.psi_birthdate_cleaned, STP_Enrolment.PSI_MIN_START_DATE, 
           STP_Enrolment_Record_Type.MinEnrolment, STP_Enrolment_Record_Type.FirstEnrolment, STP_Enrolment_Record_Type.RecordStatus
@@ -8,7 +8,7 @@ INNER JOIN STP_Enrolment_Record_Type
   ON      STP_Enrolment.ID = STP_Enrolment_Record_Type.ID;"
 
 
-# ---- qry01b_MinEnrolmentSupVar ---- 
+# ---- qry01b_MinEnrolmentSupVar ----
 qry01b_MinEnrolmentSupVar <- "ALTER TABLE MinEnrolmentSupVar 
 ADD
 	psi_birthdate_cleaned_D date NULL,
@@ -21,20 +21,20 @@ ADD
 	IS_SKILLS_BASED int NULL;"
 
 
-# ---- qry01c_MinEnrolmentSupVar ---- 
+# ---- qry01c_MinEnrolmentSupVar ----
 qry01c_MinEnrolmentSupVar <- "
 UPDATE    MinEnrolmentSupvar
 SET       psi_birthdate_cleaned_D = psi_birthdate_cleaned
 WHERE     psi_birthdate_cleaned is not null;"
 
 
-# ---- qry01d_MinEnrolmentSupVar ---- --- 
+# ---- qry01d_MinEnrolmentSupVar ---- ---
 qry01d1_MinEnrolmentSupVar <- "
 UPDATE MinEnrolmentSupvar
 SET    PSI_MIN_START_DATE_D = PSI_MIN_START_DATE
 WHERE     (PSI_MIN_START_DATE <> '' AND PSI_MIN_START_DATE <> '(Unspecified)';"
 
-# ---- qry01d_MinEnrolmentSupVar ---- 
+# ---- qry01d_MinEnrolmentSupVar ----
 qry01d2_MinEnrolmentSupVar <- "
 UPDATE      MinEnrolmentSupVar
 SET         psi_birthdate_cleaned_D = NULL
@@ -46,14 +46,14 @@ WHERE       psi_birthdate_cleaned_D = CONVERT(DATETIME, '1900-01-01 00:00:00', 1
 );"
 
 
-# ---- qry01e_MinEnrolmentSupVar ---- 
+# ---- qry01e_MinEnrolmentSupVar ----
 qry01e_MinEnrolmentSupVar <- "
 UPDATE    MinEnrolmentSupVar
 SET       IS_FIRST_ENROLMENT = 'Yes'
 WHERE     FirstEnrolment = 1;"
 
 
-# ---- qry02a_UpdateAgeAtEnrol ---- 
+# ---- qry02a_UpdateAgeAtEnrol ----
 qry02a_UpdateAgeAtEnrol <- "
 UPDATE    MinEnrolment
 SET       AGE_AT_ENROL_DATE = 
@@ -65,7 +65,7 @@ WHERE     psi_birthdate_cleaned_D IS NOT NULL
 ;"
 
 
-# ---- qry02b_UpdateAGAtEnrol ---- 
+# ---- qry02b_UpdateAGAtEnrol ----
 qry02b_UpdateAGAtEnrol <- "
 UPDATE    MinEnrolment
 SET       AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
@@ -75,7 +75,7 @@ WHERE     AgeGroupLookup.LowerBound <= MinEnrolment.AGE_AT_ENROL_DATE
   AND     AgeGroupLookup.UpperBound >= MinEnrolment.AGE_AT_ENROL_DATE;"
 
 
-# ---- qry04a*_UpdateMinEnrolment_Gender ---- 
+# ---- qry04a*_UpdateMinEnrolment_Gender ----
 qry04a1_UpdateMinEnrolment_Gender <- "
 UPDATE      MinEnrolment
 SET         PSI_GENDER = Credential.PSI_GENDER_CLEANED
@@ -102,7 +102,7 @@ WHERE       MinEnrolment.ENCRYPTED_TRUE_PEN IS NULL
 ;"
 
 
-# ---- qry04b*_tmp_MinEnrolment_Gender ---- 
+# ---- qry04b*_tmp_MinEnrolment_Gender ----
 qry04b1_tmp_MinEnrolment_Gender <- "
 SELECT    DISTINCT PSI_GENDER, ENCRYPTED_TRUE_PEN
 INTO      tmp_MinEnrolment_EPEN_Gender_step1
@@ -112,7 +112,7 @@ AND       ENCRYPTED_TRUE_PEN IS NOT NULL
 AND       ENCRYPTED_TRUE_PEN <> '(Unspecified)'
 ;"
 
-qry04b2_tmp_MinEnrolment_Gender <-"
+qry04b2_tmp_MinEnrolment_Gender <- "
 SELECT    DISTINCT PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE
 INTO      tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1
 FROM      MinEnrolment
@@ -122,20 +122,20 @@ OR        ENCRYPTED_TRUE_PEN = '(Unspecified)'
 ;"
 
 # Make a new table called tmp_MinEnrolment_EPEN_Gender and append the tmp_MinEnrolment_EPEN_Gender_step1 records to it. */
-qry04b3_tmp_MinEnrolment_Gender <-"
+qry04b3_tmp_MinEnrolment_Gender <- "
 SELECT  tmp_MinEnrolment_EPEN_Gender_step1.* 
 INTO    tmp_MinEnrolment_EPEN_Gender
 FROM    tmp_MinEnrolment_EPEN_Gender_step1;"
 
 # In the tmp_MinEnrolment_EPEN_Gender add cols for PSI_STUDENT_NUMBER, PSI_CODE and CONCATENATED_ID */
-qry04b4_tmp_MinEnrolment_Gender <-"
+qry04b4_tmp_MinEnrolment_Gender <- "
 ALTER TABLE tmp_MinEnrolment_EPEN_Gender
   ADD   PSI_STUDENT_NUMBER varchar(50), 
         PSI_CODE varchar(50),
         CONCATENATED_ID varchar(50);"
 
 # Append the tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1 records to the tmp_MinEnrolment_EPEN_Gender */
-qry04b5_tmp_MinEnrolment_Gender <-"
+qry04b5_tmp_MinEnrolment_Gender <- "
 INSERT INTO tmp_MinEnrolment_EPEN_Gender (PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE)
 SELECT      PSI_GENDER, PSI_STUDENT_NUMBER, PSI_CODE 
 FROM        tmp_MinEnrolment_STUDNUM_PSICODE_Gender_step1;"
@@ -156,7 +156,7 @@ OR          (ENCRYPTED_TRUE_PEN = '')
 OR          (ENCRYPTED_TRUE_PEN = '(Unspecified)')
 ;"
 
-# ---- qry04c_tmp_MinEnrolment_GenderDups ---- 
+# ---- qry04c_tmp_MinEnrolment_GenderDups ----
 qry04c_tmp_MinEnrolment_GenderDups <- "
 SELECT     CONCATENATED_ID, COUNT(*) AS Expr1
 INTO       tmp_Dup_MinEnrolment_EPEN_Gender
@@ -168,7 +168,7 @@ ALTER TABLE tmp_Dup_MinEnrolment_EPEN_Gender
 ADD PSI_GENDER_FirstEnrolment varchar(50);
 ;"
 
-# ---- qry04d*_tmp_MinEnrolment_GenderDups_PickGender ---- 
+# ---- qry04d*_tmp_MinEnrolment_GenderDups_PickGender ----
 qry04d1_tmp_MinEnrolment_GenderDups_PickGender <- "
 UPDATE    tmp_Dup_MinEnrolment_EPEN_Gender
 SET       PSI_GENDER_FirstEnrolment = MinEnrolment.PSI_GENDER
@@ -186,7 +186,7 @@ INNER JOIN MinEnrolment
 ON tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = (MinEnrolment.PSI_STUDENT_NUMBER+MinEnrolment.PSI_CODE)
 WHERE     (MinEnrolment.IS_FIRST_ENROLMENT = 'Yes');"
 
-# Select records with 'U' to tmp table 
+# Select records with 'U' to tmp table
 qry04d3_tmp_MinEnrolment_GenderDups_PickGender <- "
 SELECT *   
 INTO  tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
@@ -196,12 +196,12 @@ AND PSI_GENDER_FirstEnrolment <> 'Female'
 AND PSI_GENDER_FirstEnrolment <> 'Gender Diverse'
 "
 
-# Alter table to add other gender variable 
+# Alter table to add other gender variable
 qry04d4_tmp_MinEnrolment_GenderDups_PickGender <- "
 ALTER TABLE tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
 ADD PSI_GENDER_FinalUnknowns VARCHAR(50)"
 
-# Update new gender variable with gender <> 'U' 
+# Update new gender variable with gender <> 'U'
 qry04d5_tmp_MinEnrolment_GenderDups_PickGender <- "
 UPDATE       tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
 SET                PSI_GENDER_FinalUnknowns = tmp_MinEnrolment_EPEN_Gender.psi_gender
@@ -210,7 +210,7 @@ INNER JOIN      tmp_MinEnrolment_EPEN_Gender
 ON tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.CONCATENATED_ID = tmp_MinEnrolment_EPEN_Gender.CONCATENATED_ID
 WHERE        tmp_MinEnrolment_EPEN_Gender.psi_gender <> 'Unknown'"
 
-# Update original table with non-U gender 
+# Update original table with non-U gender
 qry04d6_tmp_MinEnrolment_GenderDups_PickGender <- "
 UPDATE       tmp_Dup_MinEnrolment_EPEN_Gender
 SET                PSI_GENDER_FirstEnrolment = tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.PSI_GENDER_FinalUnknowns
@@ -219,7 +219,7 @@ INNER JOIN      tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns
 ON tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = tmp_Dup_MinEnrolment_EPEN_Gender_Unknowns.CONCATENATED_ID"
 
 
-# ---- qry04e_UpdateMinEnrolment_EPEN_GenderDups ---- 
+# ---- qry04e_UpdateMinEnrolment_EPEN_GenderDups ----
 qry04e1_UpdateMinEnrolment_EPEN_GenderDups <- "
 UPDATE       MinEnrolment
 SET          PSI_GENDER = tmp_Dup_MinEnrolment_EPEN_Gender.PSI_GENDER_FirstEnrolment
@@ -234,7 +234,7 @@ FROM         MinEnrolment
 INNER JOIN   tmp_Dup_MinEnrolment_EPEN_Gender 
 ON           tmp_Dup_MinEnrolment_EPEN_Gender.CONCATENATED_ID = (MinEnrolment.PSI_STUDENT_NUMBER+MinEnrolment.PSI_CODE);"
 
-# ---- qry05a1_Extract_No_Gender ---- 
+# ---- qry05a1_Extract_No_Gender ----
 qry05a1_Extract_No_Gender <- "
 SELECT    DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER 
 INTO      Extract_No_Gender
@@ -245,7 +245,7 @@ OR        PSI_GENDER = '(Unspecified)'
 OR        PSI_GENDER = '' 
 OR        PSI_GENDER IS NULL;"
 
-# ---- qry05a1_Extract_No_Gender_First_Enrolment ---- 
+# ---- qry05a1_Extract_No_Gender_First_Enrolment ----
 qry05a1_Extract_No_Gender_First_Enrolment <- "
 SELECT    DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, PSI_GENDER 
 INTO      Extract_No_Gender_First_Enrolment
@@ -253,7 +253,7 @@ FROM      MinEnrolment
 WHERE     (PSI_GENDER ='Unknown' OR PSI_GENDER = '(Unspecified)' OR PSI_GENDER ='' OR PSI_GENDER IS NULL) 
 AND       IS_FIRST_ENROLMENT='Yes';"
 
-# ---- qry05a2_Show_Gender_Distribution ---- 
+# ---- qry05a2_Show_Gender_Distribution ----
 qry05a2_Show_Gender_Distribution <- "
 SELECT     PSI_GENDER, COUNT(*) AS NumEnrolled 
 FROM       MinEnrolment
@@ -264,12 +264,12 @@ WHERE      PSI_GENDER <> 'Unknown'
   AND      IS_FIRST_ENROLMENT='Yes'
 GROUP BY   PSI_GENDER;"
 
-# ---- qry06a1_Assign_TopID_Gender ---- 
+# ---- qry06a1_Assign_TopID_Gender ----
 qry06a1_Assign_TopID_Gender <- "
 UPDATE    TOP (5429) Extract_No_Gender_First_Enrolment
 SET       PSI_GENDER = 'Female';"
 
-# ---- qry06a2_Assign_TopID_Gender2 ---- 
+# ---- qry06a2_Assign_TopID_Gender2 ----
 qry06a2_Assign_TopID_Gender2 <- "
 UPDATE    TOP (5177) Extract_No_Gender_First_Enrolment
 SET       PSI_GENDER = 'Male'
@@ -279,7 +279,7 @@ WHERE     PSI_GENDER = 'U'
     OR    PSI_GENDER='' 
     OR    PSI_GENDER IS NULL;"
 
-# ---- qry06a2_Assign_TopID_Gender3 ---- 
+# ---- qry06a2_Assign_TopID_Gender3 ----
 qry06a2_Assign_TopID_Gender3 <- "
 UPDATE    Extract_No_Gender_First_Enrolment
 SET       PSI_GENDER = 'Gender Diverse'
@@ -290,7 +290,7 @@ WHERE     PSI_GENDER = 'U'
     OR    PSI_GENDER IS NULL;"
 
 
-# ---- qry06a3*_CorrectGender1 ---- 
+# ---- qry06a3*_CorrectGender1 ----
 qry06a3_CorrectGender1 <- "
 UPDATE    Extract_No_Gender
 SET       PSI_GENDER = Extract_No_Gender_First_Enrolment.PSI_GENDER
@@ -330,7 +330,7 @@ OR        PSI_GENDER = '(Unspecified)'
 "
 
 
-# ---- qry06a4a_ExtractNoGender_DupEPENS ---- 
+# ---- qry06a4a_ExtractNoGender_DupEPENS ----
 qry06a4a_ExtractNoGender_DupEPENS <- "
 SELECT    ENCRYPTED_TRUE_PEN, PSI_GENDER
 INTO      tmp_Extract_No_Gender_EPENS
@@ -341,7 +341,7 @@ AND       ENCRYPTED_TRUE_PEN <> '(Unspecified)'
 GROUP BY  ENCRYPTED_TRUE_PEN, PSI_GENDER;"
 
 
-# ---- qry06a4b_ExtractNoGender_DupEPENS ---- 
+# ---- qry06a4b_ExtractNoGender_DupEPENS ----
 qry06a4b_ExtractNoGender_DupEPENS_1 <- "
 SELECT     ENCRYPTED_TRUE_PEN, COUNT(*) AS Expr1
 INTO       tmp_Extract_No_Gender_DupEPENS
@@ -349,8 +349,8 @@ FROM       tmp_Extract_No_Gender_EPENS
 GROUP BY   ENCRYPTED_TRUE_PEN
 HAVING     COUNT(*) > 1;"
 
-qry06a4b_ExtractNoGender_DupEPENS_2 <- 
-"UPDATE    TOP (10) tmp_Extract_No_Gender_DupEPENS
+qry06a4b_ExtractNoGender_DupEPENS_2 <-
+  "UPDATE    TOP (10) tmp_Extract_No_Gender_DupEPENS
 SET        PSI_GENDER_to_use ='Female'
 WHERE      PSI_GENDER_to_use IS NULL;
 
@@ -364,7 +364,7 @@ WHERE      PSI_GENDER_to_use IS NULL;
 "
 
 
-# ---- qry06a4c_Update_ExtractNoGender_DupEPENS ---- 
+# ---- qry06a4c_Update_ExtractNoGender_DupEPENS ----
 qry06a4c_Update_ExtractNoGender_DupEPENS <- "
 UPDATE     Extract_No_Gender
 SET        PSI_GENDER = tmp_Extract_No_Gender_DupEPENS.PSI_GENDER_TO_USE
@@ -373,7 +373,7 @@ INNER JOIN tmp_Extract_No_Gender_DupEPENS
   ON       Extract_No_Gender.ENCRYPTED_TRUE_PEN = tmp_Extract_No_Gender_DupEPENS.ENCRYPTED_TRUE_PEN;"
 
 # ---- qry06a4c_Check_Prop  ----
-qry06a4c_Check_Prop  <- "
+qry06a4c_Check_Prop <- "
 SELECT     PSI_GENDER, COUNT(*) AS NumEnrolled
 FROM       MinEnrolment
 WHERE      PSI_GENDER <> 'Unknown' 
@@ -384,14 +384,14 @@ AND        IS_FIRST_ENROLMENT='Yes'
 GROUP BY   PSI_GENDER
 "
 
-# ---- qry06a5_CorrectGender2 ---- 
+# ---- qry06a5_CorrectGender2 ----
 qry06a5_CorrectGender2 <- "
 UPDATE    MinEnrolment
 SET       PSI_GENDER = Extract_No_Gender.PSI_GENDER
 FROM      Extract_No_Gender 
 INNER JOIN MinEnrolment ON Extract_No_Gender.id = MinEnrolment.id;"
 
-# ---- qry07a_Extract_No_Age ---- 
+# ---- qry07a_Extract_No_Age ----
 qry07a_Extract_No_Age <- "
 SELECT DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_CODE, AGE_AT_ENROL_DATE, 
 PSI_SCHOOL_YEAR, PSI_MIN_START_DATE, PSI_MIN_START_DATE_D
@@ -400,7 +400,7 @@ FROM    MinEnrolment
 WHERE   AGE_AT_ENROL_DATE IS NULL;"
 
 
-# ---- qry07b_Extract_No_Age_First_Enrolment ---- 
+# ---- qry07b_Extract_No_Age_First_Enrolment ----
 qry07b_Extract_No_Age_First_Enrolment <- "
 SELECT DISTINCT id, ENCRYPTED_TRUE_PEN, PSI_STUDENT_NUMBER, PSI_GENDER, PSI_CODE, AGE_AT_ENROL_DATE
 INTO            Extract_No_Age_First_Enrolment
@@ -408,7 +408,7 @@ FROM         MinEnrolment
 WHERE     (AGE_AT_ENROL_DATE IS NULL) AND IS_FIRST_ENROLMENT='Yes';"
 
 
-# ---- qry07b2_update_Extract_No_Age_IsFirstEnrolment ---- 
+# ---- qry07b2_update_Extract_No_Age_IsFirstEnrolment ----
 qry07b2_update_Extract_No_Age_IsFirstEnrolment <- "
 UPDATE    Extract_No_Age
 SET       IS_FIRST_ENROLMENT = 'Yes'
@@ -417,9 +417,7 @@ INNER JOIN Extract_No_Age_First_Enrolment
 ON Extract_No_Age.id = Extract_No_Age_First_Enrolment.id;"
 
 
-
-
-# ---- qry07c_Show_Age_Distribution ---- 
+# ---- qry07c_Show_Age_Distribution ----
 qry07c_Show_Age_Distribution <- "
 SELECT     AGE_AT_ENROL_DATE, PSI_GENDER, COUNT(id) AS NumEnrolled 
 FROM         MinEnrolment
@@ -427,7 +425,7 @@ WHERE     (AGE_GROUP_ENROL_DATE IS NOT NULL) AND (IS_FIRST_ENROLMENT = 'Yes')
 GROUP BY AGE_AT_ENROL_DATE, PSI_GENDER;"
 
 
-# ---- qry07d1_Update_Extract_No_Age ---- 
+# ---- qry07d1_Update_Extract_No_Age ----
 qry07d1_Update_Extract_No_Age <- "
 UPDATE    Extract_No_Age
 SET              AGE_AT_ENROL_DATE = Extract_No_Age_First_Enrolment.AGE_AT_ENROL_DATE
@@ -463,7 +461,7 @@ WHERE Extract_No_Age.AGE_AT_ENROL_DATE Is Null
 AND   R_Extract_No_Age.AGE_AT_ENROL_DATE Is Not Null;"
 
 
-# ---- qry07d_Create_Age_Manual_Fixes View ---- 
+# ---- qry07d_Create_Age_Manual_Fixes View ----
 qry07d_Create_Age_Manual_Fixes_View <- "CREATE VIEW qry05c_Age_Manual_Fixes_View AS
 SELECT     TOP (100) PERCENT Extract_No_Age.AGE_AT_ENROL_DATE AS Expr1, MinEnrolment.PSI_GENDER, MinEnrolment.PSI_STUDENT_NUMBER, MinEnrolment.PSI_CODE, MinEnrolment.id, 
                       MinEnrolment.psi_birthdate_cleaned_D, MinEnrolment.PSI_MIN_START_DATE_D, MinEnrolment.AGE_AT_ENROL_DATE, MinEnrolment.IS_FIRST_ENROLMENT
@@ -474,7 +472,7 @@ WHERE     (Extract_No_Age.AGE_AT_ENROL_DATE IS NULL)
 ORDER BY MinEnrolment.PSI_STUDENT_NUMBER;"
 
 
-# ---- qry07d2_Update_Birthdate ---- 
+# ---- qry07d2_Update_Birthdate ----
 qry07d2_Update_Birthdate <- "
 UPDATE    qry05c_Age_Manual_Fixes_View
 SET              PSI_BIRTHDATE_cleaned_D = qry05c_Age_Manual_Fixes_View_1.PSI_BIRTHDATE_cleaned_D
@@ -485,7 +483,7 @@ FROM         qry05c_Age_Manual_Fixes_View INNER JOIN
 WHERE     (qry05c_Age_Manual_Fixes_View.PSI_BIRTHDATE_cleaned_D IS NULL) AND (qry05c_Age_Manual_Fixes_View_1.PSI_BIRTHDATE_cleaned_D IS NOT NULL);"
 
 
-# ---- qry07d3_Update_Age ---- 
+# ---- qry07d3_Update_Age ----
 qry07d3_Update_Age <- "UPDATE    qry05C_Age_Manual_Fixes_View
 SET     AGE_AT_ENROL_DATE = CASE
 		WHEN dateadd(year, datediff (year, PSI_birthdate_cleaned_D, PSI_MIN_START_DATE_D), PSI_birthdate_cleaned_D) > PSI_MIN_START_DATE_D
@@ -495,14 +493,14 @@ SET     AGE_AT_ENROL_DATE = CASE
 WHERE     (PSI_birthdate_cleaned_D IS NOT NULL)"
 
 
-# ---- qry07e_Update_MinEnrolment_With_Age ---- 
+# ---- qry07e_Update_MinEnrolment_With_Age ----
 qry07e_Update_MinEnrolment_With_Age <- "UPDATE    MinEnrolment
 SET              AGE_AT_ENROL_DATE = Extract_No_Age.AGE_AT_ENROL_DATE
 FROM         MinEnrolment INNER JOIN
                       Extract_No_Age ON MinEnrolment.id = Extract_No_Age.id;"
 
 
-# ---- qry08_UpdateAGAtEnrol ---- 
+# ---- qry08_UpdateAGAtEnrol ----
 qry08_UpdateAGAtEnrol <- "UPDATE    MinEnrolment
 SET              AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
 FROM         MinEnrolment CROSS JOIN
@@ -510,7 +508,7 @@ FROM         MinEnrolment CROSS JOIN
 WHERE     (AgeGroupLookup.LowerBound <= MinEnrolment.AGE_AT_ENROL_DATE) AND (AgeGroupLookup.UpperBound >= MinEnrolment.AGE_AT_ENROL_DATE);"
 
 
-# ---- qry09c_MinEnrolment by Credential and CIP Code ---- 
+# ---- qry09c_MinEnrolment by Credential and CIP Code ----
 qry09c_MinEnrolment_by_Credential_and_CIP_Code <- "
 SELECT        PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE, COUNT(*) AS Expr1
 INTO  qry09c_MinEnrolment_by_Credential_and_CIP_Code
@@ -520,7 +518,7 @@ GROUP BY PSI_SCHOOL_YEAR, PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE
 ORDER BY PSI_CREDENTIAL_CATEGORY, PSI_CIP_CODE;"
 
 
-# ---- qry09c_MinEnrolment ---- 
+# ---- qry09c_MinEnrolment ----
 qry09c_MinEnrolment <- "
 SELECT     MinEnrolment.PSI_GENDER, MinEnrolment.PSI_GENDER + AgeGroupLookup.AgeGroup As Groups, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
 INTO    qry09c_MinEnrolment
@@ -533,7 +531,7 @@ ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHO
 ;"
 
 
-# ---- qry09c_MinEnrolment_Domestic ---- 
+# ---- qry09c_MinEnrolment_Domestic ----
 qry09c_MinEnrolment_Domestic <- "
 SELECT     MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
 INTO  qry09c_MinEnrolment_Domestic
@@ -545,8 +543,7 @@ GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHO
 ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
 
 
-
-# ---- qry09c_MinEnrolment_PSI_TYPE ---- 
+# ---- qry09c_MinEnrolment_PSI_TYPE ----
 qry09c_MinEnrolment_PSI_TYPE <- "
 SELECT        MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1, PSI_CODE_RECODE.PSI_TYPE_RECODE, PSI_CODE_RECODE.PSI_CODE_RECODE
 INTO qry09c_MinEnrolment_PSI_TYPE
@@ -559,7 +556,7 @@ GROUP BY MinEnrolment.PSI_SCHOOL_YEAR, PSI_CODE_RECODE.PSI_TYPE_RECODE, PSI_CODE
 ORDER BY MinEnrolment.PSI_SCHOOL_YEAR;"
 
 
-# ---- qry_CreateMinEnrolmentView ---- 
+# ---- qry_CreateMinEnrolmentView ----
 qry_CreateMinEnrolmentView <- "
 CREATE VIEW MinEnrolment
 AS
@@ -606,7 +603,3 @@ FROM            STP_Enrolment INNER JOIN
                          STP_Enrolment_Record_Type ON STP_Enrolment.ID = STP_Enrolment_Record_Type.ID INNER JOIN
                          MinEnrolmentSupVar ON STP_Enrolment.ID = MinEnrolmentSupVar.ID
 WHERE        (STP_Enrolment_Record_Type.RecordStatus = 0) AND (STP_Enrolment_Record_Type.MinEnrolment = 1);"
-
-
-
-

--- a/sql/01d-enrolment-analysis/enrolment_age_update.R
+++ b/sql/01d-enrolment-analysis/enrolment_age_update.R
@@ -1,46 +1,45 @@
-
-qry_Update_Linked_dbo_Extract_No_Age_after_mod2 <- 
-"UPDATE dbo_Extract_No_Age INNER JOIN Extract_No_Age ON dbo_Extract_No_Age.id = Extract_No_Age.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Extract_No_Age]![AGE_AT_ENROL_DATE]
+qry_Update_Linked_dbo_Extract_No_Age_after_mod2 <-
+  "UPDATE dbo_Extract_No_Age INNER JOIN Extract_No_Age ON dbo_Extract_No_Age.id = Extract_No_Age.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Extract_No_Age]![AGE_AT_ENROL_DATE]
 WHERE (((dbo_Extract_No_Age.AGE_AT_ENROL_DATE) Is Null) AND ((Extract_No_Age.AGE_AT_ENROL_DATE) Is Not Null));"
 
-qry02a_Multiple_Enrol <- 
-"SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Count(*) AS Expr1
+qry02a_Multiple_Enrol <-
+  "SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Count(*) AS Expr1
 FROM Extract_No_Age
 GROUP BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE
 HAVING (((Count(*))>1));"
 
-qry02b_Calc_Ages <- 
-"SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.IS_FIRST_ENROLMENT
+qry02b_Calc_Ages <-
+  "SELECT Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.IS_FIRST_ENROLMENT
 FROM Extract_No_Age
 ORDER BY Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT DESC;"
 
-qry03a_Manual_Fixes_ePEN <- 
-"SELECT dbo_MinEnrolment.id, Query1.ENCRYPTED_TRUE_PEN, dbo_MinEnrolment.PSI_CODE, dbo_MinEnrolment.PSI_STUDENT_NUMBER, dbo_MinEnrolment.PSI_SCHOOL_YEAR, dbo_MinEnrolment.PSI_MIN_START_DATE_D, dbo_MinEnrolment.PSI_BIRTHDATE_D AS Expr2, dbo_MinEnrolment.AGE_AT_ENROL_DATE, dbo_Extract_No_Age.AGE_AT_ENROL_DATE INTO tmp_tbl_Age_Manual_Fixes
+qry03a_Manual_Fixes_ePEN <-
+  "SELECT dbo_MinEnrolment.id, Query1.ENCRYPTED_TRUE_PEN, dbo_MinEnrolment.PSI_CODE, dbo_MinEnrolment.PSI_STUDENT_NUMBER, dbo_MinEnrolment.PSI_SCHOOL_YEAR, dbo_MinEnrolment.PSI_MIN_START_DATE_D, dbo_MinEnrolment.PSI_BIRTHDATE_D AS Expr2, dbo_MinEnrolment.AGE_AT_ENROL_DATE, dbo_Extract_No_Age.AGE_AT_ENROL_DATE INTO tmp_tbl_Age_Manual_Fixes
 FROM (dbo_MinEnrolment INNER JOIN Query1 ON dbo_MinEnrolment.ENCRYPTED_TRUE_PEN = Query1.ENCRYPTED_TRUE_PEN) INNER JOIN dbo_Extract_No_Age ON dbo_MinEnrolment.ENCRYPTED_TRUE_PEN = dbo_Extract_No_Age.ENCRYPTED_TRUE_PEN
 ORDER BY Query1.ENCRYPTED_TRUE_PEN, dbo_MinEnrolment.PSI_MIN_START_DATE_D;"
 
-qry03b_Update_BIRTHDATE <- 
-"UPDATE Old_tmp_tbl_Age_Manual_Fixes AS tmp_tbl_Age_Manual_Fixes_1 INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON tmp_tbl_Age_Manual_Fixes_1.ENCRYPTED_TRUE_PEN = Old_tmp_tbl_Age_Manual_Fixes.ENCRYPTED_TRUE_PEN SET tmp_tbl_Age_Manual_Fixes_1.PSI_BIRTHDATE_D = [Old_tmp_tbl_Age_Manual_Fixes].PSI_BIRTHDATE_D
+qry03b_Update_BIRTHDATE <-
+  "UPDATE Old_tmp_tbl_Age_Manual_Fixes AS tmp_tbl_Age_Manual_Fixes_1 INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON tmp_tbl_Age_Manual_Fixes_1.ENCRYPTED_TRUE_PEN = Old_tmp_tbl_Age_Manual_Fixes.ENCRYPTED_TRUE_PEN SET tmp_tbl_Age_Manual_Fixes_1.PSI_BIRTHDATE_D = [Old_tmp_tbl_Age_Manual_Fixes].PSI_BIRTHDATE_D
 WHERE (((tmp_tbl_Age_Manual_Fixes_1.PSI_BIRTHDATE_D) Is Null) AND ((Old_tmp_tbl_Age_Manual_Fixes.PSI_BIRTHDATE_D) Is Not Null));"
 
-qry03c_Update_Age <- 
-"UPDATE tmp_tbl_Age_Manual_Fixes SET tmp_tbl_Age_Manual_Fixes.dbo_MinEnrolment_AGE_AT_ENROL_DATE = DateDiff('yyyy',[PSI_BIRTHDATE_D],[PSI_MIN_START_DATE_D])+([PSI_MIN_START_DATE_D]<DateSerial(Year([PSI_MIN_START_DATE_D]),Month([PSI_BIRTHDATE_D]),Day([PSI_BIRTHDATE_D])))
+qry03c_Update_Age <-
+  "UPDATE tmp_tbl_Age_Manual_Fixes SET tmp_tbl_Age_Manual_Fixes.dbo_MinEnrolment_AGE_AT_ENROL_DATE = DateDiff('yyyy',[PSI_BIRTHDATE_D],[PSI_MIN_START_DATE_D])+([PSI_MIN_START_DATE_D]<DateSerial(Year([PSI_MIN_START_DATE_D]),Month([PSI_BIRTHDATE_D]),Day([PSI_BIRTHDATE_D])))
 WHERE (((tmp_tbl_Age_Manual_Fixes.dbo_Extract_No_Age_AGE_AT_ENROL_DATE) Is Null));"
 
-qry04d_Update_dbo_Extract_No_Age <- 
-"UPDATE dbo_Extract_No_Age INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON dbo_Extract_No_Age.id = Old_tmp_tbl_Age_Manual_Fixes.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Old_tmp_tbl_Age_Manual_Fixes].dbo_MinEnrolment_AGE_AT_ENROL_DATE;"
+qry04d_Update_dbo_Extract_No_Age <-
+  "UPDATE dbo_Extract_No_Age INNER JOIN Old_tmp_tbl_Age_Manual_Fixes ON dbo_Extract_No_Age.id = Old_tmp_tbl_Age_Manual_Fixes.id SET dbo_Extract_No_Age.AGE_AT_ENROL_DATE = [Old_tmp_tbl_Age_Manual_Fixes].dbo_MinEnrolment_AGE_AT_ENROL_DATE;"
 
-qry05c_Update_Birthdate <- 
-"UPDATE dbo_qry05c_Age_Manual_Fixes_View AS dbo_qry05c_Age_Manual_Fixes_View_1 INNER JOIN dbo_qry05c_Age_Manual_Fixes_View ON (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_STUDENT_NUMBER = dbo_qry05c_Age_Manual_Fixes_View.PSI_STUDENT_NUMBER) AND (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_CODE = dbo_qry05c_Age_Manual_Fixes_View.PSI_CODE) SET dbo_qry05c_Age_Manual_Fixes_View.PSI_BIRTHDATE_D = [dbo_qry05c_Age_Manual_Fixes_View_1].[PSI_BIRTHDATE_D]
+qry05c_Update_Birthdate <-
+  "UPDATE dbo_qry05c_Age_Manual_Fixes_View AS dbo_qry05c_Age_Manual_Fixes_View_1 INNER JOIN dbo_qry05c_Age_Manual_Fixes_View ON (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_STUDENT_NUMBER = dbo_qry05c_Age_Manual_Fixes_View.PSI_STUDENT_NUMBER) AND (dbo_qry05c_Age_Manual_Fixes_View_1.PSI_CODE = dbo_qry05c_Age_Manual_Fixes_View.PSI_CODE) SET dbo_qry05c_Age_Manual_Fixes_View.PSI_BIRTHDATE_D = [dbo_qry05c_Age_Manual_Fixes_View_1].[PSI_BIRTHDATE_D]
 WHERE ((([dbo_qry05c_Age_Manual_Fixes_View].[PSI_BIRTHDATE_D]) Is Null) AND (([dbo_qry05c_Age_Manual_Fixes_View_1].[PSI_BIRTHDATE_D]) Is Not Null));"
 
-Check_AdvancedAge_ForEPENS <- 
+Check_AdvancedAge_ForEPENS <-
   "SELECT Extract_No_Age.id, Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT
 FROM Extract_No_Age
 WHERE (((Extract_No_Age.ENCRYPTED_TRUE_PEN)<>''))
 ORDER BY Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_SCHOOL_YEAR;"
 
-Check_AdvancedAge_ForStudentNumPSICODE <- 
+Check_AdvancedAge_ForStudentNumPSICODE <-
   "SELECT Extract_No_Age.id, Extract_No_Age.ENCRYPTED_TRUE_PEN, Extract_No_Age.PSI_STUDENT_NUMBER, Extract_No_Age.PSI_CODE, Extract_No_Age.AGE_AT_ENROL_DATE, Extract_No_Age.PSI_SCHOOL_YEAR, Extract_No_Age.PSI_MIN_START_DATE, Extract_No_Age.PSI_MIN_START_DATE_D, Extract_No_Age.IS_FIRST_ENROLMENT
 FROM Extract_No_Age
 WHERE (((Extract_No_Age.ENCRYPTED_TRUE_PEN)=''))

--- a/sql/02a-program-matching/02a-appso-programs.R
+++ b/sql/02a-program-matching/02a-appso-programs.R
@@ -1,5 +1,5 @@
 # APPSO IDS ----
-## 
+##
 ## qry_APPSO_STP_CIP_Cleaning ----
 ## collect STP APPSO data
 ## New (from documentation): create table Credential_Non_Dup_STP_APPSO_Cleaning for cleaning STP CIP codes
@@ -14,7 +14,7 @@ GROUP BY
        OUTCOMES_CRED
 HAVING OUTCOMES_CRED = 'APPSO'"
 
-# add columns 
+# add columns
 qry_APPSO_STP_CIP_add_columns <- "
 ALTER TABLE Credential_Non_Dup_STP_APPSO_Cleaning
 ADD STP_CIP_CODE_4 varchar (255),
@@ -116,7 +116,7 @@ WHERE Credential_Non_Dup_STP_APPSO_Cleaning.STP_CIP_CODE_4_NAME is NULL"
 
 ## qry_Update_Credential_with_STP_CIP_APPSO ----
 ## Update STP columns in Credential_Non_Dup and filter on APPSO credentials
-qry_Update_Credential_with_STP_CIP_APPSO <-"
+qry_Update_Credential_with_STP_CIP_APPSO <- "
 Select Credential_Non_Dup.ID,
        Credential_Non_Dup.PSI_CODE,
        Credential_Non_Dup.PSI_PROGRAM_CODE,

--- a/sql/02a-program-matching/02a-bgs-program-matching.R
+++ b/sql/02a-program-matching/02a-bgs-program-matching.R
@@ -68,7 +68,7 @@ qry_Add_PSSM_CREDENTIAL <- "
 ALTER TABLE T_BGS_Data_Final_for_OutcomesMatching
 ADD PSSM_CREDENTIAL VARCHAR(255) NOT NULL DEFAULT 'BACH'"
 # qry_Update_PSSM_CREDENTIAL <- "
-# UPDATE T_BGS_Data_Final_for_OutcomesMatching 
+# UPDATE T_BGS_Data_Final_for_OutcomesMatching
 # SET    T_BGS_Data_Final_for_OutcomesMatching.PSSM_CREDENTIAL = 'BACH'"
 
 ## qry_Check_BGS_CIP_Data ----
@@ -183,7 +183,7 @@ WHERE Credential_Non_Dup_STP_CIP4_Cleaning.STP_CIP_CODE_4_NAME is NULL"
 
 ## qry_Update_Credential_with_STP_CIP_BGS ----
 ## Update STP columns in Credential_Non_Dup and filter on BGS credentials
-qry_Update_Credential_with_STP_CIP_BGS <-"
+qry_Update_Credential_with_STP_CIP_BGS <- "
 Select Credential_Non_Dup.ID,
        Credential_Non_Dup.PSI_CODE,
        Credential_Non_Dup.PSI_PROGRAM_CODE,
@@ -203,7 +203,7 @@ WHERE  Credential_Non_Dup.OUTCOMES_CRED = 'BGS'"
 
 ## qry_Update_Credential_with_STP_CIP_Grad ----
 ## Update STP columns in Credential_Non_Dup and filter on Grad credentials
-qry_Update_Credential_with_STP_CIP_GRAD <-"
+qry_Update_Credential_with_STP_CIP_GRAD <- "
 Select Credential_Non_Dup.ID,
        Credential_Non_Dup.PSI_CODE,
        Credential_Non_Dup.PSI_PROGRAM_CODE,
@@ -301,7 +301,6 @@ ADD
 	Match_All_3_CIP2_Flag [varchar](50)NULL,
 	Final_Consider_A_Match [varchar](50) NULL,
 	Final_Probable_Match [varchar](50) NULL"
-
 
 
 ## qry_add_empty_final_CIP ----
@@ -777,7 +776,7 @@ HAVING Credential_Non_Dup_BGS_IDs.USE_BGS_CIP='No because no match'"
 
 ## qry_update_Credential_Non_DUP_BGS_IDs_unmatched ----
 ## New: update Credential_Non_Dup_BGS_IDs so unmatched programs use linked BGS CIP instead
-qry_update_Credential_Non_DUP_BGS_IDs_unmatched <-  "
+qry_update_Credential_Non_DUP_BGS_IDs_unmatched <- "
 UPDATE Credential_Non_Dup_BGS_IDs
 SET    Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_4 = Credential_Unmatched_CIPS_to_update.FINAL_CIP_CODE_4, 
        Credential_Non_Dup_BGS_IDs.FINAL_CIP_CODE_4_NAME = NULL,
@@ -1011,7 +1010,7 @@ HAVING T_BGS_Data_Final_for_OutcomesMatching.USE_STP_CIP='No because no match'"
 
 ## qry_update_T_BGS_Data_unmatched ----
 ## New: update T_BGS_Data_Final_for_OutcomesMatching so unmatched programs use linked STP CIP instead
-qry_update_T_BGS_Data_unmatched <-  "
+qry_update_T_BGS_Data_unmatched <- "
 UPDATE T_BGS_Data_Final_for_OutcomesMatching
 SET    T_BGS_Data_Final_for_OutcomesMatching.FINAL_CIP_CODE_4 = T_BGS_Data_Unmatched_CIPS_to_update.FINAL_CIP_CODE_4, 
        T_BGS_Data_Final_for_OutcomesMatching.FINAL_CIP_CODE_4_NAME = NULL,
@@ -1044,6 +1043,3 @@ ON     FINAL_CIP_CODE_2 = LCP2_CD
 WHERE  FINAL_CIP_CODE_2_NAME is NULL"
 
 # end ----
-
-
-

--- a/sql/02a-program-matching/02a-convert-leftover-nulls.R
+++ b/sql/02a-program-matching/02a-convert-leftover-nulls.R
@@ -1,5 +1,5 @@
 # NULL IDS ----
-## 
+##
 ## qry_NULL_STP_CIP_Cleaning ----
 ## collect STP NULL data
 ## this will grab any NULLs that are leftover in the final_4_cip_code column and try to match them on their STP codes
@@ -16,7 +16,7 @@ GROUP BY
        OUTCOMES_CRED
 "
 
-# add columns 
+# add columns
 qry_NULL_STP_CIP_add_columns <- "
 ALTER TABLE Credential_Non_Dup_STP_NULL_Cleaning
 ADD STP_CIP_CODE_4 varchar (255),
@@ -122,7 +122,7 @@ WHERE Credential_Non_Dup_STP_NULL_Cleaning.STP_CIP_CODE_4_NAME is NULL"
 
 ## qry_Update_Credential_with_STP_CIP_NULL ----
 ## Update STP columns in Credential_Non_Dup and filter on NULL credentials
-qry_Update_Credential_with_STP_CIP_NULL <-"
+qry_Update_Credential_with_STP_CIP_NULL <- "
 Select Credential_Non_Dup.ID,
        Credential_Non_Dup.PSI_CODE,
        Credential_Non_Dup.PSI_PROGRAM_CODE,
@@ -160,6 +160,3 @@ SET    FINAL_CIP_CODE_4 = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CODE_4,
        FINAL_CIP_CLUSTER_NAME = Credential_Non_Dup_NULL_IDs.FINAL_CIP_CLUSTER_NAME
 FROM   Credential_Non_Dup_NULL_IDs INNER JOIN Credential_Non_Dup 
 ON     Credential_Non_Dup_NULL_IDs.id = Credential_Non_Dup.id"
-
-
-

--- a/sql/02a-program-matching/02a-dacso-program-matching.R
+++ b/sql/02a-program-matching/02a-dacso-program-matching.R
@@ -10,8 +10,8 @@
 # select PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESC, PSI_CREDENTIAL_CIP, PSI_CREDENTIAL_LEVEL, PSI_CREDENTIAL_CATEGORY, OUTCOMES_CRED
 # filter where OUTCOMES_CRED = DACSO
 # summarize (count) to get distinct rows by these variables
-qry_DASCO_STP_Credential_Programs <- 
-"SELECT PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CREDENTIAL_CIP,
+qry_DASCO_STP_Credential_Programs <-
+  "SELECT PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CREDENTIAL_CIP,
        PSI_CREDENTIAL_LEVEL, PSI_CREDENTIAL_CATEGORY, OUTCOMES_CRED, COUNT(*) AS Expr1
 INTO   STP_Credential_Non_Dup_Programs_DACSO
 FROM   Credential_Non_Dup
@@ -20,8 +20,8 @@ GROUP BY PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CRE
 HAVING OUTCOMES_CRED = 'DACSO'"
 
 ## qry_DASCO_STP_Credential_Programs_Add_Columns ----
-qry_DASCO_STP_Credential_Programs_Add_Columns <- 
-"ALTER TABLE STP_Credential_Non_Dup_Programs_DACSO
+qry_DASCO_STP_Credential_Programs_Add_Columns <-
+  "ALTER TABLE STP_Credential_Non_Dup_Programs_DACSO
 ADD
  OUTCOMES_CIP_CODE_4 varchar(4),
  OUTCOMES_CIP_CODE_4_NAME varchar(255),
@@ -40,7 +40,7 @@ ADD
 
 ## qry_Update_STP_CIP_CODE4 ----
 # take the STP information from the infoware tables and add to the STP_Credential_Non_Dup_Programs_DACSO
-qry_Update_STP_CIP_CODE4 <- 
+qry_Update_STP_CIP_CODE4 <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
   SET STP_Credential_Non_Dup_Programs_DACSO.STP_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD], 
 STP_Credential_Non_Dup_Programs_DACSO.STP_CIP_CODE_4_NAME = [INFOWARE_L_CIP_4DIGITS_CIP2016].[LCP4_CIP_4DIGITS_NAME]
@@ -51,10 +51,10 @@ ON INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD = INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_
 
 ## qry_STP_Credential_DACSO_Programs_AlreadyMatched ----
 ## initial program matching:
-## if STP program is already in the XWALK (joining on PSI_CREDENTIAL, PSI_PROGRAM_CODE, PSI_CODE), 
+## if STP program is already in the XWALK (joining on PSI_CREDENTIAL, PSI_PROGRAM_CODE, PSI_CODE),
 ## copy CIP_CODE_4, LCP4_CIP_4DIGITS_NAME into OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME
 ## set Already_Matched to Yes
-qry_STP_Credential_DACSO_Programs_AlreadyMatched <- 
+qry_STP_Credential_DACSO_Programs_AlreadyMatched <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET 
   STP_Credential_Non_Dup_Programs_DACSO.Already_Matched = 'Yes', 
@@ -69,11 +69,11 @@ ON (
 
 ## qry_STP_Credential_DACSO_Programs_AlreadyMatched_b ----
 ## secondary program matching:
-## if STP program is already in the XWALK (joining on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESC, PSI_PROGRAM_CODE), 
+## if STP program is already in the XWALK (joining on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESC, PSI_PROGRAM_CODE),
 ## where Already_Matched, OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME is Null
 ## copy CIP_CODE_4, LCP4_CIP_4DIGITS_NAME into OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME
 ## set Already_Matched to Yes
-qry_STP_Credential_DACSO_Programs_AlreadyMatched_b <- 
+qry_STP_Credential_DACSO_Programs_AlreadyMatched_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET 
   STP_Credential_Non_Dup_Programs_DACSO.Already_Matched = 'Yes', 
@@ -95,7 +95,7 @@ WHERE
 ## where Already_Matched is null
 ## copy CIP_CODE_4, LCP4_CIP_4DIGITS_NAME into OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME
 ## set New_Auto_Match to Yes
-qry_STP_Credential_DACSO_Programs_NewMatches_a <- 
+qry_STP_Credential_DACSO_Programs_NewMatches_a <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET 
   STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
@@ -114,7 +114,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.Already_Matched) Is Null))"
 ## where New_Auto_Match, Already_Matched, OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME is Null
 ## copy CIP_CODE_4, LCP4_CIP_4DIGITS_NAME into OUTCOMES_CIP_CODE_4 and OUTCOMES_CIP_CODE_4_NAME
 ## set New_Auto_Match to Yes
-qry_STP_Credential_DACSO_Programs_NewMatches_a_step2 <- 
+qry_STP_Credential_DACSO_Programs_NewMatches_a_step2 <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET 
   STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
@@ -136,7 +136,7 @@ WHERE
 ## where New_Auto_Match = Yes
 ## copy PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESC, STP_CIP4_CODE into STP_CIP_CODE_4, CTP_SIP4_NAME into STP_CIP_CODE_4_NAME
 ## set New_STP_Program20XX = Yes and One_To_One_Match = Yes20XX
-qry_STP_Credential_DACSO_Programs_NewMatches_b <- 
+qry_STP_Credential_DACSO_Programs_NewMatches_b <-
   "UPDATE DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
 SET 
   DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23.PSI_PROGRAM_CODE = [STP_Credential_Non_Dup_Programs_DACSO].[PSI_PROGRAM_CODE],
@@ -158,7 +158,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match)='Yes'))"
 ## where New_Auto_Match = Yes and New_STP_Program20XX and One_To_One_Match are null
 ## copy PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESC, STP_CIP4_CODE into STP_CIP_CODE_4, CTP_SIP4_NAME into STP_CIP_CODE_4_NAME
 ## set New_STP_Program20XX = Yes and One_To_One_Match = Yes20XX
-qry_STP_Credential_DACSO_Programs_NewMatches_b_step2 <- 
+qry_STP_Credential_DACSO_Programs_NewMatches_b_step2 <-
   "UPDATE DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23
 SET 
   DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23.PSI_PROGRAM_CODE = [STP_Credential_Non_Dup_Programs_DACSO].[PSI_PROGRAM_CODE], 
@@ -179,17 +179,14 @@ WHERE
 
 # ******************************************************************************
 
-
-
-
 # ******************************************************************************
 # ---- Part 3: Manual/custom STP to XWALK matching ----
 
 ## qry_Update_BCIT_Programs ----
 # join STP data to XWALK on COCI_INST_CD, PSI_CREDENTIAL_PROGRAM_DESCRIPTION = PRGM_INST_PROGRAM_NAME, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD
 # - set New_Auto_Match = 'YesXXBCIT'
-qry_Update_BCIT_Programs <- 
-"UPDATE STP_Credential_Non_Dup_Programs_DACSO
+qry_Update_BCIT_Programs <-
+  "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
 STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match = 'Yes2021_23BCIT'
@@ -204,8 +201,8 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ## qry_Update_BCIT_Programs_b ----
 # join STP data to XWALK on COCI_INST_CD, BCIT_TEST_PROGRAM_CODE = PRGM_LCPC_CD
 # - set New_Auto_Match = 'YesXXBCIT'
-qry_Update_BCIT_Programs_b <- 
-"UPDATE STP_Credential_Non_Dup_Programs_DACSO
+qry_Update_BCIT_Programs_b <-
+  "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
 STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match = 'Yes2021_23BCIT'
@@ -217,8 +214,8 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_CAPU_Programs_a ----
-qry_Update_CAPU_Programs_a <- 
-"UPDATE STP_Credential_Non_Dup_Programs_DACSO 
+qry_Update_CAPU_Programs_a <-
+  "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
 STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match = 'Yes2021_23CAPU'
@@ -231,7 +228,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_CAPU_Programs_b ----
-qry_Update_CAPU_Programs_b <- 
+qry_Update_CAPU_Programs_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
@@ -244,7 +241,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_VIU_Programs_a ----
-qry_Update_VIU_Programs_a <- 
+qry_Update_VIU_Programs_a <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
@@ -258,7 +255,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_VIU_Programs_b ----
-qry_Update_VIU_Programs_b <- 
+qry_Update_VIU_Programs_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
 SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
@@ -271,7 +268,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null) AND
 ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_Remaining_Programs_Matching_DACSO_Seen ----
-qry_Update_Remaining_Programs_Matching_DACSO_Seen <- 
+qry_Update_Remaining_Programs_Matching_DACSO_Seen <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
     SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
   STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
@@ -284,7 +281,7 @@ AND ((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME) Is Null)
 AND ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 ## qry_Update_Remaining_Programs_Matching_DACSO_Seen_b ----
-qry_Update_Remaining_Programs_Matching_DACSO_Seen_b <- 
+qry_Update_Remaining_Programs_Matching_DACSO_Seen_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
     SET STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4 = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[CIP_CODE_4], 
   STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME = [DACSO_STP_ProgramsCIP4_XWALK_ALL_2021_23].[LCP4_CIP_4DIGITS_NAME], 
@@ -298,14 +295,11 @@ AND ((STP_Credential_Non_Dup_Programs_DACSO.New_Auto_Match) Is Null))"
 
 # ******************************************************************************
 
-
-
-
 # ******************************************************************************
 # ---- Part 4: Final update to STP CIPs ----
 ## qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_a ----
 # Use the outcomes cip4 data if there was a match for the final cip4
-qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_a <- 
+qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_a <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4 = [STP_Credential_Non_Dup_Programs_DACSO].[OUTCOMES_CIP_CODE_4], 
 STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4_NAME = [STP_Credential_Non_Dup_Programs_DACSO].[OUTCOMES_CIP_CODE_4_NAME]
@@ -316,7 +310,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Not Null)
 ## qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_b ----
 # Use the STP CIP4 outcomes for the rest where there is no match
 # populate the final cip code 2
-qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_b <- 
+qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
 SET STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP4_CD], 
 STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4_NAME = [INFOWARE_L_CIP_4DIGITS_CIP2016].[LCP4_CIP_4DIGITS_NAME], 
@@ -335,7 +329,7 @@ AND ((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null)
 AND ((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME) Is Null))"
 
 ## qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_c ----
-qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_c <- 
+qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP4_c <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO 
   SET STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4_NAME = [INFOWARE_L_CIP_4DIGITS_CIP2016].[LCP4_CIP_4DIGITS_NAME], 
   STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD], 
@@ -351,7 +345,7 @@ AND ((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4) Is Null)
 AND ((STP_Credential_Non_Dup_Programs_DACSO.OUTCOMES_CIP_CODE_4_NAME) Is Null))"
 
 ## qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_a ----
-qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_a <- 
+qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_a <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
   SET STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_2 = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCP2_CD], 
 STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CLUSTER_CODE = [INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCIPPC_CD], 
@@ -360,7 +354,7 @@ FROM STP_Credential_Non_Dup_Programs_DACSO INNER JOIN INFOWARE_L_CIP_6DIGITS_CIP
 ON STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_4 = INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD"
 
 ## qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_b ----
-qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_b <- 
+qry_Update_STP_Cred_Non_Dup_Programs_DACSO_FinalCIP2_Cluster_b <-
   "UPDATE STP_Credential_Non_Dup_Programs_DACSO
   SET STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_2_NAME = [INFOWARE_L_CIP_2DIGITS_CIP2016].[LCP2_DIGITS_NAME]
 FROM STP_Credential_Non_Dup_Programs_DACSO INNER JOIN INFOWARE_L_CIP_2DIGITS_CIP2016 
@@ -370,7 +364,7 @@ WHERE (((STP_Credential_Non_Dup_Programs_DACSO.FINAL_CIP_CODE_2_NAME) Is Null))"
 
 ## qry_Check_CIP_Changes_STP_Cred_Non_Dup_DACSO ----
 ## Check how many CIP codes in STP data are actually changed
-qry_Check_CIP_Changes_STP_Cred_Non_Dup_DACSO <- 
+qry_Check_CIP_Changes_STP_Cred_Non_Dup_DACSO <-
   "SELECT PSI_CODE, PSI_PROGRAM_CODE, PSI_CREDENTIAL_PROGRAM_DESCRIPTION, PSI_CREDENTIAL_CIP, 
 STP_CIP_CODE_4, STP_CIP_CODE_4_NAME, OUTCOMES_CIP_CODE_4, OUTCOMES_CIP_CODE_4_NAME, FINAL_CIP_CODE_4, FINAL_CIP_CODE_4_NAME, 
 Already_Matched, New_Auto_Match, New_Manual_Match, COCI_INST_CD 

--- a/sql/02a-program-matching/02a-update-cred-non-dup.R
+++ b/sql/02a-program-matching/02a-update-cred-non-dup.R
@@ -1,4 +1,4 @@
-## update columns of credential non dup 
+## update columns of credential non dup
 qry_Credential_Non_Dup_Add_Columns <- "
 ALTER TABLE Credential_Non_Dup
 ADD         OUTCOMES_CIP_CODE_4 varchar(4),
@@ -84,8 +84,8 @@ WHERE OUTCOMES_CRED = 'GRAD' OR OUTCOMES_CRED = 'APPSO'
 "
 
 ## final clean up queries for non dup CIPs
-# ---- SQLQuery1 ---- 
-## not used 
+# ---- SQLQuery1 ----
+## not used
 SQLQuery1 <- "
 SELECT   Match_Inst, 
          Match_School_Year, 
@@ -111,8 +111,8 @@ ORDER BY Match_Inst DESC,
          Match_CIP_CODE_4 DESC, 
          Match_Credential DESC;"
 
-# ---- SQLQuery2 ---- 
-## not used 
+# ---- SQLQuery2 ----
+## not used
 SQLQuery2 <- "
 UPDATE    T_BGS_Data_Final
 SET       LCP2_DIGITS_NAME = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_DIGITS_NAME
@@ -122,8 +122,8 @@ ON T_BGS_Data_Final.CIP_CODE_2 = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_CD
 WHERE     (T_BGS_Data_Final.LCP2_DIGITS_NAME IS NULL);"
 
 
-# ---- SQLQuery3 ---- 
-## not used, should be done already 
+# ---- SQLQuery3 ----
+## not used, should be done already
 SQLQuery3 <- "
 UPDATE    Credential_Non_Dup
 SET       FINAL_CIP_CODE_2_NAME = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_DIGITS_NAME, 
@@ -135,7 +135,7 @@ ON Credential_Non_Dup.FINAL_CIP_CODE_2 = INFOWARE_L_CIP_2DIGITS_CIP2016.LCP2_CD
 WHERE     (Credential_Non_Dup.OUTCOMES_CRED = 'BGS');"
 
 
-# ---- SQLQuery4 ---- 
+# ---- SQLQuery4 ----
 ## update some 99 codes for BGS
 SQLQuery4 <- "
 UPDATE    Credential_Non_Dup
@@ -145,7 +145,7 @@ SET       FINAL_CIP_CODE_2_NAME = 'Undeclared activity',
 WHERE     (OUTCOMES_CRED = 'BGS') AND (FINAL_CIP_CODE_2 = '99');"
 
 
-# ---- SQLQuery5 ---- 
+# ---- SQLQuery5 ----
 ## not used (not credential_non_dup)
 SQLQuery5 <- "
 UPDATE    T_BGS_Data_Final
@@ -155,8 +155,8 @@ FROM      T_BGS_Data_Final
 INNER JOIN INFOWARE.L_CIP_2DIGITS_CIP2016 
 ON T_BGS_Data_Final.CIP_CODE_2 = INFOWARE.L_CIP_2DIGITS_CIP2016.LCP2_CD;"
 
-# ---- SQLQuery6 ---- 
-## update final to be STP if final was missing 
+# ---- SQLQuery6 ----
+## update final to be STP if final was missing
 SQLQuery6 <- "
 UPDATE    Credential_Non_Dup
 SET       FINAL_CIP_CODE_4 = STP_CIP_CODE_4, 
@@ -166,8 +166,8 @@ SET       FINAL_CIP_CODE_4 = STP_CIP_CODE_4,
 WHERE     (FINAL_CIP_CODE_4 IS NULL) OR
                       (FINAL_CIP_CODE_4 = ' ');"
 
-# ---- SQLQuery7 ---- 
-## update some 99 codes to align 
+# ---- SQLQuery7 ----
+## update some 99 codes to align
 SQLQuery7 <- "
 UPDATE    Credential_Non_Dup
 SET       FINAL_CIP_CLUSTER_CODE = '99',
@@ -176,7 +176,3 @@ WHERE     (OUTCOMES_CRED = 'GRAD')
 AND (FINAL_CIP_CLUSTER_CODE IS NULL) 
 AND (FINAL_CIP_CLUSTER_NAME IS NULL) 
 AND (FINAL_CIP_CODE_2 = '99');"
-
-
-
-

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-appso.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-appso.R
@@ -1,5 +1,5 @@
-APPSO_Graduates_Projection_Input <- 
-"SELECT t_appso_data_final.pssm_credential,
+APPSO_Graduates_Projection_Input <-
+  "SELECT t_appso_data_final.pssm_credential,
        t_appso_data_final.pssm_credential AS PSSM_CRED,
        tbl_age_groups.age_group_label,
        t_year_survey_year.award_school_year,
@@ -19,8 +19,8 @@ GROUP  BY t_appso_data_final.pssm_credential,
 ORDER  BY tbl_age_groups.age_group_label,
           t_year_survey_year.award_school_year;"
 
-APPSO_Program_Projection_Input <- 
-"SELECT tbl_age_groups.age_group_label,
+APPSO_Program_Projection_Input <-
+  "SELECT tbl_age_groups.age_group_label,
        t_appso_data_final.pssm_credential,
        pssm_credential & age_group_label        AS Expr1,
        t_appso_data_final.lcip_lcp4_cd,
@@ -44,8 +44,8 @@ GROUP  BY tbl_age_groups.age_group_label,
 ORDER  BY tbl_age_groups.age_group_label,
           t_year_survey_year.award_school_year;"
 
-APPSO_Q003b_Add_CURRENT_REGION_PSSM <- 
-"ALTER TABLE T_APPSO_Data_Final
+APPSO_Q003b_Add_CURRENT_REGION_PSSM <-
+  "ALTER TABLE T_APPSO_Data_Final
 ADD CURRENT_REGION_PSSM_CODE INT NULL;"
 
 APPSO_Q003b_Add_CURRENT_REGION_PSSM2 <- "
@@ -103,13 +103,13 @@ WHERE t_weights.model = '2022-2023'
   AND t_weights.survey = 'APPSO';"
 
 
-APPSO_Q005_1b1_Delete_Cohort <- 
-"DELETE T_Cohorts_Recoded
+APPSO_Q005_1b1_Delete_Cohort <-
+  "DELETE T_Cohorts_Recoded
 FROM T_Cohorts_Recoded
 WHERE T_Cohorts_Recoded.Survey = 'APPSO';"
 
-APPSO_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <- 
-"INSERT INTO t_cohorts_recoded
+APPSO_Q005_DACSO_DATA_Part_1b2_Cohort_Recoded <-
+  "INSERT INTO t_cohorts_recoded
             (pen,
              stqu_id,
              survey,
@@ -158,19 +158,17 @@ FROM   t_appso_data_final
 WHERE  t_year_survey_year.survey = 'appso';"
 
 
-
-
-APPSO_Q99A_ENDDT <- 
-"UPDATE (INFOWARE_APPRENTICE_COHORT_INFO INNER JOIN APPSO_Q99A_STQUI_ID ON INFOWARE_APPRENTICE_COHORT_INFO.KEY = APPSO_Q99A_STQUI_ID.KEY) 
+APPSO_Q99A_ENDDT <-
+  "UPDATE (INFOWARE_APPRENTICE_COHORT_INFO INNER JOIN APPSO_Q99A_STQUI_ID ON INFOWARE_APPRENTICE_COHORT_INFO.KEY = APPSO_Q99A_STQUI_ID.KEY) 
 INNER JOIN T_Cohorts_Recoded 
 ON APPSO_Q99A_STQUI_ID.STQU_ID = T_Cohorts_Recoded.STQU_ID 
 SET T_Cohorts_Recoded.ENDDT = Left(INFOWARE_APPRENTICE_COHORT_INFO.ENDDT,4) + '-' & Right(INFOWARE_APPRENTICE_COHORT_INFO.ENDDT,2)
 WHERE (((T_Cohorts_Recoded.Survey)='APPSO'));"
 
-APPSO_Q99A_ENDDT_IMPUTED <- 
-"UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-1) & '-12'
+APPSO_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-1) & '-12'
 WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='APPSO'));"
 
-APPSO_Q99A_STQUI_ID <- 
-"SELECT INFOWARE_APPRENTICE_COHORT_INFO.KEY, 'APPSO - ' + KEY AS STQU_ID
+APPSO_Q99A_STQUI_ID <-
+  "SELECT INFOWARE_APPRENTICE_COHORT_INFO.KEY, 'APPSO - ' + KEY AS STQU_ID
 FROM INFOWARE_APPRENTICE_COHORT_INFO;"

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-bgs.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-bgs.R
@@ -1,5 +1,3 @@
-
-
 BGS_Q001b_INST_Recode <- "
 UPDATE t_bgs_data_final
 SET    t_bgs_data_final.inst = t_bgs_inst_recode.inst_recode
@@ -31,7 +29,7 @@ SET         t_bgs_data_final.current_region_pssm_code =  bgs_current_region_data
 FROM        t_bgs_data_final
 INNER JOIN  bgs_current_region_data
     ON      t_bgs_data_final.stqu_id = bgs_current_region_data.stqu_id;"
-  
+
 BGS_Q003c_Derived_And_Weights <- "
 UPDATE t_bgs_data_final
 SET    t_bgs_data_final.BGS_New_Labour_Supply =  

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-dacso.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-dacso.R
@@ -1,5 +1,5 @@
 # ---- Q003 - Q005 Pull DACSO Records ----
-DACSO_Q003_DACSO_Data_Part_1_stepB <- 
+DACSO_Q003_DACSO_Data_Part_1_stepB <-
   "SELECT t_dacso_data_part_1_stepa.coci_pen,
        t_dacso_data_part_1_stepa.coci_stqu_id,
        t_dacso_data_part_1_stepa.coci_subm_cd,
@@ -48,7 +48,7 @@ FROM   ((t_dacso_data_part_1_stepa
        LEFT JOIN tbl_age_groups
               ON tbl_age.age_group = tbl_age_groups.age_group;"
 
-# in 2023 I removed the inner join on c_out_c_clean2 as it seemed to do nothing. 
+# in 2023 I removed the inner join on c_out_c_clean2 as it seemed to do nothing.
 DACSO_Q003b_DACSO_DATA_Part_1_Further_Ed <- "
 UPDATE t_dacso_data_part_1
 SET    t_dacso_data_part_1.had_previous_credential =

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-new-labour-supply.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-new-labour-supply.R
@@ -1,4 +1,3 @@
-
 # ---- Q005 - Q007 New labour supply ----
 DACSO_Q99A_STQUI_ID <- "
 SELECT STQU_ID AS Survey_STQU_ID, 
@@ -144,8 +143,8 @@ GROUP BY    T_Cohorts_Recoded.Survey,
 ORDER BY    T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.Survey_Year,
             T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code;"
 
-DACSO_Q005_Z01_Base_NLS <- 
-"SELECT t_cohorts_recoded.survey,
+DACSO_Q005_Z01_Base_NLS <-
+  "SELECT t_cohorts_recoded.survey,
        t_cohorts_recoded.inst_cd,
        t_cohorts_recoded.age_group_rollup,
        t_cohorts_recoded.ttrain,
@@ -170,40 +169,40 @@ HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
          AND ( ( t_cohorts_recoded.grad_status ) = '1'
                 OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
 
-DACSO_Q005_Z02a_Base <- 
-"SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Count(*) AS Count, Count(*) AS Base
+DACSO_Q005_Z02a_Base <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Count(*) AS Count, Count(*) AS Base
 FROM T_Cohorts_Recoded
 WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
 GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
 HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
 
-DACSO_Q005_Z02b_Respondents <- 
-"SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1' And Current_Region_PSSM_Code<>-1,1,0)) AS Respondents
+DACSO_Q005_Z02b_Respondents <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1' And Current_Region_PSSM_Code<>-1,1,0)) AS Respondents
 FROM T_Cohorts_Recoded
 WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
 GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
 HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
 
-DACSO_Q005_Z02b_Respondents_Region_9999 <- 
-"SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1',1,0)) AS Respondents
+DACSO_Q005_Z02b_Respondents_Region_9999 <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Sum(IIf(Respondent='1',1,0)) AS Respondents
 FROM T_Cohorts_Recoded
 WHERE (((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)=-1) AND ((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0))
 GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.GRAD_STATUS, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED
 HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
 
-#DACSO_Q005_Z02b_Respondents_Region_9999=100% <- 
+#DACSO_Q005_Z02b_Respondents_Region_9999=100% <-
 #"SELECT DACSO_Q005_Z02a_Base.Survey, DACSO_Q005_Z02a_Base.INST_CD, DACSO_Q005_Z02a_Base.Age_Group_Rollup, DACSO_Q005_Z02a_Base.GRAD_STATUS, DACSO_Q005_Z02a_Base.TTRAIN, DACSO_Q005_Z02a_Base.LCIP4_CRED, DACSO_Q005_Z02a_Base.Count, DACSO_Q005_Z02a_Base.Base, DACSO_Q005_Z02b_Respondents_Region_9999.Respondents, Respondents/Count AS Expr1
 #FROM DACSO_Q005_Z02a_Base INNER JOIN DACSO_Q005_Z02b_Respondents_Region_9999 ON (DACSO_Q005_Z02a_Base.Survey = DACSO_Q005_Z02b_Respondents_Region_9999.Survey) AND (DACSO_Q005_Z02a_Base.INST_CD = DACSO_Q005_Z02b_Respondents_Region_9999.INST_CD) AND (DACSO_Q005_Z02a_Base.Age_Group_Rollup = DACSO_Q005_Z02b_Respondents_Region_9999.Age_Group_Rollup) AND (DACSO_Q005_Z02a_Base.GRAD_STATUS = DACSO_Q005_Z02b_Respondents_Region_9999.GRAD_STATUS) AND (DACSO_Q005_Z02a_Base.LCIP4_CRED = DACSO_Q005_Z02b_Respondents_Region_9999.LCIP4_CRED)
 #WHERE (((Respondents/Count)=1));"
 
-DACSO_Q005_Z02b_Respondents_Union <- 
-"SELECT DACSO_Q005_Z02b_Respondents.Survey, DACSO_Q005_Z02b_Respondents.INST_CD, DACSO_Q005_Z02b_Respondents.Age_Group_Rollup, DACSO_Q005_Z02b_Respondents.GRAD_STATUS, DACSO_Q005_Z02b_Respondents.TTRAIN, DACSO_Q005_Z02b_Respondents.LCIP4_CRED, DACSO_Q005_Z02b_Respondents.Respondents
+DACSO_Q005_Z02b_Respondents_Union <-
+  "SELECT DACSO_Q005_Z02b_Respondents.Survey, DACSO_Q005_Z02b_Respondents.INST_CD, DACSO_Q005_Z02b_Respondents.Age_Group_Rollup, DACSO_Q005_Z02b_Respondents.GRAD_STATUS, DACSO_Q005_Z02b_Respondents.TTRAIN, DACSO_Q005_Z02b_Respondents.LCIP4_CRED, DACSO_Q005_Z02b_Respondents.Respondents
 FROM DACSO_Q005_Z02b_Respondents
 UNION ALL SELECT DACSO_Q005_Z02b_Respondents_Region_9999=100%.Survey, DACSO_Q005_Z02b_Respondents_Region_9999=100%.INST_CD, DACSO_Q005_Z02b_Respondents_Region_9999=100%.Age_Group_Rollup, DACSO_Q005_Z02b_Respondents_Region_9999=100%.GRAD_STATUS, DACSO_Q005_Z02b_Respondents_Region_9999=100%.TTRAIN, DACSO_Q005_Z02b_Respondents_Region_9999=100%.LCIP4_CRED, DACSO_Q005_Z02b_Respondents_Region_9999=100%.Respondents
 FROM DACSO_Q005_Z02b_Respondents_Region_9999=100%;"
 
-DACSO_Q005_Z02c_Weight_tmp <- 
-"SELECT t_cohorts_recoded.survey,
+DACSO_Q005_Z02c_Weight_tmp <-
+  "SELECT t_cohorts_recoded.survey,
        t_cohorts_recoded.survey_year,
        t_cohorts_recoded.inst_cd,
        t_cohorts_recoded.age_group_rollup,
@@ -241,8 +240,8 @@ FROM
   (SELECT *, CASE WHEN (Respondents = 0) THEN 1 ELSE cast(Count as float)/cast(Respondents as float) END AS Weight_Prob
   FROM  DACSO_Q005_Z02c_Weight_tmp) T;"
 
-DACSO_Q005_Z03_Weight_Total <- 
-"SELECT dacso_q005_z02c_weight.survey,
+DACSO_Q005_Z03_Weight_Total <-
+  "SELECT dacso_q005_z02c_weight.survey,
        dacso_q005_z02c_weight.inst_cd,
        dacso_q005_z02c_weight.age_group_rollup,
        dacso_q005_z02c_weight.grad_status,
@@ -259,8 +258,8 @@ GROUP  BY dacso_q005_z02c_weight.survey,
           dacso_q005_z02c_weight.ttrain,
           dacso_q005_z02c_weight.lcip4_cred;"
 
-DACSO_Q005_Z04_Weight_Adj_Fac <- 
-"SELECT dacso_q005_z03_weight_total.survey,
+DACSO_Q005_Z04_Weight_Adj_Fac <-
+  "SELECT dacso_q005_z03_weight_total.survey,
        dacso_q005_z03_weight_total.inst_cd,
        dacso_q005_z03_weight_total.age_group_rollup,
        dacso_q005_z03_weight_total.grad_status,
@@ -297,11 +296,11 @@ FROM   dacso_q005_z02c_weight
                   AND ( dacso_q005_z02c_weight.inst_cd = dacso_q005_z04_weight_adj_fac.inst_cd )
                   AND ( dacso_q005_z02c_weight.age_group_rollup = dacso_q005_z04_weight_adj_fac.age_group_rollup );"
 
-DACSO_Q005_Z06_Add_Weight_NLS_Field <- 
-"ALTER TABLE T_Cohorts_Recoded ADD Weight_NLS Float NULL;"
+DACSO_Q005_Z06_Add_Weight_NLS_Field <-
+  "ALTER TABLE T_Cohorts_Recoded ADD Weight_NLS Float NULL;"
 
-DACSO_Q005_Z07_Weight_NLS_Null <- 
-"UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_NLS = Null;"
+DACSO_Q005_Z07_Weight_NLS_Null <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_NLS = Null;"
 
 DACSO_Q005_Z08_Weight_NLS_Update <- "
 UPDATE t_cohorts_recoded
@@ -342,16 +341,16 @@ GROUP  BY t_cohorts_recoded.survey_year,
 ORDER  BY t_cohorts_recoded.survey_year,
           t_cohorts_recoded.weight_nls;"
 
-DACSO_Q005_Z09_Check_Weights_No_Weight_CIP <- 
-"SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, 
+DACSO_Q005_Z09_Check_Weights_No_Weight_CIP <-
+  "SELECT T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, 
 T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, Count(*) AS Base
 FROM T_Cohorts_Recoded
 WHERE (((T_Cohorts_Recoded.New_Labour_Supply)=0 Or (T_Cohorts_Recoded.New_Labour_Supply)=1 Or (T_Cohorts_Recoded.New_Labour_Supply)=2 Or (T_Cohorts_Recoded.New_Labour_Supply)=3) AND ((T_Cohorts_Recoded.Weight)>0) AND ((T_Cohorts_Recoded.Weight_NLS)=0 Or (T_Cohorts_Recoded.Weight_NLS) Is Null) AND ((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)<>-1))
 GROUP BY T_Cohorts_Recoded.Survey, T_Cohorts_Recoded.INST_CD, T_Cohorts_Recoded.Age_Group_Rollup, T_Cohorts_Recoded.TTRAIN, T_Cohorts_Recoded.LCIP4_CRED, T_Cohorts_Recoded.GRAD_STATUS
 HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((T_Cohorts_Recoded.GRAD_STATUS)='1' Or (T_Cohorts_Recoded.GRAD_STATUS)='2' Or (T_Cohorts_Recoded.GRAD_STATUS)='3'));"
 
-DACSO_Q006a_Weight_New_Labour_Supply <- 
-"SELECT t_cohorts_recoded.pssm_credential,
+DACSO_Q006a_Weight_New_Labour_Supply <-
+  "SELECT t_cohorts_recoded.pssm_credential,
        t_cohorts_recoded.pssm_cred,
        t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
        t_cohorts_recoded.survey_year,
@@ -396,8 +395,8 @@ AND   ( t_cohorts_recoded.new_labour_supply = 0
   OR    t_cohorts_recoded.new_labour_supply = 2 
   OR    t_cohorts_recoded.new_labour_supply = 3 ); "
 
-DACSO_Q006b_Weighted_New_Labour_Supply <- 
-"SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+DACSO_Q006b_Weighted_New_Labour_Supply <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
        dacso_q006a_weight_new_labour_supply.pssm_cred,
        dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
        dacso_q006a_weight_new_labour_supply.age_group_rollup,
@@ -423,15 +422,15 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
 HAVING (( ( dacso_q006a_weight_new_labour_supply.age_group_rollup ) IS NOT NULL
         ));"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_0 <- 
-"SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.LCP4_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP4_CRED, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+DACSO_Q006b_Weighted_New_Labour_Supply_0 <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.LCP4_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP4_CRED, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
 INTO DACSO_Q006b_Weighted_New_Labour_Supply_0
 FROM DACSO_Q006a_Weight_New_Labour_Supply
 WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0))
 GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.LCP4_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP4_CRED, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_0_2D <- 
-"SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+DACSO_Q006b_Weighted_New_Labour_Supply_0_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
 INTO DACSO_Q006b_Weighted_New_Labour_Supply_0_2D
 FROM DACSO_Q006a_Weight_New_Labour_Supply
 WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0))
@@ -476,8 +475,8 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
   (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential,
   (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential;"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_2D <- 
-"SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
+DACSO_Q006b_Weighted_New_Labour_Supply_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Count
 INTO DACSO_Q006b_Weighted_New_Labour_Supply_2D
 FROM DACSO_Q006a_Weight_New_Labour_Supply
 WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
@@ -505,8 +504,8 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
           (CASE WHEN LEFT(pssm_cred, 1) = '1'  OR LEFT(pssm_cred, 1) = '3' THEN LEFT(pssm_cred, 1) + ' - ' ELSE '' END) +
           LEFT(lcp4_cd, 2) + ' - ' + pssm_credential; "
 
-DACSO_Q006b_Weighted_New_Labour_Supply_No_TT <- 
-"SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+DACSO_Q006b_Weighted_New_Labour_Supply_No_TT <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
        dacso_q006a_weight_new_labour_supply.pssm_cred,
        dacso_q006a_weight_new_labour_supply.current_region_pssm_code_rollup,
        dacso_q006a_weight_new_labour_supply.age_group_rollup,
@@ -534,8 +533,8 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
 HAVING (( ( dacso_q006a_weight_new_labour_supply.age_group_rollup ) IS NOT NULL
         )); "
 
-DACSO_Q006b_Weighted_New_Labour_Supply_Total <- 
-"SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+DACSO_Q006b_Weighted_New_Labour_Supply_Total <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
        dacso_q006a_weight_new_labour_supply.pssm_cred,
        dacso_q006a_weight_new_labour_supply.age_group_rollup,
        dacso_q006a_weight_new_labour_supply.lcp4_cd,
@@ -557,8 +556,8 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
           dacso_q006a_weight_new_labour_supply.lcip4_cred,
           dacso_q006a_weight_new_labour_supply.lcip2_cred;"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D <- 
-"SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
 DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, 
 DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED AS LCP2_CRED, 
 Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Total
@@ -567,16 +566,16 @@ FROM DACSO_Q006a_Weight_New_Labour_Supply
 WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
 GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), DACSO_Q006a_Weight_New_Labour_Supply.TTRAIN, DACSO_Q006a_Weight_New_Labour_Supply.LCIP2_CRED;"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT <- 
-"SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT <-
+  "SELECT DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, 
 DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCP2_CRED, Sum(DACSO_Q006a_Weight_New_Labour_Supply.Weighted) AS Total
 INTO DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT
 FROM DACSO_Q006a_Weight_New_Labour_Supply
 WHERE (((DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=0 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=1 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=2 Or (DACSO_Q006a_Weight_New_Labour_Supply.New_Labour_Supply)=3))
 GROUP BY DACSO_Q006a_Weight_New_Labour_Supply.PSSM_Credential, DACSO_Q006a_Weight_New_Labour_Supply.PSSM_CRED, DACSO_Q006a_Weight_New_Labour_Supply.Age_Group_Rollup, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
 
-DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT <- 
-"SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
+DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT <-
+  "SELECT dacso_q006a_weight_new_labour_supply.pssm_credential,
        dacso_q006a_weight_new_labour_supply.pssm_cred,
        dacso_q006a_weight_new_labour_supply.age_group_rollup,
        dacso_q006a_weight_new_labour_supply.lcp4_cd,
@@ -596,8 +595,8 @@ GROUP  BY dacso_q006a_weight_new_labour_supply.pssm_credential,
           (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + lcp4_cd + ' - ' + pssm_credential,
           (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as nvarchar(10)) + ' - ' END) + LEFT(lcp4_cd, 2) + ' - ' + pssm_credential;"
 
-DACSO_Q007a_Weighted_New_Labour_Supply <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total.TTRAIN, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP2_CRED, 
@@ -607,8 +606,8 @@ FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total
 LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply.LCIP4_CRED)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup) Is Not Null));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_0 <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0 <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total.TTRAIN, DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total.Total, 
@@ -617,8 +616,8 @@ INTO DACSO_Q007a_Weighted_New_Labour_Supply_0
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0 ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0.LCIP4_CRED)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_0_2D <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.TTRAIN, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Count, 
@@ -627,8 +626,8 @@ INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_2D
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_2D ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.LCP2_CRED)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_2D.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Total, 1-(ISNULL(Count,0)/Total) AS perc
@@ -636,8 +635,8 @@ INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_2D_No_TT
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.LCP2_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Age_Group_Rollup)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_2D_No_TT.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_0_No_TT <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_0_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Count, 
@@ -646,14 +645,14 @@ INTO DACSO_Q007a_Weighted_New_Labour_Supply_0_No_TT
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.LCIP4_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Age_Group_Rollup)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_0_No_TT.Count)>0) AND ((1-(ISNULL(Count,0)/Total))=0));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_2D <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Age_Group_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.TTRAIN, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Total, ISNULL(Count,0)/Total AS perc
+DACSO_Q007a_Weighted_New_Labour_Supply_2D <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D.PSSM_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Age_Group_Rollup, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.TTRAIN, DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_2D.Count, DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Total, ISNULL(Count,0)/Total AS perc
 INTO DACSO_Q007a_Weighted_New_Labour_Supply_2D
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_2D ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_2D.Age_Group_Rollup) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_2D.LCP2_CRED)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_2D.Current_Region_PSSM_Code_Rollup) Is Not Null));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_CRED, 
+DACSO_Q007a_Weighted_New_Labour_Supply_2D_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_Credential, DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.PSSM_CRED, 
 DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Age_Group_Rollup,
 DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CD, DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CRED, 
@@ -663,8 +662,8 @@ FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT
 LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.LCP2_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.LCP2_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_2D_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Age_Group_Rollup)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_2D_No_TT.Current_Region_PSSM_Code_Rollup) Is Not Null));"
 
-DACSO_Q007a_Weighted_New_Labour_Supply_No_TT <- 
-"SELECT DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.PSSM_Credential, 
+DACSO_Q007a_Weighted_New_Labour_Supply_No_TT <-
+  "SELECT DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.PSSM_Credential, 
 DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.PSSM_CRED, DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Age_Group_Rollup, 
 DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.LCP4_CD, DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED, 
@@ -673,7 +672,6 @@ DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Total, ISNULL(Count,0)/Total 
 INTO DACSO_Q007a_Weighted_New_Labour_Supply_No_TT
 FROM DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT LEFT JOIN DACSO_Q006b_Weighted_New_Labour_Supply_No_TT ON (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.LCIP4_CRED = DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.LCIP4_CRED) AND (DACSO_Q006b_Weighted_New_Labour_Supply_Total_No_TT.Age_Group_Rollup = DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Age_Group_Rollup)
 WHERE (((DACSO_Q006b_Weighted_New_Labour_Supply_No_TT.Current_Region_PSSM_Code_Rollup) Is Not Null));"
-
 
 
 DACSO_Q007b0_Delete_New_Labour_Supply <- "
@@ -758,23 +756,23 @@ dacso_q007a_weighted_new_labour_supply_0_no_tt.total,
 dacso_q007a_weighted_new_labour_supply_0_no_tt.perc
 FROM   dacso_q007a_weighted_new_labour_supply_0_no_tt;"
 
-DACSO_Q007c0_Delete_New_Labour_Supply_2D <- 
-"DELETE 
+DACSO_Q007c0_Delete_New_Labour_Supply_2D <-
+  "DELETE 
 FROM Labour_Supply_Distribution_LCP2
 WHERE (((Labour_Supply_Distribution_LCP2.Survey)='Student Outcomes'));"
 
-DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT <- 
-"DELETE 
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT <-
+  "DELETE 
 FROM Labour_Supply_Distribution_LCP2_No_TT
 WHERE (((Labour_Supply_Distribution_LCP2_No_TT.Survey)='Student Outcomes'));"
 
-DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT_QI <- 
-"DELETE 
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_No_TT_QI <-
+  "DELETE 
 FROM Labour_Supply_Distribution_LCP2_No_TT_QI
 WHERE (((Labour_Supply_Distribution_LCP2_No_TT_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_LCP2_No_TT_QI.Survey)='PTIB'));"
 
-DACSO_Q007c0_Delete_New_Labour_Supply_2D_QI <- 
-"DELETE 
+DACSO_Q007c0_Delete_New_Labour_Supply_2D_QI <-
+  "DELETE 
 FROM Labour_Supply_Distribution_LCP2_QI
 WHERE (((Labour_Supply_Distribution_LCP2_QI.Survey)='Student Outcomes' Or (Labour_Supply_Distribution_LCP2_QI.Survey)='PTIB'));"
 

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-occupation-distributions.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-occupation-distributions.R
@@ -28,10 +28,9 @@ HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
                 OR ( t_cohorts_recoded.grad_status ) = '3' ) ); "
 
 
-
 # ---- DACSO_Q008_Z02a_Base ----
-DACSO_Q008_Z02a_Base <- 
-"
+DACSO_Q008_Z02a_Base <-
+  "
 SELECT t_cohorts_recoded.survey,
 t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
 t_cohorts_recoded.survey_year,
@@ -73,7 +72,7 @@ HAVING
   AND ( ( t_cohorts_recoded.grad_status ) = '1'
         OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
 
-  DACSO_Q008_Z02b_Respondents <- 
+DACSO_Q008_Z02b_Respondents <-
   "
   SELECT t_cohorts_recoded.survey,
   t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
@@ -113,12 +112,11 @@ HAVING
   HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
            AND ( ( t_cohorts_recoded.grad_status ) = '1'
                  OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
-  
 
 
 # ---- DACSO_Q008_Z02b_Respondents_NOC_99999 ----
-DACSO_Q008_Z02b_Respondents_NOC_99999 <- 
-"
+DACSO_Q008_Z02b_Respondents_NOC_99999 <-
+  "
 SELECT t_cohorts_recoded.survey,
 t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup,
 t_cohorts_recoded.survey_year,
@@ -158,10 +156,9 @@ HAVING ( ( ( t_cohorts_recoded.age_group_rollup ) IS NOT NULL )
                OR ( t_cohorts_recoded.grad_status ) = '3' ) );"
 
 
-
 # ---- DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc ----
-DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc <- 
-"
+DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc <-
+  "
 SELECT dacso_q008_z02a_base.survey,
        dacso_q008_z02a_base.current_region_pssm_code_rollup,
        dacso_q008_z02a_base.survey_year,
@@ -194,10 +191,9 @@ dacso_q008_z02b_respondents_noc_99999.survey )
 WHERE  (( ( respondents / count ) = 1 ));"
 
 
-
 # ---- DACSO_Q008_Z02b_Respondents_Union ----
-DACSO_Q008_Z02b_Respondents_Union <- 
-"
+DACSO_Q008_Z02b_Respondents_Union <-
+  "
 SELECT DACSO_Q008_Z02b_Respondents.Survey, 
 DACSO_Q008_Z02b_Respondents.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q008_Z02b_Respondents.Survey_Year, 
@@ -222,10 +218,9 @@ DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc.Respondents
 FROM DACSO_Q008_Z02b_Respondents_NOC_99999_100_perc;"
 
 
-
 # ---- DACSO_Q008_Z02c_Weight ----
-DACSO_Q008_Z02c_Weight <- 
-"SELECT DACSO_Q008_Z02a_Base.Survey, 
+DACSO_Q008_Z02c_Weight <-
+  "SELECT DACSO_Q008_Z02a_Base.Survey, 
         DACSO_Q008_Z02a_Base.Current_Region_PSSM_Code_Rollup, 
         DACSO_Q008_Z02a_Base.Survey_Year, DACSO_Q008_Z02a_Base.INST_CD, 
         DACSO_Q008_Z02a_Base.Age_Group_Rollup, DACSO_Q008_Z02a_Base.GRAD_STATUS, 
@@ -252,10 +247,9 @@ GROUP BY DACSO_Q008_Z02a_Base.Survey,
         DACSO_Q008_Z02b_Respondents_Union.Respondents;"
 
 
-
 # ---- DACSO_Q008_Z03_Weight_Total ----
-DACSO_Q008_Z03_Weight_Total <- 
-"SELECT dacso_q008_z02c_weight.survey,
+DACSO_Q008_Z03_Weight_Total <-
+  "SELECT dacso_q008_z02c_weight.survey,
        dacso_q008_z02c_weight.current_region_pssm_code_rollup,
        dacso_q008_z02c_weight.inst_cd,
        dacso_q008_z02c_weight.age_group_rollup,
@@ -275,10 +269,9 @@ GROUP  BY dacso_q008_z02c_weight.survey,
           dacso_q008_z02c_weight.lcip4_cred;"
 
 
-
 # ---- DACSO_Q008_Z04_Weight_Adj_Fac ----
-DACSO_Q008_Z04_Weight_Adj_Fac <- 
-"SELECT dacso_q008_z03_weight_total.survey,
+DACSO_Q008_Z04_Weight_Adj_Fac <-
+  "SELECT dacso_q008_z03_weight_total.survey,
        dacso_q008_z03_weight_total.current_region_pssm_code_rollup,
        dacso_q008_z03_weight_total.inst_cd,
        dacso_q008_z03_weight_total.age_group_rollup,
@@ -295,10 +288,9 @@ INTO DACSO_Q008_Z04_Weight_Adj_Fac
 FROM   dacso_q008_z03_weight_total;"
 
 
-
 # ---- DACSO_Q008_Z05_Weight_OCC ----
-DACSO_Q008_Z05_Weight_OCC <- 
-"SELECT DACSO_Q008_Z02c_Weight.Survey, 
+DACSO_Q008_Z05_Weight_OCC <-
+  "SELECT DACSO_Q008_Z02c_Weight.Survey, 
       DACSO_Q008_Z02c_Weight.Current_Region_PSSM_Code_Rollup,
       T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, DACSO_Q008_Z02c_Weight.Survey_Year, 
       DACSO_Q008_Z02c_Weight.INST_CD, DACSO_Q008_Z02c_Weight.Age_Group_Rollup, 
@@ -322,10 +314,9 @@ INNER JOIN T_Current_Region_PSSM_Codes
   ON T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code_Rollup;"
 
 
-
 # ---- DACSO_Q008_Z05b_Finding_NLS2_Missing ----
-DACSO_Q008_Z05b_Finding_NLS2_Missing <- 
-"SELECT 
+DACSO_Q008_Z05b_Finding_NLS2_Missing <-
+  "SELECT 
 tmp_tbl_Weights_OCC.Survey, 
 tmp_tbl_Weights_OCC.INST_CD, 
 tmp_tbl_Weights_OCC.Age_Group_Rollup, 
@@ -347,8 +338,8 @@ WHERE (((tmp_tbl_Weights_OCC.Survey) Is Null)
   AND ((tmp_tbl_Weights_OCC.LCIP4_CRED) Is Null));"
 
 # ---- DACSO_Q008_Z05b_NOC4D_NLS_XTab ----
-DACSO_Q008_Z05b_NOC4D_NLS_XTab <- 
-"
+DACSO_Q008_Z05b_NOC4D_NLS_XTab <-
+  "
 SELECT age_group_rollup, noc_cd, english_name, [1],[3]
 INTO DACSO_Q008_Z05b_NOC4D_NLS_XTab
 FROM(
@@ -373,10 +364,9 @@ PIVOT (
 order by age_group_rollup, noc_cd;"
 
 
-
 # ---- DACSO_Q008_Z05b_Weight_Comparison ----
-DACSO_Q008_Z05b_Weight_Comparison <- 
-"
+DACSO_Q008_Z05b_Weight_Comparison <-
+  "
 SELECT tmp_tbl_weights_nls.survey,
        tmp_tbl_weights_nls.survey_year,
        tmp_tbl_weights_nls.inst_cd,
@@ -406,20 +396,18 @@ WHERE  ( ( ( tmp_tbl_weights_occ.weight_occ ) <> weight_nls )
 
 
 # ---- DACSO_Q008_Z06_Add_Weight_OCC_Field ----
-DACSO_Q008_Z06_Add_Weight_OCC_Field <- 
-"ALTER TABLE T_Cohorts_Recoded ADD Weight_OCC FLOAT NULL;"
-
+DACSO_Q008_Z06_Add_Weight_OCC_Field <-
+  "ALTER TABLE T_Cohorts_Recoded ADD Weight_OCC FLOAT NULL;"
 
 
 # ---- DACSO_Q008_Z07_Weight_OCC_Null ----
-DACSO_Q008_Z07_Weight_OCC_Null <- 
-"UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_OCC = Null;"
-
+DACSO_Q008_Z07_Weight_OCC_Null <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.Weight_OCC = Null;"
 
 
 # ---- DACSO_Q008_Z08_Weight_OCC_Update ----
-DACSO_Q008_Z08_Weight_OCC_Update <- 
-"UPDATE T_Cohorts_Recoded 
+DACSO_Q008_Z08_Weight_OCC_Update <-
+  "UPDATE T_Cohorts_Recoded 
 SET T_Cohorts_Recoded.Weight_OCC = tmp_tbl_Weights_OCC.Weight_OCC
 FROM T_Current_Region_PSSM_Codes 
 INNER JOIN ((tmp_tbl_Weights_OCC INNER JOIN T_Cohorts_Recoded 
@@ -440,7 +428,7 @@ WHERE (((T_Cohorts_Recoded.CURRENT_REGION_PSSM_CODE)<>-1)
 
 # ---- DACSO_Q008_Z08_Weight_OCC_Update ----
 DACSO_Q008_Z08_Weight_OCC_Update <-
-"UPDATE T_Cohorts_Recoded
+  "UPDATE T_Cohorts_Recoded
 SET T_Cohorts_Recoded.Weight_OCC = tmp_tbl_Weights_OCC.Weight_OCC 
 from T_Cohorts_Recoded
 inner join tmp_tbl_Weights_OCC
@@ -459,8 +447,8 @@ AND T_Cohorts_Recoded.NOC_CD Is Not Null
 And T_Cohorts_Recoded.NOC_CD <> '99999';"
 
 # ---- DACSO_Q008_Z08_Weight_OCC_Update_NOC_99999_100_perc ----
-DACSO_Q008_Z08_Weight_OCC_Update_NOC_99999_100_perc <- 
-"UPDATE t_cohorts_recoded
+DACSO_Q008_Z08_Weight_OCC_Update_NOC_99999_100_perc <-
+  "UPDATE t_cohorts_recoded
 SET        t_cohorts_recoded.weight_occ = tmp_tbl_weights_occ.weight_occ
 from t_cohorts_recoded
 INNER JOIN t_current_region_pssm_codes
@@ -486,10 +474,9 @@ WHERE      t_cohorts_recoded.current_region_pssm_code<>-1
 AND        t_cohorts_recoded.noc_cd IS NOT NULL;"
 
 
-
 # ---- DACSO_Q008_Z09_Check_Weights ----
-DACSO_Q008_Z09_Check_Weights <- 
-"SELECT t_cohorts_recoded.survey_year,
+DACSO_Q008_Z09_Check_Weights <-
+  "SELECT t_cohorts_recoded.survey_year,
        t_cohorts_recoded.inst_cd,
        t_cohorts_recoded.age_group_rollup,
        t_cohorts_recoded.ttrain,
@@ -519,8 +506,6 @@ HAVING ( ( ( t_cohorts_recoded.weight_occ ) IS NOT NULL )
          AND ( ( t_cohorts_recoded.respondent ) = '1' ) )
 ORDER  BY t_cohorts_recoded.survey_year,
           t_cohorts_recoded.weight_occ;"
-
-
 
 
 # ---- DACSO_Q009_Weight_Occs ----
@@ -571,12 +556,11 @@ HAVING t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup  <> 99
 ORDER  BY t_cohorts_recoded.grad_status,
 	t_cohorts_recoded.lcip4_cred,
 	CASE WHEN t_cohorts_recoded.noc_cd = 'XXXXX' THEN '99999' ELSE t_cohorts_recoded.noc_cd END;"
-  
 
 
 # ---- DACSO_Q009_Weighted_Occs_2D ----
-DACSO_Q009_Weighted_Occs_2D <- 
-"SELECT dacso_q009_weight_occs.pssm_credential,
+DACSO_Q009_Weighted_Occs_2D <-
+  "SELECT dacso_q009_weight_occs.pssm_credential,
        dacso_q009_weight_occs.pssm_cred,
        dacso_q009_weight_occs.current_region_pssm_code_rollup,
        dacso_q009_weight_occs.age_group_rollup,
@@ -597,10 +581,9 @@ GROUP  BY dacso_q009_weight_occs.pssm_credential,
           dacso_q009_weight_occs.noc_cd; "
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_2D_BC ----
-DACSO_Q009_Weighted_Occs_2D_BC <- 
-"SELECT dacso_q009_weight_occs.pssm_credential,
+DACSO_Q009_Weighted_Occs_2D_BC <-
+  "SELECT dacso_q009_weight_occs.pssm_credential,
        dacso_q009_weight_occs.pssm_cred,
        LEFT(lcp4_cd, 2)                     AS LCP2_CD,
        dacso_q009_weight_occs.ttrain,
@@ -624,10 +607,9 @@ GROUP  BY dacso_q009_weight_occs.pssm_credential,
           dacso_q009_weight_occs.noc_cd; "
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_2D_BC_No_TT ----
-DACSO_Q009_Weighted_Occs_2D_BC_No_TT <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, 
+DACSO_Q009_Weighted_Occs_2D_BC_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, 
 IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
 DACSO_Q009_Weight_Occs.NOC_CD, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Count
 INTO DACSO_Q009_Weighted_Occs_2D_BC_No_TT
@@ -639,10 +621,9 @@ GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential,
 DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential, DACSO_Q009_Weight_Occs.NOC_CD;"
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_2D_No_TT ----
-DACSO_Q009_Weighted_Occs_2D_No_TT <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weighted_Occs_2D_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
 DACSO_Q009_Weight_Occs.PSSM_CRED, 
 DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q009_Weight_Occs.Age_Group_Rollup, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
@@ -653,10 +634,9 @@ GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRE
 DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential, DACSO_Q009_Weight_Occs.NOC_CD;"
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_Total_2D ----
-DACSO_Q009_Weighted_Occs_Total_2D <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weighted_Occs_Total_2D <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
 DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
 Left(LCP4_CD,2) AS LCP2_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED, 
 Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
@@ -667,10 +647,9 @@ DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.A
 Left(LCP4_CD,2), DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED;"
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_Total_2D_BC ----
-DACSO_Q009_Weighted_Occs_Total_2D_BC <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
+DACSO_Q009_Weighted_Occs_Total_2D_BC <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, 
 DACSO_Q009_Weight_Occs.PSSM_CRED, 
 Left(LCP4_CD,2) AS LCP2_CD, 
 DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
@@ -682,10 +661,9 @@ GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRE
 Left(LCP4_CD,2), DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP2_CRED;"
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT ----
-DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
 INTO DACSO_Q009_Weighted_Occs_Total_2D_BC_No_TT
 FROM DACSO_Q009_Weight_Occs INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
 WHERE (((T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC) Is Not Null))
@@ -695,10 +673,9 @@ IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),
 Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
 
 
-
 # ---- DACSO_Q009_Weighted_Occs_Total_2D_No_TT ----
-DACSO_Q009_Weighted_Occs_Total_2D_No_TT <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009_Weighted_Occs_Total_2D_No_TT <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
 DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
 Left(LCP4_CD,2) AS LCP2_CD, IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),
 Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential AS LCIP2_CRED, 
@@ -711,10 +688,9 @@ DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.A
 Left(LCP4_CD,2), IIf((Left(PSSM_CRED,1)='1' Or Left(PSSM_CRED,1)='3'),Left(PSSM_CRED,1) + ' - ','') + Left(LCP4_CD,2) + ' - ' + PSSM_Credential;"
 
 
-
 # ---- DACSO_Q009b_Weighted_Occs ----
-DACSO_Q009b_Weighted_Occs <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
+DACSO_Q009b_Weighted_Occs <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, 
 DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, 
 DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, 
 DACSO_Q009_Weight_Occs.LCIP2_CRED, DACSO_Q009_Weight_Occs.NOC_CD, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Count
@@ -727,10 +703,9 @@ DACSO_Q009_Weight_Occs.LCIP2_CRED, DACSO_Q009_Weight_Occs.NOC_CD
 ORDER BY DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.NOC_CD;"
 
 
-
 # ---- DACSO_Q009b_Weighted_Occs_No_TT ----
-DACSO_Q009b_Weighted_Occs_No_TT <- 
-"
+DACSO_Q009b_Weighted_Occs_No_TT <-
+  "
 SELECT dacso_q009_weight_occs.pssm_credential,
 dacso_q009_weight_occs.pssm_cred,
 dacso_q009_weight_occs.current_region_pssm_code_rollup,
@@ -753,20 +728,18 @@ dacso_q009_weight_occs.noc_cd
 ORDER  BY dacso_q009_weight_occs.noc_cd;"
 
 
-
 # ---- DACSO_Q009b_Weighted_Occs_Total ----
-DACSO_Q009b_Weighted_Occs_Total <- 
-"SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
+DACSO_Q009b_Weighted_Occs_Total <-
+  "SELECT DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.LCIP2_CRED, Sum(DACSO_Q009_Weight_Occs.Weighted) AS Total
 INTO DACSO_Q009b_Weighted_Occs_Total
 FROM DACSO_Q009_Weight_Occs
 GROUP BY DACSO_Q009_Weight_Occs.PSSM_Credential, DACSO_Q009_Weight_Occs.PSSM_CRED, DACSO_Q009_Weight_Occs.Current_Region_PSSM_Code_Rollup, DACSO_Q009_Weight_Occs.Age_Group_Rollup, DACSO_Q009_Weight_Occs.LCP4_CD, DACSO_Q009_Weight_Occs.TTRAIN, DACSO_Q009_Weight_Occs.LCIP4_CRED, DACSO_Q009_Weight_Occs.LCIP2_CRED
 ORDER BY DACSO_Q009_Weight_Occs.LCIP4_CRED;"
 
 
-
 # ---- DACSO_Q009b_Weighted_Occs_Total_No_TT ----
-DACSO_Q009b_Weighted_Occs_Total_No_TT <- 
-"SELECT   dacso_q009_weight_occs.pssm_credential,
+DACSO_Q009b_Weighted_Occs_Total_No_TT <-
+  "SELECT   dacso_q009_weight_occs.pssm_credential,
 dacso_q009_weight_occs.pssm_cred,
 dacso_q009_weight_occs.current_region_pssm_code_rollup,
 dacso_q009_weight_occs.age_group_rollup,
@@ -785,10 +758,9 @@ dacso_q009_weight_occs.lcp4_cd,
 (CASE WHEN grad_status IS NULL THEN NULL ELSE cast(grad_status as varchar) + ' - ' END ) + LEFT(lcp4_cd,2) + ' - ' + pssm_credential;"
 
 
-
 # ---- DACSO_Q010_Weighted_Occs_Dist ----
-DACSO_Q010_Weighted_Occs_Dist <- 
-"
+DACSO_Q010_Weighted_Occs_Dist <-
+  "
 SELECT dacso_q009b_weighted_occs_total.pssm_credential,
        dacso_q009b_weighted_occs_total.pssm_cred,
        dacso_q009b_weighted_occs_total.current_region_pssm_code_rollup,
@@ -814,10 +786,9 @@ FROM   dacso_q009b_weighted_occs_total
                            dacso_q009b_weighted_occs.lcip4_cred ); "
 
 
-
 # ---- DACSO_Q010_Weighted_Occs_Dist_2D ----
-DACSO_Q010_Weighted_Occs_Dist_2D <- 
-"SELECT dacso_q009_weighted_occs_total_2d.pssm_credential,
+DACSO_Q010_Weighted_Occs_Dist_2D <-
+  "SELECT dacso_q009_weighted_occs_total_2d.pssm_credential,
        dacso_q009_weighted_occs_total_2d.pssm_cred,
        dacso_q009_weighted_occs_total_2d.current_region_pssm_code_rollup,
        dacso_q009_weighted_occs_total_2d.age_group_rollup,
@@ -840,10 +811,9 @@ FROM   dacso_q009_weighted_occs_total_2d
                            dacso_q009_weighted_occs_2d.age_group_rollup ); "
 
 
-
 # ---- DACSO_Q010_Weighted_Occs_Dist_2D_BC ----
-DACSO_Q010_Weighted_Occs_Dist_2D_BC <- 
-"SELECT dacso_q009_weighted_occs_total_2d_bc.pssm_credential,
+DACSO_Q010_Weighted_Occs_Dist_2D_BC <-
+  "SELECT dacso_q009_weighted_occs_total_2d_bc.pssm_credential,
        dacso_q009_weighted_occs_total_2d_bc.pssm_cred,
        dacso_q009_weighted_occs_total_2d_bc.lcp2_cd,
        dacso_q009_weighted_occs_total_2d_bc.ttrain,
@@ -859,11 +829,9 @@ FROM   dacso_q009_weighted_occs_total_2d_bc
                  dacso_q009_weighted_occs_2d_bc.lcip2_cred; "
 
 
-
-
 # ---- DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT ----
-DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT <- 
-"SELECT dacso_q009_weighted_occs_total_2d_bc_no_tt.pssm_credential,
+DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT <-
+  "SELECT dacso_q009_weighted_occs_total_2d_bc_no_tt.pssm_credential,
        dacso_q009_weighted_occs_total_2d_bc_no_tt.pssm_cred,
        dacso_q009_weighted_occs_total_2d_bc_no_tt.lcp2_cd,
        dacso_q009_weighted_occs_total_2d_bc_no_tt.lcip2_cred,
@@ -876,12 +844,11 @@ FROM   dacso_q009_weighted_occs_total_2d_bc_no_tt
        LEFT JOIN dacso_q009_weighted_occs_2d_bc_no_tt
               ON dacso_q009_weighted_occs_total_2d_bc_no_tt.lcip2_cred =
                  dacso_q009_weighted_occs_2d_bc_no_tt.lcip2_cred; "
-  
 
 
 # ---- DACSO_Q010_Weighted_Occs_Dist_2D_No_TT ----
-DACSO_Q010_Weighted_Occs_Dist_2D_No_TT <- 
-"SELECT dacso_q009_weighted_occs_total_2d_no_tt.pssm_credential,
+DACSO_Q010_Weighted_Occs_Dist_2D_No_TT <-
+  "SELECT dacso_q009_weighted_occs_total_2d_no_tt.pssm_credential,
        dacso_q009_weighted_occs_total_2d_no_tt.pssm_cred,
        dacso_q009_weighted_occs_total_2d_no_tt.current_region_pssm_code_rollup,
        dacso_q009_weighted_occs_total_2d_no_tt.age_group_rollup,
@@ -903,10 +870,9 @@ AND ( dacso_q009_weighted_occs_total_2d_no_tt.lcip2_cred =
 dacso_q009_weighted_occs_2d_no_tt.lcip2_cred ); "
 
 
-
 # ---- DACSO_Q010_Weighted_Occs_Dist_No_TT ----
-DACSO_Q010_Weighted_Occs_Dist_No_TT <- 
-"SELECT dacso_q009b_weighted_occs_total_no_tt.pssm_credential,
+DACSO_Q010_Weighted_Occs_Dist_No_TT <-
+  "SELECT dacso_q009b_weighted_occs_total_no_tt.pssm_credential,
        dacso_q009b_weighted_occs_total_no_tt.pssm_cred,
        dacso_q009b_weighted_occs_total_no_tt.current_region_pssm_code_rollup,
        dacso_q009b_weighted_occs_total_no_tt.age_group_rollup,
@@ -923,45 +889,39 @@ LEFT JOIN dacso_q009b_weighted_occs_no_tt
   ON  (dacso_q009b_weighted_occs_total_no_tt.lcip4_cred = cast(dacso_q009b_weighted_occs_no_tt.lcip4_cred as nvarchar(20)))
   AND (dacso_q009b_weighted_occs_total_no_tt.current_region_pssm_code_rollup = dacso_q009b_weighted_occs_no_tt.current_region_pssm_code_rollup )
   AND (dacso_q009b_weighted_occs_total_no_tt.age_group_rollup = dacso_q009b_weighted_occs_no_tt.age_group_rollup ); "
-  
 
 
 # ---- DACSO_Q010a0_Delete_Occupational_Distribution ----
-DACSO_Q010a0_Delete_Occupational_Distribution <- 
-"DELETE 
+DACSO_Q010a0_Delete_Occupational_Distribution <-
+  "DELETE 
 FROM Occupation_Distributions
 WHERE (((Occupation_Distributions.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010a0_Delete_Occupational_Distribution_No_TT ----
-DACSO_Q010a0_Delete_Occupational_Distribution_No_TT <- 
-"DELETE 
+DACSO_Q010a0_Delete_Occupational_Distribution_No_TT <-
+  "DELETE 
 FROM Occupation_Distributions_No_TT
 WHERE (((Occupation_Distributions_No_TT.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010a0_Delete_Occupational_Distribution_No_TT_QI ----
-DACSO_Q010a0_Delete_Occupational_Distribution_No_TT_QI <- 
-"DELETE
+DACSO_Q010a0_Delete_Occupational_Distribution_No_TT_QI <-
+  "DELETE
 FROM Occupation_Distributions_No_TT_QI
 WHERE (((Occupation_Distributions_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_No_TT_QI.Survey)='PTIB'));"
 
 
-
 # ---- DACSO_Q010a0_Delete_Occupational_Distribution_QI ----
-DACSO_Q010a0_Delete_Occupational_Distribution_QI <- 
-"DELETE 
+DACSO_Q010a0_Delete_Occupational_Distribution_QI <-
+  "DELETE 
 FROM Occupation_Distributions_QI
 WHERE (((Occupation_Distributions_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_QI.Survey)='PTIB'));"
 
 
-
-
 # ---- DACSO_Q010a1_Append_Occupational_Distribution ----
-DACSO_Q010a1_Append_Occupational_Distribution <- 
-"INSERT INTO Occupation_Distributions (Survey, PSSM_Credential, PSSM_CRED, 
+DACSO_Q010a1_Append_Occupational_Distribution <-
+  "INSERT INTO Occupation_Distributions (Survey, PSSM_Credential, PSSM_CRED, 
   Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, LCIP2_CRED, NOC, [Count], Total, [Percent])
 SELECT 'Student Outcomes' AS Survey, 
 DACSO_Q010_Weighted_Occs_Dist.PSSM_Credential, 
@@ -979,10 +939,9 @@ DACSO_Q010_Weighted_Occs_Dist.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist;"
 
 
-
 # ---- DACSO_Q010a1_Append_Occupational_Distribution_No_TT ----
-DACSO_Q010a1_Append_Occupational_Distribution_No_TT <- 
-"INSERT INTO Occupation_Distributions_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010a1_Append_Occupational_Distribution_No_TT <-
+  "INSERT INTO Occupation_Distributions_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
 Age_Group_Rollup, LCP4_CD, LCIP4_CRED, LCIP2_CRED, NOC, [Count], Total, [Percent])
 SELECT 'Student Outcomes' AS Survey, 
 DACSO_Q010_Weighted_Occs_Dist_No_TT.PSSM_Credential, 
@@ -999,127 +958,112 @@ DACSO_Q010_Weighted_Occs_Dist_No_TT.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist_No_TT;"
 
 
-
 # ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2 ----
-DACSO_Q010b0_Delete_Occupational_Distribution_LCP2 <- 
-"DELETE 
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2 <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2
 WHERE (((Occupation_Distributions_LCP2.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT ----
-DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT <- 
-"DELETE 
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_No_TT
 WHERE (((Occupation_Distributions_LCP2_No_TT.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT_QI ----
-DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT_QI <- 
-"DELETE 
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_No_TT_QI <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_No_TT_QI
 WHERE (((Occupation_Distributions_LCP2_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_No_TT_QI.Survey)='PTIB'));"
 
 
-
 # ---- DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_QI ----
-DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_QI <- 
-"DELETE 
+DACSO_Q010b0_Delete_Occupational_Distribution_LCP2_QI <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_QI
 WHERE (((Occupation_Distributions_LCP2_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_QI.Survey)='PTIB'));"
 
 
-
 # ---- DACSO_Q010b1_Append_Occupational_Distribution_LCP2 ----
-DACSO_Q010b1_Append_Occupational_Distribution_LCP2 <- 
-"INSERT INTO Occupation_Distributions_LCP2 ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+DACSO_Q010b1_Append_Occupational_Distribution_LCP2 <-
+  "INSERT INTO Occupation_Distributions_LCP2 ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
 SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D.Current_Region_PSSM_Code_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D.Age_Group_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D.TTRAIN, DACSO_Q010_Weighted_Occs_Dist_2D.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D.Count, DACSO_Q010_Weighted_Occs_Dist_2D.Total, DACSO_Q010_Weighted_Occs_Dist_2D.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist_2D;"
 
 
-
 # ---- DACSO_Q010b1_Append_Occupational_Distribution_LCP2_No_TT ----
-DACSO_Q010b1_Append_Occupational_Distribution_LCP2_No_TT <- 
-"INSERT INTO Occupation_Distributions_LCP2_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+DACSO_Q010b1_Append_Occupational_Distribution_LCP2_No_TT <-
+  "INSERT INTO Occupation_Distributions_LCP2_No_TT ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
 SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Current_Region_PSSM_Code_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Age_Group_Rollup, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Count, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.Total, DACSO_Q010_Weighted_Occs_Dist_2D_No_TT.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist_2D_No_TT;"
 
 
-
 # ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC ----
-DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC <- 
-"DELETE 
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_BC
 WHERE (((Occupation_Distributions_LCP2_BC.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT ----
-DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT <- 
-"DELETE 
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_BC_No_TT
 WHERE (((Occupation_Distributions_LCP2_BC_No_TT.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT_QI ----
-DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT_QI <- 
-"DELETE 
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_No_TT_QI <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_BC_No_TT_QI
 WHERE (((Occupation_Distributions_LCP2_BC_No_TT_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_BC_No_TT_QI.Survey)='PTIB'));"
 
 
-
 # ---- DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_QI ----
-DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_QI <- 
-"DELETE 
+DACSO_Q010c0_Delete_Occupational_Distribution_LCP2_BC_QI <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_BC_QI
 WHERE (((Occupation_Distributions_LCP2_BC_QI.Survey)='Student Outcomes' Or (Occupation_Distributions_LCP2_BC_QI.Survey)='PTIB'));"
 
 
-
 # ---- DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC ----
-DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC <- 
-"INSERT INTO Occupation_Distributions_LCP2_BC ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC <-
+  "INSERT INTO Occupation_Distributions_LCP2_BC ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, TTRAIN, LCIP2_CRED, NOC, [Count], Total, [Percent] )
 SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_BC.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_BC.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC.TTRAIN, DACSO_Q010_Weighted_Occs_Dist_2D_BC.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC.Count, DACSO_Q010_Weighted_Occs_Dist_2D_BC.Total, DACSO_Q010_Weighted_Occs_Dist_2D_BC.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist_2D_BC;"
 
 
-
 # ---- DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC_No_TT ----
-DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC_No_TT <- 
-"INSERT INTO Occupation_Distributions_LCP2_BC_No_TT ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
+DACSO_Q010c1_Append_Occupational_Distribution_LCP2_BC_No_TT <-
+  "INSERT INTO Occupation_Distributions_LCP2_BC_No_TT ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCIP2_CRED, NOC, [Count], Total, [Percent] )
 SELECT 'Student Outcomes' AS Survey, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.PSSM_Credential, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.PSSM_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.LCP2_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.LCIP2_CRED, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.NOC_CD, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.Count, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.Total, DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT.perc_Dist
 FROM DACSO_Q010_Weighted_Occs_Dist_2D_BC_No_TT;"
 
 # ---- Q010d1 - DACSO_Q010e PDEG Law Modifications ----
 
-
 # ---- DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply ----
-DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply <- 
-"DELETE 
+DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply <-
+  "DELETE 
 FROM Labour_Supply_Distribution
 WHERE (((Labour_Supply_Distribution.Survey)='2021 Census PSSM 2023-2024') 
 AND   ((Labour_Supply_Distribution.PSSM_Credential)='PDEG') 
 AND   ((Labour_Supply_Distribution.LCP4_CD)='07'));"
 
 
-
 # ---- DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply_QI ----
-DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply_QI <- 
-"DELETE 
+DACSO_Q010d1_Delete_PDEG_CIP_Cluster_07_Law_New_Labour_Supply_QI <-
+  "DELETE 
 FROM Labour_Supply_Distribution_QI
 WHERE (((Labour_Supply_Distribution_QI.Survey)='2021 Census PSSM 2023-2024') 
 AND ((Labour_Supply_Distribution_QI.PSSM_Credential)='PDEG') 
 AND ((Labour_Supply_Distribution_QI.LCP4_CD)='07'));"
 
 
-
 # ---- DACSO_Q010d2_NLS_PDEG_07_Count ----
-DACSO_Q010d2_NLS_PDEG_07_Count <- 
-"SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
+DACSO_Q010d2_NLS_PDEG_07_Count <-
+  "SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
 Labour_Supply_Distribution.Current_Region_PSSM_Code_Rollup, Labour_Supply_Distribution.Age_Group_Rollup, Sum(Labour_Supply_Distribution.Count) AS Count
 INTO DACSO_Q010d2_NLS_PDEG_07_Count
 FROM Labour_Supply_Distribution
@@ -1128,10 +1072,9 @@ GROUP BY Labour_Supply_Distribution.Survey, Labour_Supply_Distribution.TTRAIN, L
 HAVING (((Labour_Supply_Distribution.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010d3_NLS_PDEG_07_Subtotal ----
-DACSO_Q010d3_NLS_PDEG_07_Subtotal <- 
-"SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
+DACSO_Q010d3_NLS_PDEG_07_Subtotal <-
+  "SELECT Labour_Supply_Distribution.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Labour_Supply_Distribution.TTRAIN, '07 - PDEG' AS LCIP4_CRED, 
 Labour_Supply_Distribution.Age_Group_Rollup, Labour_Supply_Distribution.Total AS Subtotal
 INTO DACSO_Q010d3_NLS_PDEG_07_Subtotal
 FROM Labour_Supply_Distribution
@@ -1140,10 +1083,9 @@ GROUP BY Labour_Supply_Distribution.Survey, Labour_Supply_Distribution.TTRAIN, L
 HAVING (((Labour_Supply_Distribution.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010d4_NLS_PDEG_07_Total ----
-DACSO_Q010d4_NLS_PDEG_07_Total <- 
-"SELECT DACSO_Q010d3_NLS_PDEG_07_Subtotal.Survey, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_Credential, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_CRED, 
+DACSO_Q010d4_NLS_PDEG_07_Total <-
+  "SELECT DACSO_Q010d3_NLS_PDEG_07_Subtotal.Survey, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_Credential, DACSO_Q010d3_NLS_PDEG_07_Subtotal.PSSM_CRED, 
 DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCP4_CD, DACSO_Q010d3_NLS_PDEG_07_Subtotal.TTRAIN, DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCIP4_CRED, 
 DACSO_Q010d3_NLS_PDEG_07_Subtotal.Age_Group_Rollup, Sum(DACSO_Q010d3_NLS_PDEG_07_Subtotal.Subtotal) AS Total
 INTO DACSO_Q010d4_NLS_PDEG_07_Total
@@ -1154,10 +1096,9 @@ DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCP4_CD, DACSO_Q010d3_NLS_PDEG_07_Subtotal.TTR
 DACSO_Q010d3_NLS_PDEG_07_Subtotal.LCIP4_CRED, DACSO_Q010d3_NLS_PDEG_07_Subtotal.Age_Group_Rollup;"
 
 
-
 # ---- DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply ----
-DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply <- 
-"SELECT DACSO_Q010d4_NLS_PDEG_07_Total.Survey, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_Credential, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_CRED, 
+DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply <-
+  "SELECT DACSO_Q010d4_NLS_PDEG_07_Total.Survey, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_Credential, DACSO_Q010d2_NLS_PDEG_07_Count.PSSM_CRED, 
 DACSO_Q010d2_NLS_PDEG_07_Count.Current_Region_PSSM_Code_Rollup, DACSO_Q010d2_NLS_PDEG_07_Count.Age_Group_Rollup, DACSO_Q010d2_NLS_PDEG_07_Count.LCP4_CD, 
 DACSO_Q010d4_NLS_PDEG_07_Total.TTRAIN, DACSO_Q010d4_NLS_PDEG_07_Total.LCIP4_CRED, DACSO_Q010d2_NLS_PDEG_07_Count.Count, DACSO_Q010d4_NLS_PDEG_07_Total.Total, 
 ISNULL(Count,0)/Total AS perc
@@ -1169,36 +1110,32 @@ AND (DACSO_Q010d4_NLS_PDEG_07_Total.Survey = DACSO_Q010d2_NLS_PDEG_07_Count.Surv
 WHERE (((DACSO_Q010d2_NLS_PDEG_07_Count.Current_Region_PSSM_Code_Rollup) Is Not Null));"
 
 
-
 # ---- DACSO_Q010d6_Append_NLS_PDEG_07_New_Labour_Supply ----
-DACSO_Q010d6_Append_NLS_PDEG_07_New_Labour_Supply <- 
-"INSERT INTO Labour_Supply_Distribution ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, Count, Total, New_Labour_Supply )
+DACSO_Q010d6_Append_NLS_PDEG_07_New_Labour_Supply <-
+  "INSERT INTO Labour_Supply_Distribution ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, Count, Total, New_Labour_Supply )
 SELECT DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Survey, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.PSSM_Credential, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.PSSM_CRED, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Current_Region_PSSM_Code_Rollup, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Age_Group_Rollup, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.LCP4_CD, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.TTRAIN, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.LCIP4_CRED, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Count, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.Total, DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply.perc
 FROM DACSO_Q010d5_NLS_PDEG_07_Weighted_New_Labour_Supply;"
 
 
-
 # ---- DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist ----
-DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist <- 
-"DELETE  
+DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist <-
+  "DELETE  
 FROM Occupation_Distributions
 WHERE (((Occupation_Distributions.Survey)='2021 Census PSSM 2022-2023') 
 AND ((Occupation_Distributions.PSSM_Credential)='PDEG') AND ((Occupation_Distributions.LCP4_CD)='07'));"
 
 
-
 # ---- DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist_QI ----
-DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist_QI <- 
-"DELETE  
+DACSO_Q010e1_Delete_PDEG_CIP_Cluster_07_Law_Occupation_Dist_QI <-
+  "DELETE  
 FROM Occupation_Distributions_QI
 WHERE (((Occupation_Distributions_QI.Survey)='2021 Census PSSM 2022-2023') 
 AND ((Occupation_Distributions_QI.PSSM_Credential)='PDEG') AND ((Occupation_Distributions_QI.LCP4_CD)='07'));"
 
 
-
 # ---- DACSO_Q010e2_Weighted_Occs_PDEG_07 ----
-DACSO_Q010e2_Weighted_Occs_PDEG_07 <- 
-"SELECT Occupation_Distributions.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Occupation_Distributions.TTRAIN, '07 - PDEG' AS LCIP4_CRED, Occupation_Distributions.Current_Region_PSSM_Code_Rollup, Occupation_Distributions.Age_Group_Rollup, Occupation_Distributions.NOC, Sum(Occupation_Distributions.Count) AS Count
+DACSO_Q010e2_Weighted_Occs_PDEG_07 <-
+  "SELECT Occupation_Distributions.Survey, 'PDEG' AS PSSM_Credential, 'PDEG' AS PSSM_CRED, '07' AS LCP4_CD, Occupation_Distributions.TTRAIN, '07 - PDEG' AS LCIP4_CRED, Occupation_Distributions.Current_Region_PSSM_Code_Rollup, Occupation_Distributions.Age_Group_Rollup, Occupation_Distributions.NOC, Sum(Occupation_Distributions.Count) AS Count
 INTO DACSO_Q010e2_Weighted_Occs_PDEG_07
 FROM Occupation_Distributions
 WHERE (((Left(LCP4_CD,2))=22) AND ((Occupation_Distributions.PSSM_Credential)='BACH'))
@@ -1207,10 +1144,9 @@ Occupation_Distributions.Age_Group_Rollup, Occupation_Distributions.NOC
 HAVING (((Occupation_Distributions.Survey)='Student Outcomes'));"
 
 
-
 # ---- DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 ----
-DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 <- 
-"SELECT DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey, DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_Credential, 
+DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 <-
+  "SELECT DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey, DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_Credential, 
 DACSO_Q010e2_Weighted_Occs_PDEG_07.PSSM_CRED, 
 DACSO_Q010e2_Weighted_Occs_PDEG_07.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q010e2_Weighted_Occs_PDEG_07.Age_Group_Rollup, DACSO_Q010e2_Weighted_Occs_PDEG_07.LCP4_CD, 
@@ -1225,10 +1161,9 @@ DACSO_Q010e2_Weighted_Occs_PDEG_07.TTRAIN, DACSO_Q010e2_Weighted_Occs_PDEG_07.LC
 ORDER BY DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED;"
 
 
-
 # ---- DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07 ----
-DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07 <- 
-"SELECT DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Survey, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.PSSM_Credential, 
+DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07 <-
+  "SELECT DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Survey, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.PSSM_Credential, 
 DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.PSSM_CRED, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Current_Region_PSSM_Code_Rollup, 
 DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Age_Group_Rollup, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCP4_CD, 
 DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.TTRAIN, DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCIP4_CRED, DACSO_Q010e2_Weighted_Occs_PDEG_07.NOC, 
@@ -1237,10 +1172,9 @@ INTO DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07
 FROM DACSO_Q010e3_Weighted_Occs_Total_PDEG_07 LEFT JOIN DACSO_Q010e2_Weighted_Occs_PDEG_07 ON (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Survey = DACSO_Q010e2_Weighted_Occs_PDEG_07.Survey) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Current_Region_PSSM_Code_Rollup = DACSO_Q010e2_Weighted_Occs_PDEG_07.Current_Region_PSSM_Code_Rollup) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.Age_Group_Rollup = DACSO_Q010e2_Weighted_Occs_PDEG_07.Age_Group_Rollup) AND (DACSO_Q010e3_Weighted_Occs_Total_PDEG_07.LCIP4_CRED = DACSO_Q010e2_Weighted_Occs_PDEG_07.LCIP4_CRED);"
 
 
-
 # ---- DACSO_Q010e5_Append_Occupational_Distribution_PDEG_07 ----
-DACSO_Q010e5_Append_Occupational_Distribution_PDEG_07 <- 
-"INSERT INTO Occupation_Distributions ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
+DACSO_Q010e5_Append_Occupational_Distribution_PDEG_07 <-
+  "INSERT INTO Occupation_Distributions ( Survey, PSSM_Credential, PSSM_CRED, Current_Region_PSSM_Code_Rollup, 
 Age_Group_Rollup, LCP4_CD, TTRAIN, LCIP4_CRED, NOC, Count, Total, [Percent])
 SELECT DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Survey, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.PSSM_Credential, 
 DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.PSSM_CRED, DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Current_Region_PSSM_Code_Rollup, 
@@ -1251,25 +1185,22 @@ DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07.Total, DACSO_Q010e4_Weighted_Occs_Dist_P
 FROM DACSO_Q010e4_Weighted_Occs_Dist_PDEG_07;"
 
 
-
 # ---- DACSO_Q99A_ENDDT_IMPUTED ----
-DACSO_Q99A_ENDDT_IMPUTED <- 
-"UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-2) + '-12'
+DACSO_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = (Survey_year-2) + '-12'
 WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='DACSO'));"
 
-#DACSO_Q99A_ENDDT - NOT USED <- 
+#DACSO_Q99A_ENDDT - NOT USED <-
 #"UPDATE (INFOWARE_SURV_COHORT_COLLECTION_INFO INNER JOIN DACSO_Q99A_STQUI_ID ON INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_STQU_ID = DACSO_Q99A_STQUI_ID.COCI_STQU_ID) INNER JOIN T_Cohorts_Recoded ON DACSO_Q99A_STQUI_ID.STQU_ID_Only=T_Cohorts_Recoded.STQU_ID SET T_Cohorts_Recoded.ENDDT = INFOWARE_SURV_COHORT_COLLECTION_INFO.COSC_ENRL_END_DATE
 #WHERE (((T_Cohorts_Recoded.Survey)='DACSO'));"
 
-#DACSO_Q99A_STQUI_ID - NOT USED <- 
+#DACSO_Q99A_STQUI_ID - NOT USED <-
 #"SELECT T_Cohorts_Recoded.STQU_ID AS Survey_STQU_ID, T_Cohorts_Recoded.Survey, CDbl(Right(STQU_ID,Len(STQU_ID)-InStr(1,STQU_ID,"-")-1)) AS STQU_ID_Only
 #FROM T_Cohorts_Recoded;"
 
-
-
 # ---- DACSO_qry99_Suppression_Public_Release_NOC ----
-DACSO_qry99_Suppression_Public_Release_NOC <- 
-"SELECT T_Cohorts_Recoded.Age_Group_Rollup, 
+DACSO_qry99_Suppression_Public_Release_NOC <-
+  "SELECT T_Cohorts_Recoded.Age_Group_Rollup, 
 tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
 T_Cohorts_Recoded.NOC_CD, 
 Count(*) AS Expr1 INTO T_Suppression_Public_Release_NOC
@@ -1279,5 +1210,3 @@ WHERE (((T_Cohorts_Recoded.Weight)>0))
 GROUP BY T_Cohorts_Recoded.Age_Group_Rollup, tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, T_Cohorts_Recoded.NOC_CD
 HAVING (((T_Cohorts_Recoded.Age_Group_Rollup) Is Not Null) AND ((Count(*))<5))
 ORDER BY Count(*);"
-
-

--- a/sql/02b-pssm-cohorts/02b-pssm-cohorts-trd.R
+++ b/sql/02b-pssm-cohorts/02b-pssm-cohorts-trd.R
@@ -1,20 +1,20 @@
-Q000_TRD_Graduates_Projection_Input <- 
-"SELECT T_TRD_Data.PSSM_Credential, T_TRD_Data.PSSM_Credential AS PSSM_CRED, tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
+Q000_TRD_Graduates_Projection_Input <-
+  "SELECT T_TRD_Data.PSSM_Credential, T_TRD_Data.PSSM_Credential AS PSSM_CRED, tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
 FROM (T_TRD_Data INNER JOIN T_Year_Survey_Year ON T_TRD_Data.SUBM_CD = T_Year_Survey_Year.SUBM_CD) 
 INNER JOIN (tbl_Age INNER JOIN tbl_Age_Groups ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group) ON T_TRD_Data.TRD_AGE_AT_SURVEY = tbl_Age.Age
 WHERE (((T_Year_Survey_Year.Survey)='TRD'))
 GROUP BY T_TRD_Data.PSSM_Credential, tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year, T_TRD_Data.PSSM_Credential
 ORDER BY tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year;"
 
-Q000_TRD_Program_Projection_Input <- 
-"SELECT tbl_Age_Groups.Age_Group_Label, T_TRD_Data.PSSM_Credential, [PSSM_Credential] + [Age_Group_Label] AS Expr1, T_TRD_Data.LCIP_LCP4_CD, Left([T_TRD_DATA].[LCIP_LCP4_CD],2) AS LCIP_CP2_CD, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
+Q000_TRD_Program_Projection_Input <-
+  "SELECT tbl_Age_Groups.Age_Group_Label, T_TRD_Data.PSSM_Credential, [PSSM_Credential] + [Age_Group_Label] AS Expr1, T_TRD_Data.LCIP_LCP4_CD, Left([T_TRD_DATA].[LCIP_LCP4_CD],2) AS LCIP_CP2_CD, T_Year_Survey_Year.Award_School_Year, Count(*) AS [Count]
 FROM (T_TRD_Data INNER JOIN (tbl_Age INNER JOIN tbl_Age_Groups ON tbl_Age.Age_Group = tbl_Age_Groups.Age_Group) ON T_TRD_Data.TRD_AGE_AT_SURVEY = tbl_Age.Age) INNER JOIN T_Year_Survey_Year ON T_TRD_Data.SUBM_CD = T_Year_Survey_Year.SUBM_CD
 WHERE (((T_Year_Survey_Year.Survey)='TRD'))
 GROUP BY tbl_Age_Groups.Age_Group_Label, T_TRD_Data.PSSM_Credential, [PSSM_Credential] + [Age_Group_Label], T_TRD_Data.LCIP_LCP4_CD, Left([T_TRD_DATA].[LCIP_LCP4_CD],2), T_Year_Survey_Year.Award_School_Year
 ORDER BY tbl_Age_Groups.Age_Group_Label, T_Year_Survey_Year.Award_School_Year;"
 
-Q000_TRD_Q003b_Add_CURRENT_REGION_PSSM <- 
-"ALTER TABLE T_TRD_Data
+Q000_TRD_Q003b_Add_CURRENT_REGION_PSSM <-
+  "ALTER TABLE T_TRD_Data
 ADD CURRENT_REGION_PSSM_CODE INT;"
 
 Q000_TRD_Q003b_Add_CURRENT_REGION_PSSM2 <- "
@@ -128,8 +128,8 @@ INNER JOIN t_year_survey_year
 	        ON tbl_Age.Age =  t_trd_data.TRD_AGE_AT_SURVEY
 WHERE  t_year_survey_year.survey = 'TRD';"
 
-Q000_TRD_Q99A_ENDDT <- 
-"UPDATE infoware_trades_cohort_info 
+Q000_TRD_Q99A_ENDDT <-
+  "UPDATE infoware_trades_cohort_info 
 INNER JOIN (t_cohorts_recoded 
 INNER JOIN 000_trd_q99a_stqui_id 
 ON t_cohorts_recoded.stqu_id = [000_TRD_Q99A_STQUI_ID].stqu_id) 
@@ -137,10 +137,10 @@ ON infoware_trades_cohort_info.KEY = [000_TRD_Q99A_STQUI_ID].KEY
 SET t_cohorts_recoded.enddt = LEFT([INFOWARE_TRADES_COHORT_INFO].[ENDDT],4) + '-' + RIGHT([INFOWARE_TRADES_COHORT_INFO].[ENDDT],2)
 WHERE (((t_cohorts_recoded.survey)='TRD'));"
 
-Q000_TRD_Q99A_ENDDT_IMPUTED <- 
-"UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = ([Survey_year]-2) + '-12'
+Q000_TRD_Q99A_ENDDT_IMPUTED <-
+  "UPDATE T_Cohorts_Recoded SET T_Cohorts_Recoded.ENDDT = ([Survey_year]-2) + '-12'
 WHERE (((T_Cohorts_Recoded.ENDDT) Is Null) AND ((T_Cohorts_Recoded.Survey)='TRD'));"
 
-Q000_TRD_Q99A_STQUI_ID <- 
-"SELECT INFOWARE_TRADES_COHORT_INFO.KEY, 'TRD - ' + [KEY] AS STQU_ID
+Q000_TRD_Q99A_STQUI_ID <-
+  "SELECT INFOWARE_TRADES_COHORT_INFO.KEY, 'TRD - ' + [KEY] AS STQU_ID
 FROM INFOWARE_TRADES_COHORT_INFO;"

--- a/sql/02b-pssm-cohorts/geocoding.R
+++ b/sql/02b-pssm-cohorts/geocoding.R
@@ -1,5 +1,5 @@
-qry_000_TRD_Current_Region_Data <- 
-"SELECT trades_cohort_info.KEY,
+qry_000_TRD_Current_Region_Data <-
+  "SELECT trades_cohort_info.KEY,
        trades_cohort_info.subm_cd,
        trades_cohort_info.respondent,
        trades_cohort_info.new_postal_code,
@@ -40,8 +40,8 @@ FROM (
 PIVOT (Count([key]) FOR SUBM_CD IN ([C_Outc14],[C_Outc15],[C_Outc16],[C_Outc17],[C_Outc18],[C_Outc19])) AS PVT
 ORDER BY cast(current_region_pssm_code AS INT)"
 
-qry_APPSO_Current_Region_Data <- 
-"SELECT apprentice_cohort_info.KEY,
+qry_APPSO_Current_Region_Data <-
+  "SELECT apprentice_cohort_info.KEY,
        apprentice_cohort_info.subm_cd,
        apprentice_cohort_info.respondent,
        apprentice_cohort_info.lrst_cd,
@@ -73,14 +73,14 @@ SET    appso_current_region_data.current_region_pssm_code =
 WHERE  appso_current_region_data.current_region_pssm_code IS NULL
 AND    appso_current_region_data.subm_cd IN ('C_Outc18', 'C_Outc19')"
 
-qry_APPSO100_Unknown_2016 <- 
-"INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], [New Phone2], [Phone Status2], [Phone category2], [New Phone3], [Phone Status3], [Phone category3], [New Phone4], [Phone Status4], [Phone category4], [New Phone5], [Phone Status5], [Phone category5], [New Phone6], [Phone Status6], [Phone category6], CURRENT_REGION_PSSM_CODE )
+qry_APPSO100_Unknown_2016 <-
+  "INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], [New Phone2], [Phone Status2], [Phone category2], [New Phone3], [Phone Status3], [Phone category3], [New Phone4], [Phone Status4], [Phone category4], [New Phone5], [Phone Status5], [Phone category5], [New Phone6], [Phone Status6], [Phone category6], CURRENT_REGION_PSSM_CODE )
 SELECT APPSO_Current_Region_Data.KEY, APPRENTICE_COHORT_INFO.SUBM_CD, APPRENTICE_COHORT_INFO.INST, APPRENTICE_COHORT_INFO.CURRENT_REGION3, 'APPSO' AS Expr1, APPRENTICE_COHORT_INFO.ADDRESS, APPRENTICE_COHORT_INFO.OPHONE1, APPRENTICE_COHORT_INFO.OPHONE2, APPRENTICE_COHORT_INFO.PHONE, APPRENTICE_COHORT_INFO.POSTAL, IIf(IsNull([APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]),[Q59],[APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]) AS Expr2, APPSO_sourcing_2016.[Research Results], APPSO_sourcing_2016.[New Phone1], APPSO_sourcing_2016.[Phone Status1], APPSO_sourcing_2016.[Phone category1], APPSO_sourcing_2016.[New Phone2], APPSO_sourcing_2016.[Phone Status2], APPSO_sourcing_2016.[Phone category2], APPSO_sourcing_2016.[New Phone3], APPSO_sourcing_2016.[Phone Status3], APPSO_sourcing_2016.[Phone category3], APPSO_sourcing_2016.[New Phone4], APPSO_sourcing_2016.[Phone Status4], APPSO_sourcing_2016.[Phone category4], APPSO_sourcing_2016.[New Phone5], APPSO_sourcing_2016.[Phone Status5], APPSO_sourcing_2016.[Phone category5], APPSO_sourcing_2016.[New Phone6], APPSO_sourcing_2016.[Phone Status6], APPSO_sourcing_2016.[Phone category6], APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE
 FROM APPSO_Current_Region_Data INNER JOIN ((APPRENTICE_COHORT_INFO LEFT JOIN APPSO_sourcing_2016 ON APPRENTICE_COHORT_INFO.KEY = APPSO_sourcing_2016.KEY) LEFT JOIN APPSO_long_response_2016 ON APPRENTICE_COHORT_INFO.KEY = APPSO_long_response_2016.KEY) ON APPSO_Current_Region_Data.KEY = APPRENTICE_COHORT_INFO.KEY
 WHERE (((APPRENTICE_COHORT_INFO.SUBM_CD)='C_Outc16') AND ((APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=-1 Or (APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=9) AND ((APPRENTICE_COHORT_INFO.RESPONDENT)='1'));"
 
-qry_APPSO100_Unknown_2017 <- 
-"INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], CURRENT_REGION_PSSM_CODE )
+qry_APPSO100_Unknown_2017 <-
+  "INSERT INTO Unknown_Geocoding_Investigation ( stqu_id, survey_year, INST, CURRENT_REGION3_CODE, Survey, ADDRESS_Cohort_Raw, OPHONE1_Cohort_Raw, OPHONE2_Cohort_Raw, PHONE_Cohort_Raw, POSTAL_Cohort_Raw, NEW_POST, [Research Results], [New Phone1], [Phone Status1], [Phone category1], CURRENT_REGION_PSSM_CODE )
 SELECT APPSO_Current_Region_Data.KEY, APPRENTICE_COHORT_INFO.SUBM_CD, APPRENTICE_COHORT_INFO.INST, APPRENTICE_COHORT_INFO.CURRENT_REGION3, 'APPSO' AS Expr1, APPRENTICE_COHORT_INFO.ADDRESS, APPRENTICE_COHORT_INFO.OPHONE1, APPRENTICE_COHORT_INFO.OPHONE2, APPRENTICE_COHORT_INFO.PHONE, APPRENTICE_COHORT_INFO.POSTAL, IIf(IsNull([APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]),[Q59],[APPRENTICE_COHORT_INFO].[POSTAL_CODE_NEW]) AS Expr2, APPSO_sourcing_2017.[Reseach Found], APPSO_sourcing_2017.[New Phone], APPSO_sourcing_2017.[Phone Status], APPSO_sourcing_2017.[Phone Category], APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE
 FROM ((APPSO_Current_Region_Data INNER JOIN APPRENTICE_COHORT_INFO ON APPSO_Current_Region_Data.KEY = APPRENTICE_COHORT_INFO.KEY) LEFT JOIN APPSO_sourcing_2017 ON APPRENTICE_COHORT_INFO.KEY = APPSO_sourcing_2017.key) LEFT JOIN APPSO_long_responses_2017 ON APPRENTICE_COHORT_INFO.KEY = APPSO_long_responses_2017.KEY
 WHERE (((APPRENTICE_COHORT_INFO.SUBM_CD)='C_Outc17') AND ((APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=-1 Or (APPSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE)=9) AND ((APPRENTICE_COHORT_INFO.RESPONDENT)='1'));"
@@ -116,13 +116,13 @@ UNION ALL
 SELECT BGS_Y19_USO_V.STQU_ID, BGS_Y19_USO_V.NEW_POST, BGS_Y19_USO_V.NEW_POSTAL, 2019 AS SURVEY_YEAR
 FROM BGS_Y19_USO_V"
 
-qry_BGS_00_Region_Codes <- 
-"SELECT BGS_DIST_13_17.REGION_CD, BGS_DIST_13_17.CURRENT_REGION, BGS_DIST_13_17.CURRENT_REGION_NAME, BGS_DIST_13_17.CUR_RES, BGS_DIST_13_17.CUR_RES_NAME
+qry_BGS_00_Region_Codes <-
+  "SELECT BGS_DIST_13_17.REGION_CD, BGS_DIST_13_17.CURRENT_REGION, BGS_DIST_13_17.CURRENT_REGION_NAME, BGS_DIST_13_17.CUR_RES, BGS_DIST_13_17.CUR_RES_NAME
 FROM BGS_DIST_13_17
 GROUP BY BGS_DIST_13_17.REGION_CD, BGS_DIST_13_17.CURRENT_REGION, BGS_DIST_13_17.CURRENT_REGION_NAME, BGS_DIST_13_17.CUR_RES, BGS_DIST_13_17.CUR_RES_NAME"
 
-qry_BGS_results <- 
-"TRANSFORM Count(*) AS Expr1
+qry_BGS_results <-
+  "TRANSFORM Count(*) AS Expr1
 SELECT T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code, T_Current_Region_PSSM_Codes.Current_Region_PSSM_Name
 FROM T_Current_Region_PSSM_Codes INNER JOIN BGS_Current_Region_Data ON T_Current_Region_PSSM_Codes.Current_Region_PSSM_Code = BGS_Current_Region_Data.[CURRENT_REGION_PSSM_CODE]
 WHERE (((BGS_Current_Region_Data.srv_y_n)=1))
@@ -141,39 +141,39 @@ FROM (
 PIVOT (Count([stqu_id]) FOR survey_year IN ([2014], [2015], [2016], [2017], [2018], [2019])) AS PVT
 ORDER BY cast(current_region_pssm_code AS INT)"
 
-qry_BGS_update_Current_Region_PSSM_step0 <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step0 <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = Null
 WHERE (((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
 
-qry_BGS_update_Current_Region_PSSM_step1 <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step1 <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = [BGS_Current_Region_Data].REGION_CD
 WHERE (((BGS_Current_Region_Data.REGION_CD)>=1 
 And (BGS_Current_Region_Data.REGION_CD)<=8) 
 AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
 
-qry_BGS_update_Current_Region_PSSM_step2 <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step2 <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 10
 WHERE (((BGS_Current_Region_Data.CURRENT_REGION)=6 Or (BGS_Current_Region_Data.CURRENT_REGION)=9 Or (BGS_Current_Region_Data.CURRENT_REGION)=10) 
 AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
 
-qry_BGS_update_Current_Region_PSSM_step3 <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step3 <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 11
 WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) AND ((BGS_Current_Region_Data.CURRENT_REGION)=7) 
 AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
 
-qry_BGS_update_Current_Region_PSSM_step4 <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step4 <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = 9
 WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) 
 AND ((BGS_Current_Region_Data.CURRENT_REGION)=5) 
 AND ((BGS_Current_Region_Data.survey_year)='2018' Or (BGS_Current_Region_Data.survey_year)='2019'));"
 
-qry_BGS_update_Current_Region_PSSM_step4b <- 
-"UPDATE BGS_Current_Region_Data 
+qry_BGS_update_Current_Region_PSSM_step4b <-
+  "UPDATE BGS_Current_Region_Data 
 SET BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE = -1
 WHERE (((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE) Is Null) 
 AND ((BGS_Current_Region_Data.CURRENT_REGION)=8) 
@@ -197,8 +197,8 @@ SET Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE = [BGS_Current_Regi
 WHERE (((Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE)=-1) AND ((BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE)<>-1));"
 
 # won't always be accurate-not used
-qry_BGS99b_FSA_Recoding <- 
-"UPDATE Unknown_Geocoding_Investigation INNER JOIN T_BGS99_FSA ON Unknown_Geocoding_Investigation.FSA = T_BGS99_FSA.Expr1 SET Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE = [T_BGS99_FSA].[CURRENT_REGION_PSSM_CODE], Unknown_Geocoding_Investigation.FSA_Used = '1'
+qry_BGS99b_FSA_Recoding <-
+  "UPDATE Unknown_Geocoding_Investigation INNER JOIN T_BGS99_FSA ON Unknown_Geocoding_Investigation.FSA = T_BGS99_FSA.Expr1 SET Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE = [T_BGS99_FSA].[CURRENT_REGION_PSSM_CODE], Unknown_Geocoding_Investigation.FSA_Used = '1'
 WHERE (((Unknown_Geocoding_Investigation.CURRENT_REGION_PSSM_CODE)=-1));"
 
 qry_DACSO_Current_Region_Data <- "
@@ -222,7 +222,7 @@ WHERE   dacso_current_region_data.current_region_pssm_code IS NULL
     AND dacso_current_region_data.tpid_current_region1 >= 1
     AND dacso_current_region_data.tpid_current_region1 <= 8
     AND dacso_current_region_data.coci_subm_cd IN ('C_Outc18', 'C_Outc19');"
-    
+
 qry_DACSO_Update_Current_Region_PSSM_step2 <- "
 UPDATE  dacso_current_region_data
 SET     dacso_current_region_data.current_region_pssm_code = 
@@ -248,18 +248,17 @@ PIVOT (Count(COCI_STQU_ID)
 FOR COCI_SUBM_CD IN ( [C_Outc02],[C_Outc03],[C_Outc04],[C_Outc05],[C_Outc06],[C_Outc07],[C_Outc08],[C_Outc09],[C_Outc10],[C_Outc11],[C_Outc12],[C_Outc13],[C_Outc14], [C_Outc15], [C_Outc16], [C_Outc17], [C_Outc18], [C_Outc19])) AS PVT
 ORDER BY cast(current_region_pssm_code AS INT)"
 
-qry98_BGS_PC <- 
-"INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
+qry98_BGS_PC <-
+  "INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
 SELECT Left([POSTAL],3) AS FSA, BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE, BGS_Current_Region_Data.POSTAL
 FROM BGS_Current_Region_Data
 WHERE (((BGS_Current_Region_Data.survey_year)='2014' Or (BGS_Current_Region_Data.survey_year)='2015' Or (BGS_Current_Region_Data.survey_year)='2016' Or (BGS_Current_Region_Data.survey_year)='2017') AND ((BGS_Current_Region_Data.srv_y_n)=1))
 GROUP BY Left([POSTAL],3), BGS_Current_Region_Data.CURRENT_REGION_PSSM_CODE, BGS_Current_Region_Data.POSTAL
 HAVING (((BGS_Current_Region_Data.POSTAL) Like 'V#?*' And (BGS_Current_Region_Data.POSTAL) Not Like 'V0R*'));"
 
-qry98_DACSO_FSA <- 
-"INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
+qry98_DACSO_FSA <-
+  "INSERT INTO T_FSA_Lookup ( FSA, CURRENT_REGION_PSSM_CODE, POSTAL )
 SELECT Left([TPID_ADDRESS_POSTAL_NEW],3) AS Expr1, DACSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE, DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW
 FROM DACSO_Current_Region_Data
 WHERE (((DACSO_Current_Region_Data.COCI_SUBM_CD) In ('C_Outc14','C_Outc15','C_Outc16','C_Outc17')) AND ((DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW) Like 'V#?*' And (DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW) Not Like 'V0R*') AND ((DACSO_Current_Region_Data.COCI_LRST_CD)='000'))
 GROUP BY Left([TPID_ADDRESS_POSTAL_NEW],3), DACSO_Current_Region_Data.CURRENT_REGION_PSSM_CODE, DACSO_Current_Region_Data.TPID_ADDRESS_POSTAL_NEW;"
-

--- a/sql/03-near-completers/near-completers-investigation-ttrain.R
+++ b/sql/03-near-completers/near-completers-investigation-ttrain.R
@@ -1,4 +1,3 @@
-
 #---- qry_make_tmp_table_Age_step2 ----
 qry_make_tmp_table_Age_step2 <- "
 UPDATE tmp_tbl_Age_AppendNewYears 
@@ -52,7 +51,7 @@ INTO T_DACSO_DATA_Part_1_TempSelection
 FROM T_DACSO_DATA_Part_1;"
 
 #---- qry99_Investigate_Near_Completes_vs_Graduates_by_Year ----
-qry99_Investigate_Near_Completes_vs_Graduates_by_Year <- 
+qry99_Investigate_Near_Completes_vs_Graduates_by_Year <-
   "select COSC_GRAD_STATUS_LGDS_CD_Group, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],
 [C_Outc22],[C_Outc23]
 FROM
@@ -69,7 +68,7 @@ PIVOT (
   ) AS PT;"
 
 #---- qry_Find_NearCompleters_in_STP_Credential_Step1 ----
-qry_Find_NearCompleters_in_STP_Credential_Step1 <- 
+qry_Find_NearCompleters_in_STP_Credential_Step1 <-
   "SELECT t_dacso_data_part_1.coci_stqu_id,
        t_dacso_data_part_1.coci_subm_cd,
        t_dacso_data_part_1.age_at_grad,
@@ -131,7 +130,7 @@ WHERE  ( ( ( t_dacso_data_part_1.coci_subm_cd ) = 'C_Outc07'
   AND ( ( dacso_matching_stp_credential_pen.coci_stqu_id ) IS NOT NULL ));"
 
 # ---- qry_Update_STP_Credential_Awarded_Before_DACSO ----
-qry_Update_STP_Credential_Awarded_Before_DACSO <- 
+qry_Update_STP_Credential_Awarded_Before_DACSO <-
   "UPDATE NearCompleters_in_STP_Credential_Step1 
   SET NearCompleters_in_STP_Credential_Step1.STP_Credential_Awarded_Before_DACSO = 'Yes'
 WHERE (((NearCompleters_in_STP_Credential_Step1.coci_subm_cd)='C_Outc07') 
@@ -551,7 +550,7 @@ ON (tmp_MaxAwardYearCleaning.MaxOfPSI_AWARD_SCHOOL_YEAR = tmp_NearCompletersWith
 AND (tmp_MaxAwardYearCleaning.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID);"
 
 # ---- qry_NearCompleters_MultiCdtls_Cleaning_Step8 ----
-qry_NearCompleters_MultiCdtls_Cleaning_Step8 <- 
+qry_NearCompleters_MultiCdtls_Cleaning_Step8 <-
   "SELECT tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID, 
 Max(tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.ID) AS MaxOfID, 
 tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Dup_STQUID_UseThisRecord 
@@ -572,7 +571,7 @@ AND (NearCompleters_in_STP_Credential_Step1.coci_STQU_ID = tmp_NearCompletersWit
 WHERE (((tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.Final_Record_To_Use)='Yes'));"
 
 # ---- qry_NearCompleters_MultiCdtls_Cleaning_Step11 ----
-qry_NearCompleters_MultiCdtls_Cleaning_Step11 <- 
+qry_NearCompleters_MultiCdtls_Cleaning_Step11 <-
   "UPDATE tmp_MaxAwardYear
   SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = 'Yes'
 FROM tmp_MaxAwardYear
@@ -633,8 +632,8 @@ ON (NearCompleters_in_STP_Credential_Step1.ID = tmp_NearCompletersWithMultiCrede
 AND (NearCompleters_in_STP_Credential_Step1.coci_STQU_ID = tmp_NearCompletersWithMultiCredentials_MaxYearCleaning.coci_STQU_ID)"
 
 # ---- qry_NearCompleters_MultiCdtls_Cleaning_Step12 ----
-qry_NearCompleters_MultiCdtls_Cleaning_Step12 <- 
-"UPDATE NearCompleters_in_STP_Credential_Step1 
+qry_NearCompleters_MultiCdtls_Cleaning_Step12 <-
+  "UPDATE NearCompleters_in_STP_Credential_Step1 
 SET NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use = 'Yes'
 WHERE (((NearCompleters_in_STP_Credential_Step1.Final_Record_to_Use) Is Null) 
 AND ((NearCompleters_in_STP_Credential_Step1.Has_Multiple_STP_Credentials) Is Null));"
@@ -672,7 +671,7 @@ WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP)='3')
 AND ((T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential)='Yes'));"
 
 # ---- qry99_Investigate_Near_Completes_vs_Graduates_by_Year  ----
-qry99_Investigate_Near_Completes_vs_Graduates_by_Year <- 
+qry99_Investigate_Near_Completes_vs_Graduates_by_Year <-
   "select COSC_GRAD_STATUS_LGDS_CD_Group, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
 FROM
 (
@@ -730,8 +729,8 @@ PIVOT (
 ) AS PT;"
 
 # ---- qry99_GradStatus_Factoring_in_STP_byCred_by_Year_Age_At_Grad ----
-qry99_GradStatus_Factoring_in_STP_byCred_by_Year_Age_At_Grad <- 
-"select PSSM_Credential,PSSM_Credential_Name,Grad_Status_Factoring_in_STP, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
+qry99_GradStatus_Factoring_in_STP_byCred_by_Year_Age_At_Grad <-
+  "select PSSM_Credential,PSSM_Credential_Name,Grad_Status_Factoring_in_STP, [C_Outc17],[C_Outc18],[C_Outc19],[C_Outc20],[C_Outc21],[C_Outc22],[C_Outc23]
 FROM(
 SELECT T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, 
 T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, 
@@ -753,7 +752,7 @@ PIVOT (
 ) AS PT;"
 
 # ---- qry_details_of_STP_Credential_Matching  ----
-qry_details_of_STP_Credential_Matching <- 
+qry_details_of_STP_Credential_Matching <-
   "SELECT T_DACSO_DATA_Part_1_TempSelection.coci_SUBM_CD, 
 T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group, 
 T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP, Count(*) AS Expr1
@@ -765,7 +764,7 @@ T_DACSO_DATA_Part_1_TempSelection.COSC_GRAD_STATUS_LGDS_CD_Group,
 T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP;"
 
 # ---- qry99_Near_completes_total_by_CIP4  ----
-qry99_Near_completes_total_by_CIP4 <-"
+qry99_Near_completes_total_by_CIP4 <- "
 SELECT     AgeGroupLookup.Age_Group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.LCIP4_CRED, 
                          T_DACSO_DATA_Part_1.LCP4_CD, T_DACSO_DATA_Part_1.LCP4_CIP_4DIGITS_NAME, COUNT(*) AS Count
 INTO NearCompleters_CIP4
@@ -802,7 +801,7 @@ GROUP  BY nearcompleters_cip4.age_group,
 
 # ---- qry99_Near_completes_total_with_STP_Credential_ByCIP4 ----
 qry99_Near_completes_total_with_STP_Credential_ByCIP4 <-
-"SELECT     AgeGroupLookup.age_group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, COUNT(*) AS Count, 
+  "SELECT     AgeGroupLookup.age_group, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, COUNT(*) AS Count, 
                       T_DACSO_DATA_Part_1_TempSelection.Has_STP_Credential, lcip4_cred,
       lcp4_cd,
      lcp4_cip_4digits_name
@@ -844,7 +843,7 @@ nearcompleters_cip4_with_stp_credential.has_stp_credential;"
 
 # ---- qry99_Completers_agg_factoring_in_STP_Credential_by_CIP4 ----
 qry99_Completers_agg_factoring_in_STP_Credential_by_CIP4 <-
-"SELECT agegrouplookup.age_group,
+  "SELECT agegrouplookup.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
        Count(*) AS Expr1,
        t_dacso_data_part_1.lcip4_cred,
@@ -894,7 +893,7 @@ GROUP  BY completersfactoringinstp_cip4.age_group,
 
 # ---- qry99_Completers_agg_by_gender ----
 qry99_Completers_agg_by_gender <-
-"SELECT     T_DACSO_DATA_Part_1.tpid_lgnd_cd, agegrouplookup.age_group, 
+  "SELECT     T_DACSO_DATA_Part_1.tpid_lgnd_cd, agegrouplookup.age_group, 
 T_DACSO_DATA_Part_1.prgm_credential_awarded_name, COUNT(*)
 AS Count
 INTO Completers_agg_by_gender
@@ -946,7 +945,7 @@ agegrouplookup.age_group,
 T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name"
 
 # ---- qry99_Near_completes_total_byGender ----
-qry99_Near_completes_total_byGender_year <-"
+qry99_Near_completes_total_byGender_year <- "
 SELECT t_dacso_data_part_1.coci_subm_cd, 
   t_dacso_data_part_1.tpid_lgnd_cd,
        agegrouplookup.age_group,
@@ -972,7 +971,7 @@ ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
           t_dacso_data_part_1.prgm_credential_awarded_name;"
 
 # ---- qry99_Near_completes_total_with_STP_Credential_by_Gender ----
-qry99_Near_completes_total_with_STP_Credential_by_Gender_year <-"
+qry99_Near_completes_total_with_STP_Credential_by_Gender_year <- "
 SELECT t_dacso_data_part_1.tpid_lgnd_cd,
 t_dacso_data_part_1.coci_subm_cd,
        agegrouplookup.age_group,
@@ -1005,7 +1004,7 @@ ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
 
 # END HISTORICAL ----
 
-# ---- qry99_Completers_agg_byCIP4---- 
+# ---- qry99_Completers_agg_byCIP4----
 qry99_Completers_agg_byCIP4 <- "
 SELECT AgeGroupLookup.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
@@ -1034,7 +1033,7 @@ ORDER  BY AgeGroupLookup.age_group,
 
 
 # ---- qry_Make_Completers_CIP4_CombinedCred ----
-qry_Make_Completers_CIP4_CombinedCred <- 
+qry_Make_Completers_CIP4_CombinedCred <-
   "SELECT completerscip4.age_group,
         combine_creds.combined_cred_name,
         completerscip4.lcip4_cred_cleaned,
@@ -1053,7 +1052,7 @@ GROUP  BY completerscip4.age_group,
         completerscip4.lcp4_cip_4digits_name;"
 
 # ---- qry_NearCompletersByCIP4CombinedCred ----
-qry_NearCompletersByCIP4CombinedCred <- 
+qry_NearCompletersByCIP4CombinedCred <-
   "SELECT NearCompleters_CIP4_CombinedCred.age_group, 
 NearCompleters_CIP4_CombinedCred.Combined_Cred_Name, 
 NearCompleters_CIP4_CombinedCred.LCIP4_CRED, 
@@ -1069,7 +1068,7 @@ NearCompleters_CIP4_CombinedCred.LCP4_CD, NearCompleters_CIP4_CombinedCred.LCP4_
 
 
 # ---- qry99_Near_completes_total_by_Gender ----
-qry99_Near_completes_total_byGender <-"
+qry99_Near_completes_total_byGender <- "
 SELECT t_dacso_data_part_1.tpid_lgnd_cd,
        agegrouplookup.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
@@ -1095,7 +1094,7 @@ ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
           t_dacso_data_part_1.prgm_credential_awarded_name;"
 
 # ---- qry99_Near_completes_total_with_STP_Credential_by_Gender ----
-qry99_Near_completes_total_with_STP_Credential_by_Gender <-"
+qry99_Near_completes_total_with_STP_Credential_by_Gender <- "
 SELECT t_dacso_data_part_1.tpid_lgnd_cd,
        agegrouplookup.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
@@ -1126,7 +1125,7 @@ ORDER  BY t_dacso_data_part_1.tpid_lgnd_cd DESC,
           t_dacso_data_part_1.prgm_credential_awarded_name;"
 
 # ---- qry99_Near_completes_factoring_in_STP_total ----
-qry99_Near_completes_factoring_in_STP_total <-"
+qry99_Near_completes_factoring_in_STP_total <- "
 SELECT agegrouplookup.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
        Count(*) AS Count
@@ -1147,7 +1146,7 @@ ORDER  BY agegrouplookup.age_group,
           t_dacso_data_part_1.prgm_credential_awarded_name;"
 
 # ---- qry99_Completers_agg_factoring_in_STP_Credential ----
-qry99_Completers_agg_factoring_in_STP_Credential <-"
+qry99_Completers_agg_factoring_in_STP_Credential <- "
 SELECT agegrouplookup_1.age_group,
        t_dacso_data_part_1.prgm_credential_awarded_name,
        Count(*) AS Expr1
@@ -1170,7 +1169,6 @@ GROUP  BY agegrouplookup_1.age_group,
           agegrouplookup_1.age_group
 ORDER  BY agegrouplookup_1.age_group,
           t_dacso_data_part_1.prgm_credential_awarded_name;"
-
 
 
 # ---- qry99_Near_completes_total_by_CIP4_TTRAIN ----
@@ -1240,8 +1238,8 @@ ORDER  BY agegrouplookup.age_group,
           t_dacso_data_part_1.prgm_credential_awarded_name"
 
 # ---- qry99_Near_completes_program_dist_count ----
-qry99_Near_completes_program_dist_count <- 
-"SELECT t_pssm_projection_cred_grp.pssm_credential,
+qry99_Near_completes_program_dist_count <-
+  "SELECT t_pssm_projection_cred_grp.pssm_credential,
        cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' +
        t_pssm_projection_cred_grp.pssm_credential AS PSSM_CRED,
        near_completes_total_by_cip4_ttrain.age_group,
@@ -1346,7 +1344,7 @@ ORDER  BY agegrouplookup.age_group,
           t_dacso_data_part_1.prgm_credential_awarded_name"
 
 # ---- qry99_Near_completes_program_dist_count ----
-qry99_Near_completes_program_dist_count_history <- 
+qry99_Near_completes_program_dist_count_history <-
   "SELECT t_pssm_projection_cred_grp.pssm_credential,
        cast(near_completes_total_by_cip4_ttrain.cosc_grad_status_lgds_cd_group as nvarchar(50)) + ' - ' +
        t_pssm_projection_cred_grp.pssm_credential AS PSSM_CRED,
@@ -1391,12 +1389,11 @@ GROUP  BY near_completes_total_by_cip4_ttrain.age_group,
 
 # ----  NOT USED ----
 # ---- qry_Number_of_NearCompleters_With_STP_Credential_by_Year ----
-qry_Number_of_NearCompleters_With_STP_Credential_by_Year <- 
-"SELECT T_DACSO_NearCompleters.coci_SUBM_CD, Count(*) AS Expr1
+qry_Number_of_NearCompleters_With_STP_Credential_by_Year <-
+  "SELECT T_DACSO_NearCompleters.coci_SUBM_CD, Count(*) AS Expr1
 FROM T_DACSO_NearCompleters
 WHERE (((T_DACSO_NearCompleters.STP_Credential_Awarded_Before_DACSO)='Yes')) OR (((T_DACSO_NearCompleters.STP_Credential_Awarded_After_DACSO)='Yes'))
 GROUP BY T_DACSO_NearCompleters.coci_SUBM_CD;"
-
 
 
 # ---- qry_make_tmp_table_GradStat_step1 ----
@@ -1407,8 +1404,8 @@ FROM INFOWARE_CO_COHORT_SAMPLE_2016 INNER JOIN INFOWARE_SURV_COHORT_COLLECTION_I
 WHERE (((INFOWARE_SURV_COHORT_COLLECTION_INFO.COCI_SUBM_CD)='C_Outc16'));"
 
 # ---- qry99_GradStatus_byCred_by_Year_Age_At_Survey ----
-qry99_GradStatus_byCred_by_Year_Age_At_Survey <- 
-"TRANSFORM Count(*) AS Expr1
+qry99_GradStatus_byCred_by_Year_Age_At_Survey <-
+  "TRANSFORM Count(*) AS Expr1
 SELECT T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential, T_DACSO_DATA_Part_1_TempSelection.PSSM_Credential_Name, T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP
 FROM (tbl_Age INNER JOIN agegrouplookup ON tbl_Age.Age_Group = agegrouplookup.Age_Group) INNER JOIN (T_DACSO_DATA_Part_1_TempSelection INNER JOIN tmp_tbl_Age ON T_DACSO_DATA_Part_1_TempSelection.coci_STQU_ID = tmp_tbl_Age.COSC_STQU_ID) ON tbl_Age.Age = tmp_tbl_Age.COCI_AGE_AT_SURVEY
 WHERE (((T_DACSO_DATA_Part_1_TempSelection.Grad_Status_Factoring_in_STP) Is Not Null) AND ((tmp_tbl_Age.COCI_AGE_AT_SURVEY)>=17 And (tmp_tbl_Age.COCI_AGE_AT_SURVEY)<=64))
@@ -1418,8 +1415,8 @@ PIVOT T_DACSO_DATA_Part_1_TempSelection.coci_SUBM_CD;"
 
 
 # ---- qry99_Graduates_for_QI ----
-qry99_Graduates_for_QI <- 
-"SELECT T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD, Count(*) AS Expr1
+qry99_Graduates_for_QI <-
+  "SELECT T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD, Count(*) AS Expr1
 FROM T_DACSO_DATA_Part_1
 WHERE (((T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)>=17 And (T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)<=64))
 GROUP BY T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.coci_SUBM_CD
@@ -1428,8 +1425,8 @@ ORDER BY T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD, T_DACSO_DATA_Part_1.PSSM_
 
 
 # ---- qry99_Near_Completes_vs_Graduates_by_Year ----
-qry99_Near_Completes_vs_Graduates_by_Year <- 
-"TRANSFORM Count(*) AS Expr1
+qry99_Near_Completes_vs_Graduates_by_Year <-
+  "TRANSFORM Count(*) AS Expr1
 SELECT agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded, T_DACSO_DATA_Part_1.PRGM_Credential_Awarded_Name, T_DACSO_DATA_Part_1.coci_SUBM_CD
 FROM (T_DACSO_DATA_Part_1 INNER JOIN tbl_Age ON T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY = tbl_Age.Age) INNER JOIN agegrouplookup ON tbl_Age.Age_Group = agegrouplookup.Age_Group
 WHERE (((T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc09' Or (T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc08' Or (T_DACSO_DATA_Part_1.coci_SUBM_CD)='C_Outc10') 
@@ -1438,8 +1435,8 @@ GROUP BY agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PRGM_Credential_Awa
 PIVOT T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD_Group;"
 
 # ---- qry99_Near_Completes_vs_Graduates_by_Year_by_Age ----
-qry99_Near_Completes_vs_Graduates_by_Year_by_Age <- 
-"TRANSFORM Count(*) AS Expr1
+qry99_Near_Completes_vs_Graduates_by_Year_by_Age <-
+  "TRANSFORM Count(*) AS Expr1
 SELECT agegrouplookup.Age_Group_Label, T_DACSO_DATA_Part_1.PSSM_Credential, T_DACSO_DATA_Part_1.PSSM_Credential_Name, T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD
 FROM T_DACSO_DATA_Part_1 INNER JOIN (agegrouplookup INNER JOIN tbl_Age ON agegrouplookup.Age_Group = tbl_Age.Age_Group) ON T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY = tbl_Age.Age
 WHERE (((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD) Is Not Null) AND ((T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)>=17 And (T_DACSO_DATA_Part_1.COCI_AGE_AT_SURVEY)<=64))
@@ -1448,10 +1445,8 @@ ORDER BY agegrouplookup.Age_Group
 PIVOT T_DACSO_DATA_Part_1.coci_SUBM_CD;"
 
 # ---- qry9999_DACSO_Q006_Occ_by_completion ----
-qry9999_DACSO_Q006_Occ_by_completion <- 
-"SELECT 'DACSO' AS Survey, T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD, tbl_NOC_Skill_Level_Aged_17_34.MINOR_GROUP_CODE, T_Year_Survey_Year.Year_Code, Count(T_DACSO_DATA_Part_1.coci_STQU_ID) AS [Count]
+qry9999_DACSO_Q006_Occ_by_completion <-
+  "SELECT 'DACSO' AS Survey, T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD, tbl_NOC_Skill_Level_Aged_17_34.MINOR_GROUP_CODE, T_Year_Survey_Year.Year_Code, Count(T_DACSO_DATA_Part_1.coci_STQU_ID) AS [Count]
 FROM tbl_NOC_Skill_Level_Aged_17_34 INNER JOIN (T_DACSO_DATA_Part_1 INNER JOIN T_Year_Survey_Year ON T_DACSO_DATA_Part_1.coci_SUBM_CD=T_Year_Survey_Year.SUBM_CD) ON tbl_NOC_Skill_Level_Aged_17_34.UNIT_GROUP_CODE=T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD
 WHERE (((T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD) Is Not Null And (T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD)<>'XXXX') AND ((T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD)='1' Or (T_DACSO_DATA_Part_1.COSC_GRAD_STATUS_LGDS_CD)='2') AND ((T_DACSO_DATA_Part_1.Weight)<>0 And (T_DACSO_DATA_Part_1.Weight) Is Not Null))
 GROUP BY 'DACSO', T_DACSO_DATA_Part_1.coci_OCCUPATION_LNOC_CD, tbl_NOC_Skill_Level_Aged_17_34.MINOR_GROUP_CODE, T_Year_Survey_Year.Year_Code;"
-
-

--- a/sql/04-graduate-projections/04-graduate-projections-sql.R
+++ b/sql/04-graduate-projections/04-graduate-projections-sql.R
@@ -1,4 +1,4 @@
-# ---- qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ---- 
+# ---- qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs ----
 qry20a_4Credential_By_Year_Gender_AgeGroup_Domestic_Exclude_RU_DACSO_Exclude_CIPs <- "SELECT        tblCredential_HighestRank.psi_gender_cleaned, AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, 
                          tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY + AgeGroupLookup.AgeGroup + tblCredential_HighestRank.psi_gender_cleaned AS Expr1, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, COUNT(*) 
                          AS Count
@@ -18,7 +18,7 @@ GROUP BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEG
 HAVING        (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP')
 ORDER BY AgeGroupLookup.AgeGroup, tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY, tblCredential_HighestRank.PSI_AWARD_SCHOOL_YEAR_DELAYED, tblCredential_HighestRank.psi_gender_cleaned DESC;"
 
-# ---- qry09c_MinEnrolment ---- 
+# ---- qry09c_MinEnrolment ----
 qry09c_MinEnrolment <- "
 SELECT     MinEnrolment.PSI_GENDER, MinEnrolment.PSI_GENDER + AgeGroupLookup.AgeGroup As Groups, MinEnrolment.PSI_SCHOOL_YEAR, COUNT(*) AS Expr1
 INTO    qry09c_MinEnrolment
@@ -28,4 +28,3 @@ ON  MinEnrolment.AGE_GROUP_ENROL_DATE = AgeGroupLookup.AgeIndex
 GROUP BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR
 HAVING      (MinEnrolment.PSI_SCHOOL_YEAR <> '2023/2024')
 ORDER BY MinEnrolment.PSI_GENDER, AgeGroupLookup.AgeGroup, MinEnrolment.PSI_SCHOOL_YEAR;"
-

--- a/sql/05-ptib-analysis/05-private-training-institutions.R
+++ b/sql/05-ptib-analysis/05-private-training-institutions.R
@@ -3,8 +3,8 @@
 
 ## qry_Private_Credentials_00a_Append ----
 # grab PSSM_Credential and add to PTIB data; drop other and none credential
-qry_Private_Credentials_00a_Append <- 
-"SELECT intYear = T_Private_Institutions_Credentials_Raw.Year, 
+qry_Private_Credentials_00a_Append <-
+  "SELECT intYear = T_Private_Institutions_Credentials_Raw.Year, 
 Credential = T_PSSM_Credential_Grouping.PSSM_Credential, 
 LCIP_CD = T_Private_Institutions_Credentials_Raw.CIP, 
 Age_Group = T_Private_Institutions_Credentials_Raw.Age_Group,
@@ -20,21 +20,21 @@ AND ((T_Private_Institutions_Credentials_Raw.Credential)<>'None'))"
 
 ## qry_Private_Credentials_00b_Check_CIP_Length ----
 # Check that all CIPs are 7 digits
-qry_Private_Credentials_00b_Check_CIP_Length <- 
+qry_Private_Credentials_00b_Check_CIP_Length <-
   "SELECT T_Private_Institutions_Credentials.LCIP_CD, Len([LCIP_CD]) AS Expr1
 FROM T_Private_Institutions_Credentials
 WHERE (((Len([LCIP_CD]))<>7))"
 
 ## qry_Private_Credentials_00c_Clean_CIP_Period ----
 # remove periods from LCIP_CD
-qry_Private_Credentials_00c_Clean_CIP_Period <- 
-"UPDATE T_Private_Institutions_Credentials 
+qry_Private_Credentials_00c_Clean_CIP_Period <-
+  "UPDATE T_Private_Institutions_Credentials 
 SET T_Private_Institutions_Credentials.LCIP_CD = Replace([LCIP_CD],'.','')"
 
 ## qry_Private_Credentials_00d_Check_CIPs ----
 # Check CIPs valid; compared to the Infoware table
-qry_Private_Credentials_00d_Check_CIPs <- 
-"SELECT T_Private_Institutions_Credentials.LCIP_CD, 
+qry_Private_Credentials_00d_Check_CIPs <-
+  "SELECT T_Private_Institutions_Credentials.LCIP_CD, 
 INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD
 FROM INFOWARE_L_CIP_6DIGITS_CIP2016 RIGHT JOIN T_Private_Institutions_Credentials 
 ON INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD = T_Private_Institutions_Credentials.LCIP_CD
@@ -42,14 +42,14 @@ WHERE (((INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_CD) Is Null));"
 
 ## qry_Private_Credentials_00f_Recode_Age_Group ----
 ## recode dashes in age group
-qry_Private_Credentials_00f_Recode_Age_Group <- 
-"UPDATE T_Private_Institutions_Credentials 
+qry_Private_Credentials_00f_Recode_Age_Group <-
+  "UPDATE T_Private_Institutions_Credentials 
 SET T_Private_Institutions_Credentials.Age_Group = Replace([Age_Group],'-',' to ');"
 
 ## qry_Private_Credentials_00g_Avg ----
 ## Get averages of enrolments/graduates by credential/LCIP_CD/Age/Immigration by # years; remove excluded
-qry_Private_Credentials_00g_Avg <- 
-"INSERT INTO T_Private_Institutions_Credentials ( intYear, Credential, LCIP_CD, Age_Group, Immigration_Status, Enrolment, Enrolled_Not_Graduated, Graduates, Exclude )
+qry_Private_Credentials_00g_Avg <-
+  "INSERT INTO T_Private_Institutions_Credentials ( intYear, Credential, LCIP_CD, Age_Group, Immigration_Status, Enrolment, Enrolled_Not_Graduated, Graduates, Exclude )
 SELECT 'Avg 2021 & 2022' AS intYear, 
 T_Private_Institutions_Credentials_Clean.Credential, 
 T_Private_Institutions_Credentials_Clean.LCIP_CD, 
@@ -72,7 +72,7 @@ HAVING (((T_Private_Institutions_Credentials_Clean.Exclude) Is Null));"
 ## qry_Private_Credentials_01a_Domestic ----
 # count domestic grads for each combination of age group, CIP and Credential
 qry_Private_Credentials_01a_Domestic <-
-"SELECT '2023/2024' AS [Year],
+  "SELECT '2023/2024' AS [Year],
 T_Private_Institutions_Credentials.Credential,
 T_Private_Institutions_Credentials.LCIP_CD,
 T_Private_Institutions_Credentials.Age_Group,
@@ -90,7 +90,7 @@ Or (T_Private_Institutions_Credentials.Credential)='DIPL'));"
 ## qry_Private_Credentials_01b_Domestic_International ----
 # count domenstic and international grads for each combination of age group, CIP and Credential
 qry_Private_Credentials_01b_Domestic_International <-
-"SELECT '2023/2024' AS [Year],
+  "SELECT '2023/2024' AS [Year],
 T_Private_Institutions_Credentials.Credential,
 T_Private_Institutions_Credentials.LCIP_CD,
 T_Private_Institutions_Credentials.Age_Group,
@@ -109,8 +109,8 @@ Or (T_Private_Institutions_Credentials.Credential)='DIPL'));"
 
 ## qry_Private_Credentials_01c_Percent_Domestic ----
 # Compute percent of domestic and international grads that are domestic
-qry_Private_Credentials_01c_Percent_Domestic <- 
-"SELECT qry_Private_Credentials_01a_Domestic.Year, 
+qry_Private_Credentials_01c_Percent_Domestic <-
+  "SELECT qry_Private_Credentials_01a_Domestic.Year, 
 qry_Private_Credentials_01a_Domestic.Credential, 
 qry_Private_Credentials_01a_Domestic.LCIP_CD, 
 qry_Private_Credentials_01a_Domestic.Age_Group, 
@@ -125,8 +125,8 @@ AND (qry_Private_Credentials_01a_Domestic.Credential = qry_Private_Credentials_0
 AND (qry_Private_Credentials_01a_Domestic.Year = qry_Private_Credentials_01b_Domestic_International.Year);"
 
 ## qry_Private_Credentials_01d_Grads_Blank ----
-qry_Private_Credentials_01d_Grads_Blank <- 
-"SELECT [qry_Private_Credentials_01c_Percent_Domestic].Year, 
+qry_Private_Credentials_01d_Grads_Blank <-
+  "SELECT [qry_Private_Credentials_01c_Percent_Domestic].Year, 
 T_Private_Institutions_Credentials.Credential, 
 T_Private_Institutions_Credentials.LCIP_CD, 
 T_Private_Institutions_Credentials.Age_Group, 
@@ -173,7 +173,7 @@ qry_Private_Credentials_01e_Grads_Union.Age_Group;"
 
 ## qry_Private_Credentials_05i_Grads ----
 # Summarize the Grads by Credential/Age
-qry_Private_Credentials_05i_Grads <- 
+qry_Private_Credentials_05i_Grads <-
   "SELECT qry_Private_Credentials_01f_Grads.Year, 
 qry_Private_Credentials_01f_Grads.Credential, 
 qry_Private_Credentials_01f_Grads.Age_Group, 
@@ -186,7 +186,7 @@ qry_Private_Credentials_01f_Grads.Age_Group;"
 
 ## qry_Private_Credentials_05i1_Grads_by_Year ----
 # add Grads for all years to new table for import into Graduate_Projections later
-qry_Private_Credentials_05i1_Grads_by_Year <- 
+qry_Private_Credentials_05i1_Grads_by_Year <-
   "SELECT 'PTIB' AS Survey, 
 'P - ' + [Credential] AS PSSM_CRED, 
 qry_Private_Credentials_05i_Grads.Age_Group, 
@@ -198,7 +198,7 @@ ON qry_Private_Credentials_05i_Grads.Year = T_PTIB_Y1_to_Y10.Y1;"
 
 ## qry_Private_Credentials_05i2_Delete_AgeGrps ----
 # remove excess age groups
-qry_Private_Credentials_05i2_Delete_AgeGrps <- 
+qry_Private_Credentials_05i2_Delete_AgeGrps <-
   "DELETE FROM qry_Private_Credentials_05i1_Grads_by_Year
 WHERE (((qry_Private_Credentials_05i1_Grads_by_Year.Survey)='PTIB') AND
 ((qry_Private_Credentials_05i1_Grads_by_Year.Age_Group)='(blank)') OR
@@ -211,7 +211,7 @@ WHERE (((qry_Private_Credentials_05i1_Grads_by_Year.Survey)='PTIB') AND
 # Part 3 ----
 ## qry_Private_Credentials_06b_Cohort_Dist ----
 # count grads by CIP
-qry_Private_Credentials_06b_Cohort_Dist <- 
+qry_Private_Credentials_06b_Cohort_Dist <-
   "SELECT qry_Private_Credentials_01f_Grads.Year, 
 qry_Private_Credentials_01f_Grads.Credential, 
 'P - ' + [Credential] AS PSSM_CRED, 
@@ -231,7 +231,7 @@ qry_Private_Credentials_01f_Grads.Age_Group;"
 
 ## qry_Private_Credentials_06c_Cohort_Dist_Total ----
 # sum totals by age group
-qry_Private_Credentials_06c_Cohort_Dist_Total <- 
+qry_Private_Credentials_06c_Cohort_Dist_Total <-
   "SELECT qry_Private_Credentials_06b_Cohort_Dist.Year, 
 qry_Private_Credentials_06b_Cohort_Dist.Credential, 
 qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED, 
@@ -245,18 +245,18 @@ qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED,
 qry_Private_Credentials_06b_Cohort_Dist.Age_Group;"
 
 ## qry_Private_Credentials_06d0_Cohort_Dist_Delete_Projected ----
-qry_Private_Credentials_06d0_Cohort_Dist_Delete_Projected <- 
+qry_Private_Credentials_06d0_Cohort_Dist_Delete_Projected <-
   "DELETE FROM Cohort_Program_Distributions_Projected
 WHERE (((Cohort_Program_Distributions_Projected.Survey)='PTIB'));"
 
 ## qry_Private_Credentials_06d0_Cohort_Dist_Delete_Static ----
-qry_Private_Credentials_06d0_Cohort_Dist_Delete_Static <- 
+qry_Private_Credentials_06d0_Cohort_Dist_Delete_Static <-
   "DELETE FROM Cohort_Program_Distributions_Static
 WHERE (((Cohort_Program_Distributions_Static.Survey)='PTIB'));"
 
 ## qry_Private_Credentials_06d1_Cohort_Dist ----
-qry_Private_Credentials_06d1_Cohort_Dist <- 
-"SELECT 'PTIB' AS Survey, 
+qry_Private_Credentials_06d1_Cohort_Dist <-
+  "SELECT 'PTIB' AS Survey, 
 qry_Private_Credentials_06b_Cohort_Dist.Credential, 
 qry_Private_Credentials_06b_Cohort_Dist.PSSM_CRED, 
 qry_Private_Credentials_06b_Cohort_Dist.LCP4_CD, 
@@ -275,13 +275,12 @@ AND (qry_Private_Credentials_06c_Cohort_Dist_Total.Age_Group = qry_Private_Crede
 
 ## qry_Private_Credentials_06d2_Delete_AgeGrps ----
 # remove excess age groups
-qry_Private_Credentials_06d2_Delete_AgeGrps <- 
+qry_Private_Credentials_06d2_Delete_AgeGrps <-
   "DELETE FROM qry_Private_Credentials_06d1_Cohort_Dist
 WHERE (((qry_Private_Credentials_06d1_Cohort_Dist.Survey)='PTIB') AND
 ((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='(blank)') OR
 ((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='Unknown') OR
 ((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='65+') OR
 ((qry_Private_Credentials_06d1_Cohort_Dist.Age_Group)='16 or less'))"
-
 
 # ******************************************************************************

--- a/sql/06-program-projections/06-program-projections.R
+++ b/sql/06-program-projections/06-program-projections.R
@@ -36,18 +36,18 @@ GROUP BY A.AgeGroup,
         Credential_Non_Dup.FINAL_CIP_CODE_4 
 HAVING  (tblCredential_HighestRank.PSI_CREDENTIAL_CATEGORY <> 'APPRENTICESHIP');"
 
-# ---- Q012a_Check_Total_for_Invalid_CIPs ---- 
-Q012a_Check_Total_for_Invalid_CIPs <- 
-"SELECT tbl_Program_Projection_Input.FINAL_CIP_CODE_4, 
+# ---- Q012a_Check_Total_for_Invalid_CIPs ----
+Q012a_Check_Total_for_Invalid_CIPs <-
+  "SELECT tbl_Program_Projection_Input.FINAL_CIP_CODE_4, 
         tbl_Program_Projection_Input.Count
 FROM    tbl_Program_Projection_Input INNER JOIN INFOWARE_L_CIP_4DIGITS_CIP2016 
 ON      tbl_Program_Projection_Input.FINAL_CIP_CODE_4 = INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD
 WHERE   (((INFOWARE_L_CIP_4DIGITS_CIP2016.LCP4_CD) Is Null))
 GROUP BY tbl_Program_Projection_Input.FINAL_CIP_CODE_4, tbl_Program_Projection_Input.Count;"
 
-# ---- Q012b_Weight_Cohort_Dist ---- 
-Q012b_Weight_Cohort_Dist <- 
-"SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+# ---- Q012b_Weight_Cohort_Dist ----
+Q012b_Weight_Cohort_Dist <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
         CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
         tbl_Program_Projection_Input.FINAL_CIP_CODE_4 AS LCP4_CD, T_PSSM_Projection_Cred_Grp.COSC_GRAD_STATUS_LGDS_CD, 
         CONCAT(CASE WHEN COSC_GRAD_STATUS_LGDS_CD IS Null THEN NULL ELSE cast(COSC_GRAD_STATUS_LGDS_CD as nvarchar(50)) + ' - ' END, [FINAL_CIP_CODE_4], ' - ', [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS LCIP4_CRED, 
@@ -73,9 +73,9 @@ GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential,
         T_Weights_STP.Weight
 HAVING (((T_Weights_STP.Weight)>0));"
 
-# ---- Q012c_Weighted_Cohort_Dist ---- 
-Q012c_Weighted_Cohort_Dist <- 
-"SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+# ---- Q012c_Weighted_Cohort_Dist ----
+Q012c_Weighted_Cohort_Dist <-
+  "SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
       Q012b_Weight_Cohort_Dist.PSSM_CRED, 
       Q012b_Weight_Cohort_Dist.LCP4_CD, 
       Q012b_Weight_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD, 
@@ -93,9 +93,9 @@ GROUP BY Q012b_Weight_Cohort_Dist.PSSM_Credential,
       Q012b_Weight_Cohort_Dist.LCIP2_CRED, 
       Q012b_Weight_Cohort_Dist.AgeGroup;"
 
-# ---- Q012c1_Weighted_Cohort_Dist_TTRAIN ---- 
-Q012c1_Weighted_Cohort_Dist_TTRAIN <- 
-"SELECT T_Cohorts_Recoded.PSSM_Credential, 
+# ---- Q012c1_Weighted_Cohort_Dist_TTRAIN ----
+Q012c1_Weighted_Cohort_Dist_TTRAIN <-
+  "SELECT T_Cohorts_Recoded.PSSM_Credential, 
         T_Cohorts_Recoded.PSSM_Credential AS PSSM_CRED, 
         T_Cohorts_Recoded.LCP4_CD, 
         T_Cohorts_Recoded.GRAD_STATUS, 
@@ -117,9 +117,9 @@ GROUP BY T_Cohorts_Recoded.PSSM_Credential, T_Cohorts_Recoded.LCP4_CD,
 HAVING (((T_Cohorts_Recoded.TTRAIN) Is Not Null) 
 AND ((T_Cohorts_Recoded.Weight)>0));"
 
-# ---- Q012c2_Weighted_Cohort_Dist ---- 
-Q012c2_Weighted_Cohort_Dist <- 
-"SELECT Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential, 
+# ---- Q012c2_Weighted_Cohort_Dist ----
+Q012c2_Weighted_Cohort_Dist <-
+  "SELECT Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential, 
          Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED, 
          Q012c1_Weighted_Cohort_Dist_TTRAIN.LCP4_CD, 
          Q012c1_Weighted_Cohort_Dist_TTRAIN.GRAD_STATUS, 
@@ -139,9 +139,9 @@ GROUP BY Q012c1_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential,
          Q012c1_Weighted_Cohort_Dist_TTRAIN.LCIP2_CRED, 
          Q012c1_Weighted_Cohort_Dist_TTRAIN.Age_Group;"
 
-# ---- Q012c3_Weighted_Cohort_Dist_Total ---- 
-Q012c3_Weighted_Cohort_Dist_Total <- 
-"SELECT Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
+# ---- Q012c3_Weighted_Cohort_Dist_Total ----
+Q012c3_Weighted_Cohort_Dist_Total <-
+  "SELECT Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
         Q012c2_Weighted_Cohort_Dist.PSSM_CRED, 
         Q012c2_Weighted_Cohort_Dist.LCP4_CD, 
         Q012c2_Weighted_Cohort_Dist.GRAD_STATUS, 
@@ -155,9 +155,9 @@ GROUP BY Q012c2_Weighted_Cohort_Dist.PSSM_Credential,
         Q012c2_Weighted_Cohort_Dist.GRAD_STATUS, 
         Q012c2_Weighted_Cohort_Dist.Age_Group;"
 
-# ---- Q012c4_Weighted_Cohort_Distribution_Projected ---- 
-Q012c4_Weighted_Cohort_Distribution_Projected <- 
-"SELECT 'Program_Projections_2023-2024_Q015e' AS Survey, 
+# ---- Q012c4_Weighted_Cohort_Distribution_Projected ----
+Q012c4_Weighted_Cohort_Distribution_Projected <-
+  "SELECT 'Program_Projections_2023-2024_Q015e' AS Survey, 
         Q012c2_Weighted_Cohort_Dist.PSSM_Credential, 
         Q012c2_Weighted_Cohort_Dist.PSSM_CRED, 
         Q012c2_Weighted_Cohort_Dist.LCP4_CD, 
@@ -177,8 +177,8 @@ INNER JOIN Q012c3_Weighted_Cohort_Dist_Total
   AND   (Q012c2_Weighted_Cohort_Dist.LCP4_CD = Q012c3_Weighted_Cohort_Dist_Total.LCP4_CD);"
 
 # ---- Q012c5_Weighted_Cohort_Dist_TTRAIN ----
-Q012c5_Weighted_Cohort_Dist_TTRAIN <- 
-"SELECT Q012c_Weighted_Cohort_Dist.PSSM_Credential, 
+Q012c5_Weighted_Cohort_Dist_TTRAIN <-
+  "SELECT Q012c_Weighted_Cohort_Dist.PSSM_Credential, 
         Q012c_Weighted_Cohort_Dist.PSSM_CRED, 
         Q012c_Weighted_Cohort_Dist.LCP4_CD, 
         Q012c_Weighted_Cohort_Dist.COSC_GRAD_STATUS_LGDS_CD, 
@@ -205,9 +205,9 @@ LEFT JOIN Q012c4_Weighted_Cohort_Distribution_Projected
   AND   (Q012c_Weighted_Cohort_Dist.LCP4_CD = Q012c4_Weighted_Cohort_Distribution_Projected.LCP4_CD) 
   AND   (Q012c_Weighted_Cohort_Dist.PSSM_Credential = Q012c4_Weighted_Cohort_Distribution_Projected.PSSM_Credential);"
 
-# ---- Q012d_Weighted_Cohort_Dist_Total ---- 
-Q012d_Weighted_Cohort_Dist_Total <- 
-"SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
+# ---- Q012d_Weighted_Cohort_Dist_Total ----
+Q012d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q012b_Weight_Cohort_Dist.PSSM_Credential, 
         Q012b_Weight_Cohort_Dist.PSSM_CRED, 
         Q012b_Weight_Cohort_Dist.AgeGroup, 
         Sum(Q012b_Weight_Cohort_Dist.Weighted) AS Totals
@@ -217,15 +217,15 @@ GROUP BY Q012b_Weight_Cohort_Dist.PSSM_Credential,
         Q012b_Weight_Cohort_Dist.PSSM_CRED, 
         Q012b_Weight_Cohort_Dist.AgeGroup;"
 
-# ---- Q012e_Delete_Weighted_Cohort_Distribution ---- 
-Q012e_Delete_Weighted_Cohort_Distribution <- 
-"DELETE 
+# ---- Q012e_Delete_Weighted_Cohort_Distribution ----
+Q012e_Delete_Weighted_Cohort_Distribution <-
+  "DELETE 
 FROM Cohort_Program_Distributions_Static
 WHERE (((Cohort_Program_Distributions_Static.Survey) Like '%Q012e'));"
 
-# ---- Q012e_Weighted_Cohort_Distribution ---- 
-Q012e_Weighted_Cohort_Distribution <- 
-"INSERT INTO Cohort_Program_Distributions_Static 
+# ---- Q012e_Weighted_Cohort_Distribution ----
+Q012e_Weighted_Cohort_Distribution <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_Q012e' AS Survey, 
 Q012c5_Weighted_Cohort_Dist_TTRAIN.PSSM_Credential,
@@ -245,9 +245,9 @@ INNER JOIN Q012d_Weighted_Cohort_Dist_Total
   ON    (Q012c5_Weighted_Cohort_Dist_TTRAIN.AgeGroup = Q012d_Weighted_Cohort_Dist_Total.AgeGroup) 
   AND   (Q012c5_Weighted_Cohort_Dist_TTRAIN.PSSM_CRED = Q012d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
 
-# ---- Q013a_Check_PDEG_CLP_07_Only_CIP_22 ---- 
-Q013a_Check_PDEG_CLP_07_Only_CIP_22 <- 
-"SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+# ---- Q013a_Check_PDEG_CLP_07_Only_CIP_22 ----
+Q013a_Check_PDEG_CLP_07_Only_CIP_22 <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
         CONCAT
         (CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
         tbl_Program_Projection_Input.FINAL_CIP_CODE_4, qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD AS LCIPPC_CD, 
@@ -275,9 +275,9 @@ GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential,
 		tbl_Program_Projection_Input.AgeGroup, T_Weights_STP.Weight
 HAVING (((T_Weights_STP.Weight)>0));"
 
-# ---- Q013b_Weight_Cohort_Dist_MAST_DOCT_Others ---- 
-Q013b_Weight_Cohort_Dist_MAST_DOCT_Others <- 
-"SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+# ---- Q013b_Weight_Cohort_Dist_MAST_DOCT_Others ----
+Q013b_Weight_Cohort_Dist_MAST_DOCT_Others <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
 		    CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [PSSM_Credential]) AS PSSM_CRED, 
         qry_12_LCP4_LCIPPC_Recode_9999.LCIP_LCIPPC_CD AS LCIPPC_CD, 
         CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [LCIP_LCIPPC_CD], ' - ',
@@ -304,9 +304,9 @@ GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential,
       tbl_Program_Projection_Input.AgeGroup, T_Weights_STP.Weight
 HAVING (((T_Weights_STP.Weight)>0));"
 
-# ---- Q013c_Weighted_Cohort_Dist ---- 
-Q013c_Weighted_Cohort_Dist <- 
-"SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+# ---- Q013c_Weighted_Cohort_Dist ----
+Q013c_Weighted_Cohort_Dist <-
+  "SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED,
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CD, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CRED, 
@@ -320,9 +320,9 @@ GROUP BY Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential,
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.LCIPPC_CRED, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup;"
 
-# ---- Q013d_Weighted_Cohort_Dist_Total ---- 
-Q013d_Weighted_Cohort_Dist_Total <- 
-"SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
+# ---- Q013d_Weighted_Cohort_Dist_Total ----
+Q013d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup, 
         Sum(Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.Weighted) AS Totals
@@ -332,7 +332,7 @@ GROUP BY Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_Credential,
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.PSSM_CRED, 
         Q013b_Weight_Cohort_Dist_MAST_DOCT_Others.AgeGroup;"
 
-# ---- Q013e_Weighted_Cohort_Distribution ---- 
+# ---- Q013e_Weighted_Cohort_Distribution ----
 Q013e_Weighted_Cohort_Distribution <- "
 INSERT INTO Cohort_Program_Distributions_Static (Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Age_Group, [Year], [Count], [Total], [Percent] )
 SELECT 'Program_Projections_2023-2024_Q013e' AS Survey, 
@@ -350,9 +350,9 @@ INNER JOIN Q013d_Weighted_Cohort_Dist_Total
   ON    (Q013c_Weighted_Cohort_Dist.AgeGroup = Q013d_Weighted_Cohort_Dist_Total.AgeGroup) 
   AND   (Q013c_Weighted_Cohort_Dist.PSSM_CRED = Q013d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
 
-# ---- Q014b_Weighted_Cohort_Dist_APPR ---- 
-Q014b_Weighted_Cohort_Dist_APPR <- 
-"SELECT T_Cohorts_Recoded.PSSM_Credential, 
+# ---- Q014b_Weighted_Cohort_Dist_APPR ----
+Q014b_Weighted_Cohort_Dist_APPR <-
+  "SELECT T_Cohorts_Recoded.PSSM_Credential, 
         T_Cohorts_Recoded.PSSM_Credential AS PSSM_CRED, 
         T_Cohorts_Recoded.LCP4_CD, 
         T_Cohorts_Recoded.TTRAIN, 
@@ -376,8 +376,8 @@ GROUP BY T_Cohorts_Recoded.PSSM_Credential,
 HAVING (((T_Cohorts_Recoded.Weight)>0));"
 
 # ---- Q014c_Weighted_Cohort_Dist ----
-Q014c_Weighted_Cohort_Dist <- 
-"SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+Q014c_Weighted_Cohort_Dist <-
+  "SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
         Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
         Q014b_Weighted_Cohort_Dist_APPR.LCP4_CD, 
         Q014b_Weighted_Cohort_Dist_APPR.LCIP4_CRED, 
@@ -393,9 +393,9 @@ GROUP BY Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential,
         Q014b_Weighted_Cohort_Dist_APPR.LCIP2_CRED, 
         Q014b_Weighted_Cohort_Dist_APPR.Age_Group;"
 
-# ---- Q014d_Weighted_Cohort_Dist_Total ---- 
-Q014d_Weighted_Cohort_Dist_Total <- 
-"SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
+# ---- Q014d_Weighted_Cohort_Dist_Total ----
+Q014d_Weighted_Cohort_Dist_Total <-
+  "SELECT Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential, 
         Q014b_Weighted_Cohort_Dist_APPR.PSSM_CRED, 
         Q014b_Weighted_Cohort_Dist_APPR.Age_Group, 
         Sum(Q014b_Weighted_Cohort_Dist_APPR.Weighted) AS Totals
@@ -406,8 +406,8 @@ GROUP BY Q014b_Weighted_Cohort_Dist_APPR.PSSM_Credential,
         Q014b_Weighted_Cohort_Dist_APPR.Age_Group;"
 
 # Q014e_Weighted_Cohort_Distribution_Projected ----
-Q014e_Weighted_Cohort_Distribution_Projected <- 
-"INSERT INTO Cohort_Program_Distributions_Projected 
+Q014e_Weighted_Cohort_Distribution_Projected <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_Q014e' AS Survey, 
         Q014c_Weighted_Cohort_Dist.PSSM_Credential, 
@@ -425,8 +425,8 @@ INNER JOIN Q014d_Weighted_Cohort_Dist_Total
   AND  (Q014c_Weighted_Cohort_Dist.PSSM_CRED = Q014d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
 
 # ---- Q014e_Weighted_Cohort_Distribution_Static ----
-Q014e_Weighted_Cohort_Distribution_Static <- 
-"INSERT INTO Cohort_Program_Distributions_Static 
+Q014e_Weighted_Cohort_Distribution_Static <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_Q014e' AS Survey, 
         Q014c_Weighted_Cohort_Dist.PSSM_Credential, 
@@ -442,9 +442,9 @@ INNER JOIN Q014d_Weighted_Cohort_Dist_Total
   ON    (Q014c_Weighted_Cohort_Dist.Age_Group = Q014d_Weighted_Cohort_Dist_Total.Age_Group) 
   AND   (Q014c_Weighted_Cohort_Dist.PSSM_CRED = Q014d_Weighted_Cohort_Dist_Total.PSSM_CRED);"
 
-# ---- Q014f_APPSO_Grads_Y2_to_Y10 ---- 
-Q014f_APPSO_Grads_Y2_to_Y10 <- 
-"INSERT INTO Graduate_Projections ( Survey, PSSM_Credential, PSSM_CRED, Age_Group, [Year], Graduates )
+# ---- Q014f_APPSO_Grads_Y2_to_Y10 ----
+Q014f_APPSO_Grads_Y2_to_Y10 <-
+  "INSERT INTO Graduate_Projections ( Survey, PSSM_Credential, PSSM_CRED, Age_Group, [Year], Graduates )
 SELECT  Graduate_Projections.Survey, 
         Graduate_Projections.PSSM_Credential, 
         Graduate_Projections.PSSM_CRED, 
@@ -455,9 +455,9 @@ FROM    Graduate_Projections INNER JOIN T_APPR_Y2_to_Y10
 ON      Graduate_Projections.Year = T_APPR_Y2_to_Y10.Y1
 WHERE   (((Graduate_Projections.Survey)='APPSO'));"
 
-# ---- Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected ---- 
-Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected <- 
-"INSERT INTO Cohort_Program_Distributions_Projected 
+# ---- Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected ----
+Q015e21_Append_Selected_Static_Distribution_Y2_to_Y12_Projected <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], [Total], [Percent] )
 SELECT 'Program_Projections_2023-2024_Q015e21' AS Survey, 
         Cohort_Program_Distributions_Static.PSSM_Credential, 
@@ -478,9 +478,9 @@ ON      Cohort_Program_Distributions_Static.Year = T_Cohort_Program_Distribution
 WHERE   (((Cohort_Program_Distributions_Static.PSSM_CRED) In ('APPRAPPR','APPRCERT') 
     Or (Cohort_Program_Distributions_Static.PSSM_CRED) Like '3 - %'));"
 
-# ---- Q015e22_Append_Distribution_Y2_to_Y12_Static ---- 
-Q015e22_Append_Distribution_Y2_to_Y12_Static <- 
-"INSERT INTO Cohort_Program_Distributions_Static 
+# ---- Q015e22_Append_Distribution_Y2_to_Y12_Static ----
+Q015e22_Append_Distribution_Y2_to_Y12_Static <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
         SELECT 'Program_Projections_2023-2024_Q015e22' AS Survey, 
         Cohort_Program_Distributions_Static.PSSM_Credential, 
@@ -499,9 +499,9 @@ FROM Cohort_Program_Distributions_Static
 INNER JOIN T_Cohort_Program_Distributions_Y2_to_Y12 
 ON Cohort_Program_Distributions_Static.Year = T_Cohort_Program_Distributions_Y2_to_Y12.Y1;"
 
-# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_1 ---- 
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_1 ----
 qry_05_Flip_T_Predict_CIP_CRED_AGE_1 <-
-"SELECT T_Predict_CIP_CRED_AGE.CIP,
+  "SELECT T_Predict_CIP_CRED_AGE.CIP,
 T_Predict_CIP_CRED_AGE.CRED, 
 T_Predict_CIP_CRED_AGE.AGE, 
 T_Predict_CIP_CRED_AGE.[2023/2024] AS [Count], 
@@ -509,9 +509,9 @@ T_Predict_CIP_CRED_AGE.[2023/2024] AS [Count],
 INTO T_Predict_CIP_CRED_AGE_Flipped
 FROM T_Predict_CIP_CRED_AGE;"
 
-# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2 ---- 
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2 ----
 qry_05_Flip_T_Predict_CIP_CRED_AGE_2 <-
-"INSERT INTO T_Predict_CIP_CRED_AGE_Flipped ( CIP, CRED, AGE, [Year], [Count] )
+  "INSERT INTO T_Predict_CIP_CRED_AGE_Flipped ( CIP, CRED, AGE, [Year], [Count] )
 SELECT T_Predict_CIP_CRED_AGE.CIP, 
 T_Predict_CIP_CRED_AGE.CRED, 
 T_Predict_CIP_CRED_AGE.AGE, 
@@ -519,15 +519,15 @@ T_Predict_CIP_CRED_AGE.AGE,
 T_Predict_CIP_CRED_AGE.[2020/2021]
 FROM T_Predict_CIP_CRED_AGE;"
 
-# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2_Check ---- 
+# ---- qry_05_Flip_T_Predict_CIP_CRED_AGE_2_Check ----
 qry_05_Flip_T_Predict_CIP_CRED_AGE_2_Check <-
-"SELECT T_Predict_CIP_CRED_AGE_Flipped.Year, 
+  "SELECT T_Predict_CIP_CRED_AGE_Flipped.Year, 
 Sum(T_Predict_CIP_CRED_AGE_Flipped.Count) AS SumOfCount
 FROM T_Predict_CIP_CRED_AGE_Flipped
 GROUP BY T_Predict_CIP_CRED_AGE_Flipped.Year;"
 
-# ---- qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected ----  
-qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected <-"
+# ---- qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected ----
+qry_09_Delete_Selected_Static_Cohort_Dist_from_Projected <- "
 DELETE 
 FROM    Cohort_Program_Distributions_Projected
 WHERE   (((Cohort_Program_Distributions_Projected.PSSM_CRED) Not In ('APPRAPPR','APPRCERT') 
@@ -535,8 +535,8 @@ WHERE   (((Cohort_Program_Distributions_Projected.PSSM_CRED) Not In ('APPRAPPR',
   AND   (Cohort_Program_Distributions_Projected.PSSM_CRED) Not Like 'P -%'));"
 
 # ---- qry_10a_Program_Dist_Count ----
-qry_10a_Program_Dist_Count <- 
-"SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
+qry_10a_Program_Dist_Count <-
+  "SELECT T_PSSM_Projection_Cred_Grp.PSSM_Credential, 
         CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [T_PSSM_Projection_Cred_Grp].[PSSM_Credential]) AS PSSM_CRED, 
         T_Predict_CIP_CRED_AGE_Flipped.CIP, 
         CONCAT(CASE WHEN [COSC_GRAD_STATUS_LGDS_CD] IS NULL THEN Null ELSE CAST([COSC_GRAD_STATUS_LGDS_CD] AS NVARCHAR(50)) + ' - ' END, [CIP], ' - ' 
@@ -562,8 +562,8 @@ GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential,
         T_Predict_CIP_CRED_AGE_Flipped.Year;"
 
 # ---- qry_10b_Program_Dist_Total ----
-qry_10b_Program_Dist_Total <- 
-"SELECT qry_10a_Program_Dist_Count.PSSM_Credential, 
+qry_10b_Program_Dist_Total <-
+  "SELECT qry_10a_Program_Dist_Count.PSSM_Credential, 
         qry_10a_Program_Dist_Count.PSSM_CRED, 
         qry_10a_Program_Dist_Count.AGE, 
         qry_10a_Program_Dist_Count.Year, 
@@ -575,9 +575,9 @@ GROUP BY qry_10a_Program_Dist_Count.PSSM_Credential,
         qry_10a_Program_Dist_Count.AGE, 
         qry_10a_Program_Dist_Count.Year;"
 
-# ---- qry_10c_Program_Dist_Distribution ---- 
-qry_10c_Program_Dist_Distribution <- 
-"INSERT INTO Cohort_Program_Distributions_Projected 
+# ---- qry_10c_Program_Dist_Distribution ----
+qry_10c_Program_Dist_Distribution <-
+  "INSERT INTO Cohort_Program_Distributions_Projected 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_qry10c' AS Survey, 
         qry_10a_Program_Dist_Count.PSSM_Credential, 
@@ -597,8 +597,8 @@ INNER JOIN qry_10b_Program_Dist_Total
   AND   (qry_10a_Program_Dist_Count.PSSM_CRED = qry_10b_Program_Dist_Total.PSSM_CRED);"
 
 # ---- qry_12_LCP4_LCIPPC_Recode_9999 ----
-qry_12_LCP4_LCIPPC_Recode_9999 <- 
-"SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD, 
+qry_12_LCP4_LCIPPC_Recode_9999 <-
+  "SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD, 
         IIf([LCIP_LCP4_CD]='9999','99',[INFOWARE_L_CIP_6DIGITS_CIP2016].[LCIP_LCIPPC_CD]) AS LCIP_LCIPPC_CD
 INTO    qry_12_LCP4_LCIPPC_Recode_9999
 FROM    INFOWARE_L_CIP_6DIGITS_CIP2016
@@ -628,7 +628,7 @@ GROUP BY T_PSSM_Projection_Cred_Grp.PSSM_Credential,
 
 # ---- qry_12b_Program_Dist_Total ----
 qry_12b_Program_Dist_Total <-
-"SELECT qry_12a_Program_Dist_Count.PSSM_Credential, 
+  "SELECT qry_12a_Program_Dist_Count.PSSM_Credential, 
         qry_12a_Program_Dist_Count.PSSM_CRED, 
         qry_12a_Program_Dist_Count.Age_Group, 
         qry_12a_Program_Dist_Count.Year, 
@@ -640,9 +640,9 @@ GROUP BY qry_12a_Program_Dist_Count.PSSM_Credential,
          qry_12a_Program_Dist_Count.Age_Group, 
          qry_12a_Program_Dist_Count.Year;"
 
-# ---- qry_12c_Program_Dist_Distribution ---- 
+# ---- qry_12c_Program_Dist_Distribution ----
 qry_12c_Program_Dist_Distribution <-
-"INSERT INTO Cohort_Program_Distributions_Projected 
+  "INSERT INTO Cohort_Program_Distributions_Projected 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_qry12c' AS Survey, 
         qry_12a_Program_Dist_Count.PSSM_Credential, 
@@ -660,9 +660,9 @@ INNER JOIN qry_12b_Program_Dist_Total
   AND   (qry_12a_Program_Dist_Count.Age_Group = qry_12b_Program_Dist_Total.Age_Group) 
   AND   (qry_12a_Program_Dist_Count.Year = qry_12b_Program_Dist_Total.Year);"
 
-# ---- qry_12d_Check_Missing ---- 
-qry_12d_Check_Missing <- 
-"SELECT Cohort_Program_Distributions_Static.PSSM_Credential, 
+# ---- qry_12d_Check_Missing ----
+qry_12d_Check_Missing <-
+  "SELECT Cohort_Program_Distributions_Static.PSSM_Credential, 
         Cohort_Program_Distributions_Static.PSSM_CRED, 
         Cohort_Program_Distributions_Static.LCP4_CD, 
         Cohort_Program_Distributions_Static.LCIP4_CRED, 
@@ -689,21 +689,21 @@ WHERE (((Cohort_Program_Distributions_Static.Age_Group)
       AND ((Cohort_Program_Distributions_Projected.Age_Group) Is Null) 
       AND ((Cohort_Program_Distributions_Projected.Year) Is Null));"
 
-# ---- qry_13a0_Delete_Near_Completers_Projected ---- 
-qry_13a0_Delete_Near_Completers_Projected <- 
-"DELETE 
+# ---- qry_13a0_Delete_Near_Completers_Projected ----
+qry_13a0_Delete_Near_Completers_Projected <-
+  "DELETE 
 FROM Cohort_Program_Distributions_Projected
 WHERE (((Cohort_Program_Distributions_Projected.PSSM_CRED) Like '3 - %'));"
 
-# ---- qry_13a0_Delete_Near_Completers_Static ---- 
-qry_13a0_Delete_Near_Completers_Static <- 
-"DELETE 
+# ---- qry_13a0_Delete_Near_Completers_Static ----
+qry_13a0_Delete_Near_Completers_Static <-
+  "DELETE 
 FROM Cohort_Program_Distributions_Static
 WHERE (((Cohort_Program_Distributions_Static.PSSM_CRED) Like '3 - %'));"
 
-# ---- qry_13a_Near_completers ---- 
-qry_13a_Near_completers <- 
-"SELECT T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_Credential, 
+# ---- qry_13a_Near_completers ----
+qry_13a_Near_completers <-
+  "SELECT T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_Credential, 
         T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_CRED, 
         T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.LCP4_CD, 
         T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.COSC_GRAD_STATUS_LGDS_CD_Group, 
@@ -723,9 +723,9 @@ GROUP BY T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.PSSM_Credential,
         CAST([COSC_GRAD_STATUS_LGDS_CD_Group] as NVARCHAR(50)) + ' - ' + Left([LCP4_CD],2) + ' - ' + CAST([TTRAIN] as NVARCHAR(50)) + ' - ' + [PSSM_Credential], 
         T_DACSO_Near_Completers_RatiosAgeAtGradCIP4_TTRAIN.Age_Group;"
 
-# ---- qry_13b_Near_Completers_Total ---- 
-qry_13b_Near_Completers_Total <- 
-"SELECT qry_13a_Near_completers.PSSM_Credential, 
+# ---- qry_13b_Near_Completers_Total ----
+qry_13b_Near_Completers_Total <-
+  "SELECT qry_13a_Near_completers.PSSM_Credential, 
         qry_13a_Near_completers.PSSM_CRED, 
         qry_13a_Near_completers.AgeGroup, 
         Sum(qry_13a_Near_completers.Count) AS Totals
@@ -735,9 +735,9 @@ GROUP BY qry_13a_Near_completers.PSSM_Credential,
         qry_13a_Near_completers.PSSM_CRED, 
         qry_13a_Near_completers.AgeGroup;"
 
-# ---- qry_13c_Near_Completers_Program_Dist ---- 
-qry_13c_Near_Completers_Program_Dist <- 
-"SELECT qry_13a_Near_completers.PSSM_Credential, 
+# ---- qry_13c_Near_Completers_Program_Dist ----
+qry_13c_Near_Completers_Program_Dist <-
+  "SELECT qry_13a_Near_completers.PSSM_Credential, 
         qry_13a_Near_completers.PSSM_CRED, 
         qry_13a_Near_completers.LCP4_CD, 
         qry_13a_Near_completers.COSC_GRAD_STATUS_LGDS_CD_Group, 
@@ -755,9 +755,9 @@ INNER JOIN qry_13a_Near_completers
   AND   (qry_13b_Near_Completers_Total.PSSM_CRED = qry_13a_Near_completers.PSSM_CRED);"
 
 
-# ---- qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN ---- 
-qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN <- 
-"INSERT INTO  Cohort_Program_Distributions_Projected 
+# ---- qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN ----
+qry_13d_Append_Near_Completers_Program_Dist_Projected_TTRAIN <-
+  "INSERT INTO  Cohort_Program_Distributions_Projected 
         (Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_qry_13d' AS Survey, 
         qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
@@ -775,9 +775,9 @@ INNER JOIN tbl_Age_Groups_Near_Completers
   ON    qry_13c_Near_Completers_Program_Dist.AgeGroup = tbl_Age_Groups_Near_Completers.Age_Group_Label_Near_Completer_Projection;"
 
 
-# ---- qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN ---- 
-qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN <- 
-"INSERT INTO Cohort_Program_Distributions_Static 
+# ---- qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN ----
+qry_13d_Append_Near_Completers_Program_Dist_Static_TTRAIN <-
+  "INSERT INTO Cohort_Program_Distributions_Static 
         ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, GRAD_STATUS, TTRAIN, LCIP4_CRED, LCIP2_CRED, Age_Group, [Year], [Count], Total, [Percent] )
 SELECT 'Program_Projections_2023-2024_qry_13d' AS Survey, 
         qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
@@ -797,8 +797,8 @@ INNER JOIN tbl_Age_Groups_Near_Completers
 
 # ---- NOT USED ----
 
-# ---- qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used ---- 
-qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used <- 
+# ---- qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used ----
+qry_13c2_Near_Completers_Program_Dist_TTRAIN_not_used <-
   "SELECT qry_13c_Near_Completers_Program_Dist.PSSM_Credential, 
         qry_13c_Near_Completers_Program_Dist.PSSM_CRED, 
         qry_13c_Near_Completers_Program_Dist.LCP4_CD,'3' AS GRADSTAT, '0' AS TTRAIN, '3 - ' + [LCP4_CD] + ' - 0 - ' + [PSSM_Credential] AS LCIP4_CRED, 

--- a/sql/07-occupation-projections/occupation-projections.R
+++ b/sql/07-occupation-projections/occupation-projections.R
@@ -1,28 +1,26 @@
-
-
 # ---- Count_Cohort_Program_Distributions ----
-Count_Cohort_Program_Distributions <- 
-"SELECT Cohort_Program_Distributions.Survey,
+Count_Cohort_Program_Distributions <-
+  "SELECT Cohort_Program_Distributions.Survey,
 Count(*) AS Expr1
 FROM Cohort_Program_Distributions
 GROUP BY Cohort_Program_Distributions.Survey;"
 
 # ---- Count_Labour_Supply_Distribution ----
-Count_Labour_Supply_Distribution1 <- 
-"SELECT Labour_Supply_Distribution.Survey, LCIP4_CRED,
+Count_Labour_Supply_Distribution1 <-
+  "SELECT Labour_Supply_Distribution.Survey, LCIP4_CRED,
 Count(*) AS Expr1
 FROM Labour_Supply_Distribution
 GROUP BY Labour_Supply_Distribution.Survey, LCIP4_CRED;"
 
 # ---- Count_Labour_Supply_Distribution ----
-Count_Labour_Supply_Distribution2 <- 
-"SELECT Labour_Supply_Distribution.Survey, PSSM_CREDENTIAL,
+Count_Labour_Supply_Distribution2 <-
+  "SELECT Labour_Supply_Distribution.Survey, PSSM_CREDENTIAL,
 Count(*) AS Expr1
 FROM Labour_Supply_Distribution
 GROUP BY Labour_Supply_Distribution.Survey, PSSM_CREDENTIAL;"
 
 # ---- Count_Occupation_Distributions ----
-Count_Occupation_Distributions1 <- 
+Count_Occupation_Distributions1 <-
   "SELECT Occupation_Distributions.Survey, 
 Occupation_Distributions.PSSM_CREDENTIAL,
 Count(*) AS Expr1
@@ -31,8 +29,8 @@ GROUP BY Occupation_Distributions.Survey,
 Occupation_Distributions.PSSM_CREDENTIAL;"
 
 # ---- Count_Occupation_Distributions ----
-Count_Occupation_Distributions2 <- 
-"SELECT Occupation_Distributions.Survey, 
+Count_Occupation_Distributions2 <-
+  "SELECT Occupation_Distributions.Survey, 
 Occupation_Distributions.LCIP4_CRED, 
 Count(*) AS Expr1
 FROM Occupation_Distributions
@@ -40,10 +38,9 @@ GROUP BY Occupation_Distributions.Survey,
 Occupation_Distributions.LCIP4_CRED"
 
 
-
 # ---- Occupation_Unknown ----
-Occupation_Unknown <- 
-"SELECT Cohort_Program_Distributions.LCIP4_CRED, 
+Occupation_Unknown <-
+  "SELECT Cohort_Program_Distributions.LCIP4_CRED, 
 Labour_Supply_Distribution.LCIP4_CRED, 
 Cohort_Program_Distributions.Age_Group, 
 Occupation_Distributions.LCIP4_CRED, 
@@ -69,48 +66,44 @@ AND ((Occupation_Distributions.Age_Group_Rollup) Is Null)
 AND ((Cohort_Program_Distributions.Year)='2023/2024'));"
 
 
-
 # ---- Q_0_LCP2_LCP4 ----
-Q_0_LCP2_LCP4 <- 
-"SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP2_CD, 
+Q_0_LCP2_LCP4 <-
+  "SELECT INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP2_CD, 
 INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD INTO T_LCP2_LCP4
 FROM INFOWARE_L_CIP_6DIGITS_CIP2016
 GROUP BY INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP2_CD, 
 INFOWARE_L_CIP_6DIGITS_CIP2016.LCIP_LCP4_CD;"
 
 
-
 # ---- Q_0a_Delete_Private_Inst_Labour_Supply_Distribution ----
-Q_0a_Delete_Private_Inst_Labour_Supply_Distribution <- 
-"DELETE 
+Q_0a_Delete_Private_Inst_Labour_Supply_Distribution <-
+  "DELETE 
 FROM Labour_Supply_Distribution_No_TT
 WHERE (((Labour_Supply_Distribution_No_TT.PSSM_CRED) Like 'P - %'));"
 
 
-
 # ---- Q_0a_Delete_Private_Inst_Labour_Supply_Distribution_LCP2 ----
-Q_0a_Delete_Private_Inst_Labour_Supply_Distribution_LCP2 <- 
-"DELETE 
+Q_0a_Delete_Private_Inst_Labour_Supply_Distribution_LCP2 <-
+  "DELETE 
 FROM Labour_Supply_Distribution_LCP2_No_TT
 WHERE (((Labour_Supply_Distribution_LCP2_No_TT.PSSM_CRED) Like 'P - %'));"
 
 
-
 # ---- Q_0a_Delete_Private_Inst_Occupation_Distribution ----
-Q_0a_Delete_Private_Inst_Occupation_Distribution <- 
-"DELETE 
+Q_0a_Delete_Private_Inst_Occupation_Distribution <-
+  "DELETE 
 FROM Occupation_Distributions_No_TT
 WHERE (((Occupation_Distributions_No_TT.PSSM_CRED) Like 'P - %'));"
 
 # ---- Q_0a_Delete_Private_Inst_Occupation_Distribution_LCP2 ----
-Q_0a_Delete_Private_Inst_Occupation_Distribution_LCP2 <- 
-"DELETE 
+Q_0a_Delete_Private_Inst_Occupation_Distribution_LCP2 <-
+  "DELETE 
 FROM Occupation_Distributions_LCP2_No_TT
 WHERE (((Occupation_Distributions_LCP2_No_TT.PSSM_CRED) Like 'P - %'));"
 
 # ---- Q_0b_Append_Private_Institution_Labour_Supply_Distribution ----
-Q_0b_Append_Private_Institution_Labour_Supply_Distribution <- 
-"INSERT INTO Labour_Supply_Distribution_No_TT 
+Q_0b_Append_Private_Institution_Labour_Supply_Distribution <-
+  "INSERT INTO Labour_Supply_Distribution_No_TT 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, [Count], Total, New_Labour_Supply )
 SELECT 'PTIB' AS Survey, 
 Labour_Supply_Distribution_No_TT.PSSM_Credential, 
@@ -125,8 +118,8 @@ AND ((Labour_Supply_Distribution_No_TT.LCIP4_CRED) Not Like '3 - %'));"
 
 
 # ---- Q_0b_Append_Private_Institution_Labour_Supply_Distribution_2D ----
-Q_0b_Append_Private_Institution_Labour_Supply_Distribution_2D <- 
-"INSERT INTO Labour_Supply_Distribution_LCP2_No_TT 
+Q_0b_Append_Private_Institution_Labour_Supply_Distribution_2D <-
+  "INSERT INTO Labour_Supply_Distribution_LCP2_No_TT 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCP2_CRED, 
 Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, [Count], Total, New_Labour_Supply )
 SELECT 'PTIB' AS Survey, Labour_Supply_Distribution_LCP2_No_TT.PSSM_Credential, 
@@ -142,10 +135,9 @@ WHERE (((Labour_Supply_Distribution_LCP2_No_TT.PSSM_Credential) In ('CERT','DIPL
 AND ((Labour_Supply_Distribution_LCP2_No_TT.LCP2_CRED) Not Like '3 - %'));"
 
 
-
 # ---- Q_0c_Append_Private_Institution_Occupation_Distribution ----
-Q_0c_Append_Private_Institution_Occupation_Distribution <- 
-"INSERT INTO Occupation_Distributions_No_TT 
+Q_0c_Append_Private_Institution_Occupation_Distribution <-
+  "INSERT INTO Occupation_Distributions_No_TT 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP4_CD, LCIP4_CRED, LCIP2_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, NOC, [Count], Total, [Percent] )
 SELECT 'PTIB' AS Survey, 
 Occupation_Distributions_No_TT.PSSM_Credential, 
@@ -164,8 +156,8 @@ AND ((Occupation_Distributions_No_TT.LCIP4_CRED) Not Like '3 - %'));"
 
 
 # ---- Q_0c_Append_Private_Institution_Occupation_Distribution_2D ----
-Q_0c_Append_Private_Institution_Occupation_Distribution_2D <- 
-"INSERT INTO Occupation_Distributions_LCP2_No_TT 
+Q_0c_Append_Private_Institution_Occupation_Distribution_2D <-
+  "INSERT INTO Occupation_Distributions_LCP2_No_TT 
 ( Survey, PSSM_Credential, PSSM_CRED, LCP2_CD, LCIP2_CRED, Current_Region_PSSM_Code_Rollup, Age_Group_Rollup, NOC, [Count], Total, [Percent] )
 SELECT 'PTIB' AS Survey, 
 Occupation_Distributions_LCP2_No_TT.PSSM_Credential, 
@@ -183,8 +175,8 @@ AND ((Occupation_Distributions_LCP2_No_TT.LCIP2_CRED) Not Like '3 - %'));"
 
 
 # ---- Q_1_Grad_Projections_by_Age_by_Program ----
-Q_1_Grad_Projections_by_Age_by_Program <- 
-"SELECT Cohort_Program_Distributions.PSSM_Credential AS PSSM_Credential, 
+Q_1_Grad_Projections_by_Age_by_Program <-
+  "SELECT Cohort_Program_Distributions.PSSM_Credential AS PSSM_Credential, 
         Graduate_Projections.PSSM_CRED, 
         Graduate_Projections.Age_Group, 
         Graduate_Projections.Year, 
@@ -208,7 +200,6 @@ LEFT JOIN T_Exclude_from_Projections_LCIP4_CRED
 WHERE   (((T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD) Is Null) 
   AND   ((T_Exclude_from_Projections_PSSM_Credential.PSSM_Credential) Is Null) 
   AND   ((T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED) Is Null));"
-
 
 
 # ---- Q_1_Grad_Projections_by_Age_by_Program_Static ----
@@ -258,10 +249,9 @@ PIVOT (
 order by PSSM_Credential, PSSM_CRED, Age_Group"
 
 
-
 # ---- Q_1c_Grad_Projections_by_Program ----
-Q_1c_Grad_Projections_by_Program <- 
-"SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+Q_1c_Grad_Projections_by_Program <-
+  "SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
         Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
         tbl_Age_Groups_Rollup.Age_Group_Rollup, 
         tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
@@ -288,10 +278,9 @@ GROUP BY Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential,
         Q_1_Grad_Projections_by_Age_by_Program.LCIP4_CRED;"
 
 
-
 # ---- Q_1c_Grad_Projections_by_Program_LCP2 ----
-Q_1c_Grad_Projections_by_Program_LCP2 <- 
-" SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
+Q_1c_Grad_Projections_by_Program_LCP2 <-
+  " SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
 Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
 tbl_Age_Groups_Rollup.Age_Group_Rollup, 
 tbl_Age_Groups_Rollup.Age_Group_Rollup_Label, 
@@ -328,7 +317,6 @@ CONCAT(
   , PSSM_Credential);"
 
 
-
 # ---- Q_2_Labour_Supply_by_LCIP4_CRED ----
 Q_2_Labour_Supply_by_LCIP4_CRED <- "
 SELECT Q_1c_Grad_Projections_by_Program.PSSM_Credential, 
@@ -348,10 +336,9 @@ ON (Q_1c_Grad_Projections_by_Program.LCIP4_CRED = Labour_Supply_Distribution.LCI
 AND (Q_1c_Grad_Projections_by_Program.Age_Group_Rollup = Labour_Supply_Distribution.Age_Group_Rollup);"
 
 
-
 # ---- Q_2a_Labour_Supply_Unknown ----
-Q_2a_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2a_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -379,8 +366,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
           q_1c_grad_projections_by_program.year;"
 
 # ---- Q_2a2_Labour_Supply_Unknown_No_TT_Proxy ----
-Q_2a2_Labour_Supply_Unknown_No_TT_Proxy <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2a2_Labour_Supply_Unknown_No_TT_Proxy <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -411,26 +398,24 @@ q_1c_grad_projections_by_program.lcip4_cred );"
 
 
 # ---- Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union ----
-Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union <- 
-"SELECT Q_2_Labour_Supply_by_LCIP4_CRED.*
+Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union <-
+  "SELECT Q_2_Labour_Supply_by_LCIP4_CRED.*
 INTO Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union
 FROM Q_2_Labour_Supply_by_LCIP4_CRED
 UNION ALL SELECT Q_2a2_Labour_Supply_Unknown_No_TT_Proxy.*
 FROM Q_2a2_Labour_Supply_Unknown_No_TT_Proxy;"
 
 
-
 # ---- Q_2a4_Labour_Supply ----
-Q_2a4_Labour_Supply <- 
-"SELECT Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union.* 
+Q_2a4_Labour_Supply <-
+  "SELECT Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union.* 
 INTO tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp
 FROM Q_2a3_Labour_Supply_by_LCIP4_CRED_No_TT_Proxy_Union;"
 
 
-
 # ---- Q_2b_Labour_Supply_Unknown ----
-Q_2b_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2b_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -465,8 +450,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
           q_1c_grad_projections_by_program.year;"
 
 # ---- Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy ----
-Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -503,18 +488,17 @@ WHERE  ( ( ( q_1c_grad_projections_by_program.pssm_cred ) LIKE 'P - CERT' )
 
 
 # ---- Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union ----
-Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union <- 
-"SELECT tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp.*
+Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union <-
+  "SELECT tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp.*
 INTO Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union
 FROM tmp_tbl_Q_2a4_Labour_Supply_by_LCIP4_CRED_No_TT_Union_tmp
 UNION ALL SELECT Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy.*
 FROM Q_2b2_Labour_Supply_Unknown_Private_Cred_Proxy;"
 
 
-
 # ---- Q_2b4_Labour_Supply_Unknown ----
-Q_2b4_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2b4_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -549,8 +533,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
 
 
 # ---- Q_2c_Labour_Supply_Unknown_LCP2_Proxy ----
-Q_2c_Labour_Supply_Unknown_LCP2_Proxy <- 
-"SELECT Q_2b4_Labour_Supply_Unknown.PSSM_Credential, 
+Q_2c_Labour_Supply_Unknown_LCP2_Proxy <-
+  "SELECT Q_2b4_Labour_Supply_Unknown.PSSM_Credential, 
         Q_2b4_Labour_Supply_Unknown.PSSM_CRED, 
         Q_2b4_Labour_Supply_Unknown.Age_Group_Rollup, 
         Q_2b4_Labour_Supply_Unknown.Age_Group_Rollup_Label, 
@@ -573,20 +557,18 @@ WHERE (((T_Exclude_from_Labour_Supply_Unknown_LCP2_Proxy.LCIP_LCP4_CD) Is Null))
 OR (((Left([LCIP4_CRED],1))='P - '));"
 
 
-
 # ---- Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union ----
-Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union <- 
-"SELECT Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union.*
+Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union <-
+  "SELECT Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union.*
 INTO Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union
 FROM Q_2b3_Labour_Supply_by_LCIP4_CRED_Private_Cred_Proxy_Union
 UNION ALL SELECT Q_2c_Labour_Supply_Unknown_LCP2_Proxy.*
 FROM Q_2c_Labour_Supply_Unknown_LCP2_Proxy;"
 
 
-
 # ---- Q_2c3_Labour_Supply_Unknown ----
-Q_2c3_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2c3_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -617,8 +599,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
 
 
 # ---- Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT ----
-Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT <- 
-"SELECT q_2c3_labour_supply_unknown.pssm_credential,
+Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT <-
+  "SELECT q_2c3_labour_supply_unknown.pssm_credential,
        q_2c3_labour_supply_unknown.pssm_cred,
        q_2c3_labour_supply_unknown.age_group_rollup,
        q_2c3_labour_supply_unknown.age_group_rollup_label,
@@ -651,26 +633,24 @@ WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS
 
 
 # ---- Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union ----
-Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union <- 
-"SELECT Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union.*
+Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union.*
 INTO Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
 FROM Q_2c2_Labour_Supply_Unknown_LCP2_Proxy_Union
 UNION ALL Select Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT.*
 FROM Q_2c4_Labour_Supply_Unknown_LCP2_Proxy_No_TT;"
 
 
-
 # ---- Q_2d2_Labour_Supply ----
-Q_2d2_Labour_Supply <- 
-"SELECT Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.* 
+Q_2d2_Labour_Supply <-
+  "SELECT Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.* 
 INTO tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp
 FROM Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union;"
 
 
-
 # ---- Q_2d2_Labour_Supply_Unknown ----
-Q_2d2_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2d2_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup AS Age_Group_Rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -706,8 +686,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
           q_1c_grad_projections_by_program.year;"
 
 # ---- Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy ----
-Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy <- 
-"SELECT q_2d2_labour_supply_unknown.pssm_credential,
+Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy <-
+  "SELECT q_2d2_labour_supply_unknown.pssm_credential,
        q_2d2_labour_supply_unknown.pssm_cred,
        q_2d2_labour_supply_unknown.age_group_rollup,
        q_2d2_labour_supply_unknown.age_group_rollup_label,
@@ -738,26 +718,24 @@ WHERE  ( ( ( q_2d2_labour_supply_unknown.pssm_cred ) LIKE 'P - CERT' )
 
 
 # ---- Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union ----
-Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union <- 
-"SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp.*
+Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp.*
 INTO Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union
 FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union_tmp
 UNION ALL SELECT Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy.*
 FROM Q_2d3_Labour_Supply_Unknown_LCP2_Private_Cred_Proxy;"
 
 
-
 # ---- Q_2f_Labour_Supply ----
-Q_2f_Labour_Supply <- 
-"SELECT Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union.* 
+Q_2f_Labour_Supply <-
+  "SELECT Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union.* 
 INTO tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
 FROM Q_2d4_Labour_Supply_by_LCIP4_CRED_LCP2_LCP2_Private_Union;"
 
 
-
 # ---- Q_2f2_Labour_Supply_Unknown ----
-Q_2f2_Labour_Supply_Unknown <- 
-"SELECT q_1c_grad_projections_by_program.pssm_credential,
+Q_2f2_Labour_Supply_Unknown <-
+  "SELECT q_1c_grad_projections_by_program.pssm_credential,
        q_1c_grad_projections_by_program.pssm_cred,
        q_1c_grad_projections_by_program.age_group_rollup,
        q_1c_grad_projections_by_program.age_group_rollup_label,
@@ -788,8 +766,8 @@ GROUP  BY q_1c_grad_projections_by_program.pssm_credential,
 
 
 # ---- Q_3_Occupations_by_LCIP4_CRED ----
-Q_3_Occupations_by_LCIP4_CRED <- 
-"SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
+Q_3_Occupations_by_LCIP4_CRED <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
         tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
         tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, 
         tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
@@ -808,10 +786,9 @@ AND (tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Cod
 AND (tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup = Occupation_Distributions.Age_Group_Rollup);"
 
 
-
 # ---- Q_3b_Occupations_Unknown ----
-Q_3b_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3b_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -834,8 +811,8 @@ WHERE  ( ( ( occupation_distributions.lcip4_cred ) IS NULL )
 
 
 # ---- Q_3b11_Ocupations_Unknown_No_TT_Proxy ----
-Q_3b11_Ocupations_Unknown_No_TT_Proxy <- 
-"SELECT q_3b_occupations_unknown.pssm_credential,
+Q_3b11_Ocupations_Unknown_No_TT_Proxy <-
+  "SELECT q_3b_occupations_unknown.pssm_credential,
         q_3b_occupations_unknown.pssm_cred,
         q_3b_occupations_unknown.age_group_rollup,
         q_3b_occupations_unknown.age_group_rollup_label,
@@ -857,8 +834,8 @@ FROM   q_3b_occupations_unknown
 
 
 # ---- q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union ----
-q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union <- 
-"SELECT Q_3_Occupations_by_LCIP4_CRED.*
+q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union <-
+  "SELECT Q_3_Occupations_by_LCIP4_CRED.*
 INTO q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union
 FROM Q_3_Occupations_by_LCIP4_CRED
 UNION ALL SELECT Q_3b11_Ocupations_Unknown_No_TT_Proxy.*
@@ -866,15 +843,15 @@ FROM Q_3b11_Ocupations_Unknown_No_TT_Proxy;"
 
 
 # ---- Q_3b13_Occupations ----
-Q_3b13_Occupations <- 
-"SELECT q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union.* 
+Q_3b13_Occupations <-
+  "SELECT q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union.* 
 INTO tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
 FROM q_3b12_Occupations_by_LCIP4_CRED_No_TT_Proxy_Union;"
 
 
 # ---- Q_3b14_Occupations_Unknown ----
-Q_3b14_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3b14_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -898,10 +875,9 @@ WHERE  (((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.year ) IS NULL
     AND ((tmp_tbl_q3b12_occupations_by_lcip4_cred_no_tt_union_tmp.current_region_pssm_code_rollup ) IS NULL ) );"
 
 
-
 # ---- Q_3b2_Occupations_Unknown_Private_Cred_Proxy ----
-Q_3b2_Occupations_Unknown_Private_Cred_Proxy <- 
-"SELECT q_3b14_occupations_unknown.pssm_credential,
+Q_3b2_Occupations_Unknown_Private_Cred_Proxy <-
+  "SELECT q_3b14_occupations_unknown.pssm_credential,
        q_3b14_occupations_unknown.pssm_cred,
        q_3b14_occupations_unknown.age_group_rollup,
        q_3b14_occupations_unknown.age_group_rollup_label,
@@ -931,8 +907,8 @@ WHERE  ( ( ( q_3b14_occupations_unknown.pssm_cred ) LIKE 'P - CERT')
 
 
 # ---- Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union ----
-Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union <- 
-"SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
+Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union <-
+  "SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
 INTO Q_3b3_Occupations_by_LCIP4_CRED_Private_Cred_Proxy_Union
 FROM tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
 UNION ALL SELECT Q_3b2_Occupations_Unknown_Private_Cred_Proxy.*
@@ -940,8 +916,8 @@ FROM Q_3b2_Occupations_Unknown_Private_Cred_Proxy;"
 
 
 # ---- Q_3b4_Occupations_Unknown ----
-Q_3b4_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3b4_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -965,8 +941,8 @@ WHERE  (((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.age_group_rol
  AND ((q_3b3_occupations_by_lcip4_cred_private_cred_proxy_union.current_region_pssm_code_rollup ) IS NULL));"
 
 # ---- Q_3c_Occupations_Unknown_LCP2_Proxy ----
-Q_3c_Occupations_Unknown_LCP2_Proxy <- 
-"SELECT q_3b4_occupations_unknown.pssm_credential,
+Q_3c_Occupations_Unknown_LCP2_Proxy <-
+  "SELECT q_3b4_occupations_unknown.pssm_credential,
         q_3b4_occupations_unknown.pssm_cred,
         q_3b4_occupations_unknown.age_group_rollup,
         q_3b4_occupations_unknown.age_group_rollup_label,
@@ -993,8 +969,8 @@ WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS  N
 
 
 # ---- Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union ----
-Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union <- 
-"SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
+Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp.*
 INTO Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union
 FROM tmp_tbl_Q3b12_Occupations_by_LCIP4_CRED_No_TT_Union_tmp
 UNION ALL SELECT Q_3b2_Occupations_Unknown_Private_Cred_Proxy.*
@@ -1004,15 +980,15 @@ FROM Q_3c_Occupations_Unknown_LCP2_Proxy;"
 
 
 # ---- Q_3d2_Occupations ----
-Q_3d2_Occupations <- 
-"SELECT Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.* 
+Q_3d2_Occupations <-
+  "SELECT Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.* 
 INTO tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
 FROM Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union;"
 
 
 # ---- Q_3d2_Occupations_Unknown ----
-Q_3d2_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3d2_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -1037,8 +1013,8 @@ AND ((tmp_tbl_q_3d_occupations_by_lcip4_cred_lcp2_union_tmp.current_region_pssm_
 
 
 # ---- Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT ----
-Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT <- 
-"SELECT q_3d2_occupations_unknown.pssm_credential,
+Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT <-
+  "SELECT q_3d2_occupations_unknown.pssm_credential,
        q_3d2_occupations_unknown.pssm_cred,
        q_3d2_occupations_unknown.age_group_rollup,
        q_3d2_occupations_unknown.age_group_rollup_label,
@@ -1066,18 +1042,17 @@ WHERE  (( ( t_exclude_from_labour_supply_unknown_lcp2_proxy.lcip_lcp4_cd ) IS NU
 
 
 # ---- Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union ----
-Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union <- 
-"SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
+Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
 INTO Q_3d22_Occupations_by_LCIP4_CRED_LCP2_No_T_Proxy_Union
 FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
 UNION ALL SELECT Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT.*
 FROM Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT;"
 
 
-
 # ---- Q_3d24_Occupations_Unknown ----
-Q_3d24_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3d24_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -1101,8 +1076,8 @@ AND ( ( q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.lcip4_cred ) IS N
 AND ((q_3d22_occupations_by_lcip4_cred_lcp2_no_t_proxy_union.current_region_pssm_code_rollup ) IS NULL ) );"
 
 # ---- Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy ----
-Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy <- 
-"SELECT q_3d24_occupations_unknown.pssm_credential,
+Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy <-
+  "SELECT q_3d24_occupations_unknown.pssm_credential,
        q_3d24_occupations_unknown.pssm_cred,
        q_3d24_occupations_unknown.age_group_rollup,
        q_3d24_occupations_unknown.age_group_rollup_label,
@@ -1129,8 +1104,8 @@ OR ( ( ( q_3d24_occupations_unknown.pssm_cred ) LIKE 'P - DIPL' )
 AND ( ( occupation_distributions_lcp2_no_tt.pssm_cred ) LIKE'P - CERT' ) );"
 
 # ---- Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union ----
-Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union <- 
-"SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
+Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp.*
 INTO Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union
 FROM tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_tmp
 UNION ALL SELECT Q_3d21_Occupations_Unknown_LCP2_Proxy_No_TT.*
@@ -1140,8 +1115,8 @@ FROM Q_3d3_Occupations_Unknown_LCP2_Private_Cred_Proxy;"
 
 
 # ---- Q_3e_Occupations_Unknown ----
-Q_3e_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3e_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -1173,8 +1148,8 @@ GROUP BY tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
         tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.current_region_pssm_code_rollup;"
 
 # ---- Q_3e2_Occupations_Unknown ----
-Q_3e2_Occupations_Unknown <- 
-"SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
+Q_3e2_Occupations_Unknown <-
+  "SELECT tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_credential,
        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.pssm_cred,
        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup,
        tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.age_group_rollup_label,
@@ -1210,18 +1185,17 @@ HAVING  (( ( Sum(tmp_tbl_q_2d_labour_supply_by_lcip4_cred_lcp2_union.nls) ) > 0 
 
 
 # ---- Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union ----
-Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union <- 
-"SELECT Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union.*
+Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union <-
+  "SELECT Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union.*
 INTO Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union
 FROM Q_3d4_Occupations_by_LCIP4_CRED_LCP2_LCP2_Private_Union
 UNION ALL SELECT Q_3e2_Occupations_Unknown.*
 FROM Q_3e2_Occupations_Unknown;"
 
 
-
 # ---- Q_3f_Occupations ----
-Q_3f_Occupations <- 
-"SELECT Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
+Q_3f_Occupations <-
+  "SELECT Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, 
         Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
         Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, 
         Q_3e3_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, 
@@ -1266,7 +1240,6 @@ PIVOT (
 	 [APPRAPPR],[APPRCERT],[BACH],[DOCT],[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG])
 ) AS PivotTable
 ORDER BY NOC;"
-
 
 
 # ---- Q_4_NOC_1D_Totals_by_Year ----
@@ -1337,7 +1310,6 @@ PIVOT (
 ORDER BY NOC;"
 
 
-
 # ---- Q_4_NOC_2D_Totals_by_PSSM_CRED_Appendix ----
 Q_4_NOC_2D_Totals_by_PSSM_CRED_Appendix <- "
 SELECT NOC_Level, NOC, Expr1, 
@@ -1372,10 +1344,9 @@ PIVOT (
 ORDER BY  NOC_LEVEL, NOC;"
 
 
-
 # ---- Q_4_NOC_2D_Totals_by_Year ----
-Q_4_NOC_2D_Totals_by_Year <- 
-"SELECT 	Expr1, Age_Group_Rollup_Label, NOC_Level, NOC, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
+Q_4_NOC_2D_Totals_by_Year <-
+  "SELECT 	Expr1, Age_Group_Rollup_Label, NOC_Level, NOC, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup, Current_Region_PSSM_Name_Rollup,
 	 [2023/2024], [2024/2025], [2025/2026], [2026/2027], [2027/2028], [2028/2029], 
 	 [2029/2030], [2030/2031], [2031/2032], [2032/2033], [2033/2034],[2034/2035]
 	 
@@ -1406,7 +1377,6 @@ PIVOT (
 ) AS PivotTable
 
 ORDER BY Age_Group_Rollup_Label,  ENGLISH_NAME,  Current_Region_PSSM_Name_Rollup;"
-
 
 
 # ---- Q_4_NOC_3D_Totals_by_PSSM_CRED ----
@@ -1545,10 +1515,9 @@ PIVOT (
 ORDER BY Age_Group_Rollup_Label, NOC_Level, ENGLISH_NAME, Current_Region_PSSM_Code_Rollup;"
 
 
-
 # ---- Q_4_NOC_5D_Totals_by_PSSM_CRED ----
-Q_4_NOC_5D_Totals_by_PSSM_CRED <- 
-"SELECT NOC_Level, NOC, ENGLISH_NAME,
+Q_4_NOC_5D_Totals_by_PSSM_CRED <-
+  "SELECT NOC_Level, NOC, ENGLISH_NAME,
 		[1 - ADCT or ADIP],[1 - ADGR or UT],[1 - CERT],[1 - DIPL],[1 - PDCT or PDDP],[3 - ADCT or ADIP],
 		[3 - ADGR or UT],[3 - CERT],[3 - DIPL],[3 - PDCT or PDDP],[APPRAPPR],[APPRCERT],[BACH],[DOCT],
 		[GRCT or GRDP],[MAST],[P - CERT],[P - DIPL],[PDEG]
@@ -1575,7 +1544,6 @@ PIVOT (
 ) AS PivotTable
 
 ORDER BY NOC_Level, NOC;"
-
 
 
 # ---- Q_4_NOC_5D_Totals_by_Year ----
@@ -1616,8 +1584,8 @@ ORDER BY age_group_rollup_label, NOC, current_region_pssm_code_rollup;"
 
 
 # ---- Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding ----
-Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding <- 
-"SELECT 
+Q_4_NOC_5D_Totals_by_Year_Input_for_Rounding <-
+  "SELECT 
   [age_group_rollup_label] + '-' 
     + RIGHT(REPLICATE('0', 5) + CAST([noc] AS NVARCHAR(5)), 5) + '-' 
     + CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50)) AS Expr1,
@@ -1650,8 +1618,8 @@ t_current_region_pssm_rollup_codes.current_region_pssm_code_rollup;"
 
 
 # ---- Q_4_NOC_Totals_by_PSSM_CRED ----
-Q_4_NOC_Totals_by_PSSM_CRED <- 
-"SELECT q_4_noc_4d_totals_by_pssm_cred.noc_level,
+Q_4_NOC_Totals_by_PSSM_CRED <-
+  "SELECT q_4_noc_4d_totals_by_pssm_cred.noc_level,
        q_4_noc_4d_totals_by_pssm_cred.noc,
        q_4_noc_4d_totals_by_pssm_cred.english_name,
        q_4_noc_4d_totals_by_pssm_cred.apprappr,
@@ -1747,10 +1715,9 @@ ORDER  BY 6,
           1;"
 
 
-
 # ---- Q_4_NOC_Totals_by_Year ----
-Q_4_NOC_Totals_by_Year <- 
-"SELECT *
+Q_4_NOC_Totals_by_Year <-
+  "SELECT *
 INTO Q_4_NOC_Totals_by_Year 
 FROM Q_4_NOC_4D_Totals_by_Year
 UNION ALL SELECT *
@@ -1764,10 +1731,9 @@ FROM Q_4_NOC_5D_Totals_by_Year
 ORDER BY 6, 4, 2, 8;"
 
 
-
 # ---- Q_4_NOC_Totals_by_Year_and_PSSM_CRED ----
-Q_4_NOC_Totals_by_Year_and_PSSM_CRED <- 
-"SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
+Q_4_NOC_Totals_by_Year_and_PSSM_CRED <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, 
 tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, 
 tbl_NOC_Skill_Level_Aged_17_34.PSSM_Skill_Level, 
 tbl_NOC_Skill_Level_Aged_17_34.SKILL_LEVEL_Initial, 
@@ -1787,8 +1753,8 @@ HAVING (((tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year) In ('2011/2012
 
 
 # ---- Q_4_NOC_Totals_by_Year_BC ----
-Q_4_NOC_Totals_by_Year_BC <- 
-"SELECT [q_4_noc_totals_by_year].[age_group_rollup_label] + '-'
+Q_4_NOC_Totals_by_Year_BC <-
+  "SELECT [q_4_noc_totals_by_year].[age_group_rollup_label] + '-'
        + [q_4_noc_totals_by_year].[noc] + '-'
        + CAST([t_current_region_pssm_rollup_codes].[current_region_pssm_code_rollup] AS NVARCHAR(50))  AS  Expr1000,
        q_4_noc_totals_by_year.age_group_rollup_label,
@@ -1867,8 +1833,8 @@ GROUP BY [q_4_noc_totals_by_year].[age_group_rollup_label]
 
 
 # ---- Q_5_NOC_Totals_by_Year_and_BC ----
-Q_5_NOC_Totals_by_Year_and_BC <- 
-"SELECT Q_4_NOC_Totals_by_Year.*
+Q_5_NOC_Totals_by_Year_and_BC <-
+  "SELECT Q_4_NOC_Totals_by_Year.*
 INTO Q_5_NOC_Totals_by_Year_and_BC
 FROM Q_4_NOC_Totals_by_Year
 UNION ALL SELECT Q_4_NOC_Totals_by_Year_BC.*
@@ -1876,10 +1842,9 @@ FROM Q_4_NOC_Totals_by_Year_BC
 ORDER BY 6, 4, 2, 8;"
 
 
-
 # ---- Q_5_NOC_Totals_by_Year_and_BC_and_Total ----
-Q_5_NOC_Totals_by_Year_and_BC_and_Total <- 
-"SELECT Q_4_NOC_Totals_by_Year.*
+Q_5_NOC_Totals_by_Year_and_BC_and_Total <-
+  "SELECT Q_4_NOC_Totals_by_Year.*
 INTO Q_5_NOC_Totals_by_Year_and_BC_and_Total
 FROM Q_4_NOC_Totals_by_Year
 
@@ -1891,39 +1856,39 @@ FROM Q_4_NOC_Totals_by_Year_Total
 ORDER BY 6, 4, 2, 8;"
 
 # ---- Q_6_tmp_tbl_Model ----
-Q_6_tmp_tbl_Model <- 
-"SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+Q_6_tmp_tbl_Model <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
 INTO tmp_tbl_Model
 FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
 
-Q_6_tmp_tbl_Model_QI <- 
-"SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+Q_6_tmp_tbl_Model_QI <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
  INTO tmp_tbl_QI
  FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
 
 # ---- Q_6_tmp_tbl_Model_Inc_Private_Inst ----
-Q_6_tmp_tbl_Model_Inc_Private_Inst <- 
-"SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+Q_6_tmp_tbl_Model_Inc_Private_Inst <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
 INTO tmp_tbl_Model_Inc_Private_Inst
 FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
 
 # ---- Q_6_tmp_tbl_Model_Program_Projection ----
-Q_6_tmp_tbl_Model_Program_Projection <- 
-"SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
+Q_6_tmp_tbl_Model_Program_Projection <-
+  "SELECT Q_5_NOC_Totals_by_Year_and_BC_and_Total.* 
 INTO tmp_tbl_Model_Program_Projection
 FROM Q_5_NOC_Totals_by_Year_and_BC_and_Total;"
 
 # ---- Q_7_QI ----
-Q_7_QI_Old <- 
-"SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.PSSM_Skill_Level, tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, tmp_tbl_Model.NOC_Level, 
+Q_7_QI_Old <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.PSSM_Skill_Level, tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, tmp_tbl_Model.NOC_Level, 
 tmp_tbl_Model.NOC_SKILL_TYPE, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
 tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, tmp_tbl_Model.[2023/2024] AS Model_Y1, tmp_tbl_QI.[2023/2024] AS QI_Y1, 
 IIf([tmp_tbl_QI].[Expr1]=Null,'',Abs(([Model_Y1]-[QI_Y1])/[QI_Y1])) AS ErrorRate
 FROM tmp_tbl_Model LEFT JOIN tmp_tbl_QI ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1000
 ORDER BY 6, 4, 2, 8;"
 
-Q_7_QI <- 
-"SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.NOC_Level, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
+Q_7_QI <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.NOC_Level, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, 
 tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
 tmp_tbl_Model.[2023/2024] AS Model_Y1, 
 tmp_tbl_QI.[2023/2024] AS QI_Y1,
@@ -1934,8 +1899,8 @@ LEFT JOIN tmp_tbl_QI
 
 
 # ---- Q_8_Labour_Supply_Total_by_Year ----
-Q_8_Labour_Supply_Total_by_Year <- 
-"SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED AS Expr1, 
+Q_8_Labour_Supply_Total_by_Year <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED AS Expr1, 
 Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
 FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union
 WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year) In 
@@ -1944,8 +1909,8 @@ GROUP BY tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED;"
 
 
 # ---- qry_10a_Model ----
-qry_10a_Model <- 
-"SELECT tmp_tbl_Model.Expr1, 
+qry_10a_Model <-
+  "SELECT tmp_tbl_Model.Expr1, 
 tmp_tbl_Model.Age_Group_Rollup_Label, 
 tmp_tbl_Model.NOC, 
 tmp_tbl_Model.ENGLISH_NAME, 
@@ -1974,8 +1939,8 @@ ORDER BY 2, 7, 5, 3, 9;"
 
 
 # ---- qry_10a_Model_Public_Release ----
-qry_10a_Model_Public_Release <- 
-"SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, 
+qry_10a_Model_Public_Release <-
+  "SELECT tmp_tbl_Model.Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, 
 tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, 
 tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
 CEILING([tmp_tbl_Model].[2023/2024]) AS [2023/2024], 
@@ -2007,10 +1972,9 @@ And ((T_Suppression_Public_Release_NOC.NOC_CD) Is Null))
 ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
 
 
-
 # ---- qry_10a_Model_Public_Release_Suppressed ----
-qry_10a_Model_Public_Release_Suppressed <- 
-"SELECT tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, 
+qry_10a_Model_Public_Release_Suppressed <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC, tmp_tbl_Model.ENGLISH_NAME, 
 tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
 CEILING(Sum([tmp_tbl_Model].[2023/2024])) AS [2023/2024], 
 CEILING(Sum([tmp_tbl_Model].[2024/2025])) AS [2024/2025], 
@@ -2039,10 +2003,9 @@ HAVING (((tmp_tbl_Model.Current_Region_PSSM_Code_Rollup)=5900))
 ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
 
 
-
 # ---- qry_10a_Model_Public_Release_Suppressed_Total ----
-qry_10a_Model_Public_Release_Suppressed_Total <- 
-"SELECT '' AS Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, '99998' AS [NOC], 'Other' AS [ENGLISH_NAME], 
+qry_10a_Model_Public_Release_Suppressed_Total <-
+  "SELECT '' AS Expr1, tmp_tbl_Model.Age_Group_Rollup_Label, '99998' AS [NOC], 'Other' AS [ENGLISH_NAME], 
 tmp_tbl_Model.Current_Region_PSSM_Code_Rollup, tmp_tbl_Model.Current_Region_PSSM_Name_Rollup, 
 Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2023/2024] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2023/2024] END)) AS [2023/2024], 
 Sum(CEILING(CASE WHEN [tmp_tbl_Model].[2024/2025] IS NULL THEN 0 ELSE [tmp_tbl_Model].[2024/2025] END)) AS [2024/2025], 
@@ -2065,10 +2028,9 @@ tmp_tbl_Model.Current_Region_PSSM_Name_Rollup
 HAVING (((tmp_tbl_Model.Current_Region_PSSM_Code_Rollup) = 5900));"
 
 
-
 # ---- qry_10a_Model_Public_Release_Union ----
-qry_10a_Model_Public_Release_Union <- 
-"SELECT qry_10a_Model_Public_Release.*
+qry_10a_Model_Public_Release_Union <-
+  "SELECT qry_10a_Model_Public_Release.*
 INTO qry_10a_Model_Public_Release_Union
 FROM qry_10a_Model_Public_Release
 UNION ALL SELECT qry_10a_Model_Public_Release_Suppressed_Total.*
@@ -2076,10 +2038,9 @@ FROM qry_10a_Model_Public_Release_Suppressed_Total
 ORDER BY 2, 6, 4, 5, 8;"
 
 
-
 # ---- qry_10a_Model_QI_PPCI ----
-qry_10a_Model_QI_PPCI <- 
-"SELECT tmp_tbl_Model.Expr1, 
+qry_10a_Model_QI_PPCI <-
+  "SELECT tmp_tbl_Model.Expr1, 
 tmp_tbl_Model.Age_Group_Rollup_Label, 
 --no longer present in NOC data
 --tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
@@ -2117,8 +2078,8 @@ ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC, 2, 5, 4, 8;"
 
 
 # ---- qry_10a_Model_QI_PPCI_No_Supp ----
-qry_10a_Model_QI_PPCI_No_Supp <- 
-"SELECT tmp_tbl_Model.Expr1, 
+qry_10a_Model_QI_PPCI_No_Supp <-
+  "SELECT tmp_tbl_Model.Expr1, 
 tmp_tbl_Model.Age_Group_Rollup_Label, 
 --tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
 tmp_tbl_Model.NOC_Level, 
@@ -2155,8 +2116,8 @@ ORDER BY 2,4,6;"
 
 
 # ---- qry_10a_Model_QI_PPCI_Suppressed ----
-qry_10a_Model_QI_PPCI_Suppressed <- 
-"SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
+qry_10a_Model_QI_PPCI_Suppressed <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
 --tmp_tbl_Model.SKILL_LEVEL_CATEGORY_CODE, 
 --tmp_tbl_Model.NOC_SKILL_TYPE, 
 tmp_tbl_Model.NOC, 
@@ -2189,8 +2150,8 @@ ORDER BY tmp_tbl_Model.Age_Group_Rollup_Label, tmp_tbl_Model.NOC;"
 
 
 # ---- qry_10a_Model_QI_PPCI_Suppressed_Total ----
-qry_10a_Model_QI_PPCI_Suppressed_Total <- 
-"SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
+qry_10a_Model_QI_PPCI_Suppressed_Total <-
+  "SELECT tmp_tbl_Model.Age_Group_Rollup_Label, 
 --'N/A' AS [NOC Skill Level], 
 tmp_tbl_Model.NOC_Level, 
 --'N/A' AS [NOC Skill Type], 
@@ -2223,8 +2184,8 @@ tmp_tbl_Model.Current_Region_PSSM_Name_Rollup
 HAVING (((tmp_tbl_Model.NOC_Level)=5));"
 
 # ---- qry_10b_Quality_Indicator ----
-qry_10b_Quality_Indicator <- 
-"SELECT tmp_tbl_Model.Expr1, 
+qry_10b_Quality_Indicator <-
+  "SELECT tmp_tbl_Model.Expr1, 
 tmp_tbl_Model.Age_Group_Rollup_Label, 
 tmp_tbl_Model.NOC_Level, 
 tmp_tbl_Model.NOC, 
@@ -2237,10 +2198,9 @@ ON tmp_tbl_Model.Expr1 = tmp_tbl_QI.Expr1
 ORDER BY tmp_tbl_Model.Expr1;"
 
 
-
 # ---- qry_10c_Coverage_Indicator ----
-qry_10c_Coverage_Indicator <- 
-"SELECT tmp_tbl_Model.Expr1, 
+qry_10c_Coverage_Indicator <-
+  "SELECT tmp_tbl_Model.Expr1, 
 tmp_tbl_Model.Age_Group_Rollup_Label, 
 tmp_tbl_Model.NOC_Level, 
 tmp_tbl_Model.NOC, 
@@ -2254,10 +2214,9 @@ LEFT JOIN tmp_tbl_Model_Inc_Private_Inst
 ORDER BY tmp_tbl_Model.Expr1;"
 
 
-
 # ---- qry_10d_tmp_No_Near_Completers ----
-qry_10d_tmp_No_Near_Completers <- 
-"SELECT [tmp_tbl_Model_2017-05-16].Expr1, [tmp_tbl_Model_2017-05-16].Age_Group_Rollup_Label, 
+qry_10d_tmp_No_Near_Completers <-
+  "SELECT [tmp_tbl_Model_2017-05-16].Expr1, [tmp_tbl_Model_2017-05-16].Age_Group_Rollup_Label, 
 [tmp_tbl_Model_2017-05-16].PSSM_Skill_Level, [tmp_tbl_Model_2017-05-16].SKILL_LEVEL_CATEGORY_CODE, 
 [tmp_tbl_Model_2017-05-16].NOC_Level, [tmp_tbl_Model_2017-05-16].NOC_SKILL_TYPE, 
 [tmp_tbl_Model_2017-05-16].NOC, [tmp_tbl_Model_2017-05-16].ENGLISH_NAME, 
@@ -2292,45 +2251,40 @@ ON [tmp_tbl_Model_2017-05-16].Expr1 = [tmp_tbl_Model_2017-06-08_No_Near_Complete
 ORDER BY 2, 7, 5, 3, 9;"
 
 
-
 # ---- qry_LCIP4_CRED ----
-qry_LCIP4_CRED <- 
-"SELECT Occupation_Distributions.LCIP4_CRED
+qry_LCIP4_CRED <-
+  "SELECT Occupation_Distributions.LCIP4_CRED
 FROM Occupation_Distributions
 GROUP BY Occupation_Distributions.LCIP4_CRED
 ORDER BY Occupation_Distributions.LCIP4_CRED;"
 
 
-
 # ---- qry_LCIP4_CRED_Filtered_NOC ----
-qry_LCIP4_CRED_Filtered_NOC <- 
-"SELECT TOP 10 Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC, Occupation_Distributions.Count, Occupation_Distributions.[percent]
+qry_LCIP4_CRED_Filtered_NOC <-
+  "SELECT TOP 10 Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC, Occupation_Distributions.Count, Occupation_Distributions.[percent]
 FROM Occupation_Distributions INNER JOIN qry_LCIP4_CRED ON Occupation_Distributions.LCIP4_CRED=qry_LCIP4_CRED.LCIP4_CRED
 WHERE (((Occupation_Distributions.Count) In (Select Top 3 [Count] From Occupation_Distributions WHERE [Occupation_Distributions].[LCIP4_CRED]=[qry_LCIP4_CRED].[LCIP4_CRED] Order By [Count] Desc)))
 ORDER BY Occupation_Distributions.[percent] DESC;"
 
 
-
 # ---- qry_LCIP4_CRED_NOC ----
-qry_LCIP4_CRED_NOC <- 
-"SELECT Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC
+qry_LCIP4_CRED_NOC <-
+  "SELECT Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC
 FROM Occupation_Distributions
 GROUP BY Occupation_Distributions.LCIP4_CRED, Occupation_Distributions.NOC
 ORDER BY Occupation_Distributions.LCIP4_CRED;"
 
 
-
 # ---- qry100_Grad_Skill_Level ----
-qry100_Grad_Skill_Level <- 
-"SELECT Q_4_NOC_4D_Totals_by_PSSM_CRED.PSSM_Skill_Level AS Expr1, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRAPPR) AS SumOfAPPRAPPR, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRCERT) AS SumOfAPPRCERT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - CERT]) AS [SumOf1 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - DIPL]) AS [SumOf1 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADGR or UT]) AS [SumOf1 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADCT or ADIP]) AS [SumOf1 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.BACH) AS SumOfBACH, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - PDCT or PDDP]) AS [SumOf1 - PDCT or PDDP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.MAST) AS SumOfMAST, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.DOCT) AS SumOfDOCT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - CERT]) AS [SumOf2 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - DIPL]) AS [SumOf2 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADGR or UT]) AS [SumOf2 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADCT or ADIP]) AS [SumOf2 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - PDCT or PDDP]) AS [SumOf2 - PDCT or PDDP]
+qry100_Grad_Skill_Level <-
+  "SELECT Q_4_NOC_4D_Totals_by_PSSM_CRED.PSSM_Skill_Level AS Expr1, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRAPPR) AS SumOfAPPRAPPR, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.APPRCERT) AS SumOfAPPRCERT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - CERT]) AS [SumOf1 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - DIPL]) AS [SumOf1 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADGR or UT]) AS [SumOf1 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - ADCT or ADIP]) AS [SumOf1 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.BACH) AS SumOfBACH, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[1 - PDCT or PDDP]) AS [SumOf1 - PDCT or PDDP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.MAST) AS SumOfMAST, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.DOCT) AS SumOfDOCT, Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - CERT]) AS [SumOf2 - CERT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - DIPL]) AS [SumOf2 - DIPL], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADGR or UT]) AS [SumOf2 - ADGR or UT], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - ADCT or ADIP]) AS [SumOf2 - ADCT or ADIP], Sum(Q_4_NOC_4D_Totals_by_PSSM_CRED.[2 - PDCT or PDDP]) AS [SumOf2 - PDCT or PDDP]
 FROM Q_4_NOC_4D_Totals_by_PSSM_CRED
 GROUP BY Q_4_NOC_4D_Totals_by_PSSM_CRED.PSSM_Skill_Level;"
 
 
-
 # ---- qry99_Presentations_Graduates_Appendix ----
-qry99_Presentations_Graduates_Appendix_old <- 
-"TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
+qry99_Presentations_Graduates_Appendix_old <-
+  "TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
 SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name
 FROM T_PSSM_Credential_Grouping_Appendix INNER JOIN Q_1c_Grad_Projections_by_Program ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
 WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
@@ -2340,8 +2294,8 @@ PIVOT Q_1c_Grad_Projections_by_Program.Year;"
 
 
 # ---- qry99_Presentations_Graduates_Appendix ----
-qry99_Presentations_Graduates_Appendix <- 
-"SELECT Age_Group_Rollup_Label, PSSM_Credential_Name, 
+qry99_Presentations_Graduates_Appendix <-
+  "SELECT Age_Group_Rollup_Label, PSSM_Credential_Name, 
 [2023/2024], 
 [2024/2025], 
 [2025/2026], 
@@ -2381,8 +2335,8 @@ PIVOT (
 
 
 # ---- qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals ----
-qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals_old <- 
-"TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
+qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals_old <-
+  "TRANSFORM (Int(Sum([Grads])+2.5)\5)*5 AS Expr1
 SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label
 FROM T_PSSM_Credential_Grouping_Appendix 
 INNER JOIN Q_1c_Grad_Projections_by_Program 
@@ -2392,7 +2346,7 @@ GROUP BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label
 PIVOT Q_1c_Grad_Projections_by_Program.Year;"
 
 # ---- qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals ----
-qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals <- 
+qry99_Presentations_Graduates_Appendix_by_Age_Group_Totals <-
   "SELECT Age_Group_Rollup_Label, 
 [2023/2024], 
 [2024/2025], 
@@ -2432,11 +2386,9 @@ PIVOT (
 ) AS PivotTable;"
 
 
-
-
 # ---- qry99_Presentations_Graduates_Appendix_Unrounded ----
-qry99_Presentations_Graduates_Appendix_Unrounded <- 
-"TRANSFORM Sum(Q_1c_Grad_Projections_by_Program.Grads) AS SumOfGrads
+qry99_Presentations_Graduates_Appendix_Unrounded <-
+  "TRANSFORM Sum(Q_1c_Grad_Projections_by_Program.Grads) AS SumOfGrads
 SELECT Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credential_Grouping_Appendix.PSSM_Credential_Name
 FROM T_PSSM_Credential_Grouping_Appendix INNER JOIN Q_1c_Grad_Projections_by_Program ON T_PSSM_Credential_Grouping_Appendix.PSSM_Credential = Q_1c_Grad_Projections_by_Program.PSSM_Credential
 WHERE (((Q_1c_Grad_Projections_by_Program.PSSM_CRED) Not Like 'P - %'))
@@ -2445,68 +2397,62 @@ ORDER BY Q_1c_Grad_Projections_by_Program.Age_Group_Rollup_Label, T_PSSM_Credent
 PIVOT Q_1c_Grad_Projections_by_Program.Year;"
 
 
-
 # ---- qry99_Presentations_Graduates_Including_those_not_projected ----
-qry99_Presentations_Graduates_Including_those_not_projected <- 
-"SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
+qry99_Presentations_Graduates_Including_those_not_projected <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
 FROM Graduate_Projections INNER JOIN T_PSSM_CRED_RECODE ON Graduate_Projections.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
 WHERE ((((Graduate_Projections.Year)='2015/2016' Or (Graduate_Projections.Year)='2016/2017')=False) And (((Graduate_Projections.Age_Group)='15 to 16' Or (Graduate_Projections.Age_Group)='65 to 89')=False) And ((Graduate_Projections.PSSM_CRED) Not Like 'P - %'))
 GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
 ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
 
 
-
 # ---- qry99_Presentations_Labour_Force ----
-qry99_Presentations_Labour_Force <- 
-"SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.New_Labour_Supply) AS SumOfNew_Labour_Supply, T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+qry99_Presentations_Labour_Force <-
+  "SELECT tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.New_Labour_Supply) AS SumOfNew_Labour_Supply, T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
 FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup
 WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
 GROUP BY tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup;"
 
 
-
 # ---- qry99_Presentations_Labour_Force_BC ----
-qry99_Presentations_Labour_Force_BC <- 
-"SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+qry99_Presentations_Labour_Force_BC <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
 FROM ((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_PSSM_CRED_RECODE ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED) INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup) INNER JOIN T_Current_Region_PSSM_Rollup_Codes ON T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC = T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup
 WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
 GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
 ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
 
 
-
 # ---- qry99_Presentations_Labour_Force_Overall ----
-qry99_Presentations_Labour_Force_Overall <- 
-"SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
+qry99_Presentations_Labour_Force_Overall <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.NLS) AS SumOfNLS
 FROM tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union INNER JOIN T_PSSM_CRED_RECODE ON tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
 WHERE (((tmp_tbl_Q_2d_Labour_Supply_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'))
 GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER
 ORDER BY T_PSSM_CRED_RECODE.ORDER DESC;"
 
 
-
 # ---- qry99_Presentations_Occs ----
-qry99_Presentations_Occs <- 
-"SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC, Sum(tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN) AS SumOfOccsN
+qry99_Presentations_Occs <-
+  "SELECT tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC, Sum(tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.OccsN) AS SumOfOccsN
 FROM (tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union INNER JOIN T_Current_Region_PSSM_Rollup_Codes_BC ON tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Current_Region_PSSM_Code_Rollup = T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup) INNER JOIN T_Current_Region_PSSM_Rollup_Codes ON T_Current_Region_PSSM_Rollup_Codes_BC.Current_Region_PSSM_Code_Rollup_BC = T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup
 GROUP BY tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_Credential, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Age_Group_Rollup_Label, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.Year, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCP4_CD, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.LCIP4_CRED, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Code_Rollup, T_Current_Region_PSSM_Rollup_Codes.Current_Region_PSSM_Name_Rollup, tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.NOC
 HAVING (((tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union.PSSM_CRED) Not Like 'P - %'));"
 
 
 # ---- qry99_Presentations_PPSCI_Graduates ----
-qry99_Presentations_PPSCI_Graduates <- 
-"SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
+qry99_Presentations_PPSCI_Graduates <-
+  "SELECT T_PSSM_CRED_RECODE.PSSM_CRED_Group, Sum(Graduate_Projections.Graduates) AS SumOfGraduates
 FROM Graduate_Projections INNER JOIN T_PSSM_CRED_RECODE ON Graduate_Projections.PSSM_CRED = T_PSSM_CRED_RECODE.PSSM_CRED
 GROUP BY T_PSSM_CRED_RECODE.PSSM_CRED_Group, T_PSSM_CRED_RECODE.ORDER, Graduate_Projections.Year
 HAVING (((Graduate_Projections.Year)='2019/2020'))
 ORDER BY T_PSSM_CRED_RECODE.ORDER;"
 
 # ---- qry9999_NOC_4031_4032 ----
-qry9999_NOC_4031_4032 <- 
-"SELECT [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_Credential AS Expr1, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_CRED AS Expr2, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup AS Expr3, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup_Label AS Expr4, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year AS Expr5, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC AS Expr6, Sum([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].OccsN) AS SumOfOccsN
+qry9999_NOC_4031_4032 <-
+  "SELECT [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_Credential AS Expr1, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_CRED AS Expr2, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup AS Expr3, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup_Label AS Expr4, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year AS Expr5, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC AS Expr6, Sum([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].OccsN) AS SumOfOccsN
 FROM [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16]
 WHERE ((([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9910 And ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9911 And ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].[Current_Region_PSSM_Code_Rollup])<>9999))
 GROUP BY [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_Credential, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].PSSM_CRED, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup_Label, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year, [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC
 HAVING ((([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Age_Group_Rollup)=3) And (([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].Year)='2015/2016') And (([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC)='4031' Or ([tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC)='4032'))
 ORDER BY [tmp_tbl_Q_3d_Occupations_by_LCIP4_CRED_LCP2_Union_2017-05-16].NOC;"
-

--- a/sql/zz-historical/historical-projections.R
+++ b/sql/zz-historical/historical-projections.R
@@ -1,5 +1,5 @@
 # ---- Q_1_Grad_Projections_by_Age_by_Program ----
-Q_1_Grad_Projections_by_Age_by_Program <- 
+Q_1_Grad_Projections_by_Age_by_Program <-
   "SELECT Cohort_Program_Distributions.PSSM_Credential AS PSSM_Credential, 
         Graduate_Projections.PSSM_CRED, 
         Graduate_Projections.Age_Group, 
@@ -26,7 +26,7 @@ WHERE   (((T_Exclude_from_Projections_LCP4_CD.LCIP_LCP4_CD) Is Null)
   AND   ((T_Exclude_from_Projections_LCIP4_CRED.LCIP4_CRED) Is Null));"
 
 # ---- Q_1c_Grad_Projections_by_Program ----
-Q_1c_Grad_Projections_by_Program <- 
+Q_1c_Grad_Projections_by_Program <-
   "SELECT Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential, 
         Q_1_Grad_Projections_by_Age_by_Program.PSSM_CRED, 
         tbl_Age_Groups_Rollup.Age_Group_Rollup, 
@@ -55,7 +55,7 @@ GROUP BY Q_1_Grad_Projections_by_Age_by_Program.PSSM_Credential,
 
 
 # ---- qry99_Presentations_Graduates_Appendix ----
-qry99_Presentations_Graduates_Appendix <- 
+qry99_Presentations_Graduates_Appendix <-
   "SELECT Age_Group_Rollup_Label, PSSM_Credential_Name, 
 [2023/2024], 
 [2024/2025], 


### PR DESCRIPTION
## Summary
This PR is **layer 1 of 5** for splitting source PR #102.

It establishes a **format-only baseline** by applying Air formatting across R/SQL surfaces and adding formatter configuration.

## Scope
- Mechanical formatting updates only (no intended functional changes)
- Formatter config included for repeatable formatting
- Excludes non-format/noise artifacts for clean review