### PR TITLE
docs: analyst summary and repo housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,19 +6,19 @@
 config.yml
 scratch/*
 *_log.txt
-tmp
+tmp/
 *.html
 .github/copilot-instructions.md
-presentations/presentation-06-2026_files/
-.factory/
-tmp/
-.github/agents/*
-.github/instructions/*
-.gitignore
-.claude/
 
+/sql
+
+presentations/presentation-06-2026_files/
+.claude/
 docs/agents/
+.factory/
+AGENTS.md
 *.sh
+
 plan/
 
 scratch/

--- a/R/.gitignore
+++ b/R/.gitignore
@@ -1,3 +1,6 @@
 execution_log.txt
+gender_cleaning.R
 *.txt
 *.csv
+04-graduate-projections-refactor.R
+03-near-completers-ttrain-refactor.R


### PR DESCRIPTION
## Layer 5/5 — docs and housekeeping split from #102

This is the final layer of the 5-part split of PR #102 (`bcgov/post-secondary-supply-model`).

### PR chain
| Layer | PR | Branch |
|---|---|---|
| 1 | #103 | `split/102-01-air-format` |
| 2 | #104 | `split/102-02-logging` |
| 3 | #105 | `split/102-03-stp-2026-loaders` |
| 4 | #106 | `split/102-04-model-fixes` |
| **5** | **this PR** | `jonjunduan-split-102-05-docs-housekeeping` |

### Scope
Docs and `.gitignore` housekeeping only — no functional, model, logging, or formatting changes.

**Source commits from #102:**
- `fa33d4af`, `b84c74c0` — analyst onboarding docs (`docs/project-summary-for-new-analyst.md`, `docs/weights-explained-02b-2-and-02b-3.md`)
- `58009e9f`, `5291b94c`, `257246e3`, `dfe9cf8b`, `74a8b929` — `.gitignore` / `R/.gitignore` housekeeping

### Changes in this PR
- **`.gitignore`** — remove duplicate `tmp` entry; drop stale per-file ignores; add `/sql` section; add `AGENTS.md`; remove self-ignore and `.github/agents/*` / `.github/instructions/*` overrides; fix `tmp` → `tmp/`
- **`R/.gitignore`** — add `gender_cleaning.R`, `04-graduate-projections-refactor.R`, `03-near-completers-ttrain-refactor.R`

> **Note:** The analyst summary docs (`docs/project-summary-for-new-analyst.md`, `docs/weights-explained-02b-2-and-02b-3.md`) were already incorporated into the `split/102-04-model-fixes` base branch as part of the prior layer build. They are part of this layer's conceptual scope but do not appear in this PR's diff.

### Explicit confirmations
- ✅ `debug.log` is **not included** — no runtime artifacts in any cherry-picked commit or in this diff
- ✅ No functional/model/logging/formatting changes