### PR TITLE
feat: load 2027 student outcome survey data (APPSO, TRD, BGS, DACSO)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ AGENTS.md
 plan/
 
 scratch/
+.scratch/
+main.py

--- a/R/02a-bgs-program-matching.R
+++ b/R/02a-bgs-program-matching.R
@@ -105,6 +105,7 @@ log_info("==== 02a-bgs-program-matching.R START ====")
 lan <- config::get("lan")
 db_config <- config::get("decimal")
 my_schema <- config::get("myschema")
+shareschema <- config::get("shareschema")
 
 # Connect to Decimal
 con <- dbConnect(
@@ -118,39 +119,56 @@ log_info("Connected to SQL Server database")
 
 
 # ---- Read in INFOWARE tables ----
-# Note: These tables should be loaded by 'R/load-infoware-lookups.R'
-# source("R/load-infoware-lookups.R")
-# We check for their existence and proceed.
+# The BGS distribution/cohort tables are copied to SQL Server (dbo) by
+# 'R/load-cohort-bgs.R' (or 'R/run-data-loading.R'); the CIP taxonomy tables
+# are copied by 'R/load-infoware-lookups.R' (my_schema).  We check for their
+# existence and proceed.
 
-required_tables <- c(
-  "INFOWARE_BGS_DIST_19_23",
-  "INFOWARE_BGS_DIST_18_22",
-  "INFOWARE_BGS_COHORT_INFO",
+# BGS survey records, in the shared (dbo) schema
+bgs_infoware_tables <- c(
+  "INFOWARE_BGS_DIST_20_24",
+  "INFOWARE_BGS_DIST_21_25",
+  "INFOWARE_BGS_COHORT_INFO"
+)
+
+# CIP taxonomy lookups, in the analyst's own schema
+lookup_tables <- c(
   "INFOWARE_L_CIP_6DIGITS_CIP2016",
   "INFOWARE_L_CIP_4DIGITS_CIP2016",
   "INFOWARE_L_CIP_2DIGITS_CIP2016"
 )
 
-missing_tables <- required_tables[
+missing_bgs <- bgs_infoware_tables[
   !map_lgl(
-    required_tables,
+    bgs_infoware_tables,
+    ~ dbExistsTable(con, Id(schema = shareschema, table = .x))
+  )
+]
+missing_lookups <- lookup_tables[
+  !map_lgl(
+    lookup_tables,
     ~ dbExistsTable(con, Id(schema = my_schema, table = .x))
   )
 ]
 
-if (length(missing_tables) > 0) {
+if (length(missing_bgs) > 0) {
   stop(glue::glue(
-    "The following required tables are missing in schema '{my_schema}': {paste(missing_tables, collapse = ', ')}. Please run 'R/load-infoware-lookups.R' first."
+    "The following required INFOWARE BGS tables are missing in schema '{shareschema}': {paste(missing_bgs, collapse = ', ')}. Please run 'R/load-cohort-bgs.R' first."
+  ))
+}
+if (length(missing_lookups) > 0) {
+  stop(glue::glue(
+    "The following required CIP lookup tables are missing in schema '{my_schema}': {paste(missing_lookups, collapse = ', ')}. Please run 'R/load-infoware-lookups.R' first."
   ))
 }
 log_info("All required INFOWARE tables present in database")
 
 # ---- Table References ----
-infoware_bgs_19_23 <- tbl(con, in_schema(my_schema, "INFOWARE_BGS_DIST_19_23"))
-infoware_bgs_18_22 <- tbl(con, in_schema(my_schema, "INFOWARE_BGS_DIST_18_22"))
+infoware_bgs_20_24 <- tbl(con, in_schema(shareschema, "INFOWARE_BGS_DIST_20_24"))
+infoware_bgs_21_25 <- tbl(con, in_schema(shareschema, "INFOWARE_BGS_DIST_21_25"))
 infoware_cohort_info <- tbl(
   con,
-  in_schema(my_schema, "INFOWARE_BGS_COHORT_INFO")
+  in_schema(shareschema, "INFOWARE_BGS_COHORT_INFO")
 )
 
 cip_6_tbl <- tbl(con, in_schema(my_schema, "INFOWARE_L_CIP_6DIGITS_CIP2016"))
@@ -216,21 +234,21 @@ log_info(
 # We need one consistent table with common field names before matching to STP.
 #
 # Inputs:
-# - INFOWARE_BGS_DIST_19_23
-# - INFOWARE_BGS_DIST_18_22
+# - INFOWARE_BGS_DIST_20_24
+# - INFOWARE_BGS_DIST_21_25
 # - INFOWARE_BGS_COHORT_INFO
 #
 # Output:
 # - T_BGS_Data_Final_for_OutcomesMatching
 #
 # Notes:
-# - The current script takes all years from the 2019–2023 table and only 2018
-#   from the 2018–2022 table.
+# - The current script takes all years from the 2020–2024 table and only 2025
+#   from the 2021–2025 table (2025 is the only year the 20_24 table lacks).
 # - STQU_ID is the safest row-level key for later updates in this table.
 # ------------------------------------------------------------------------------
 
-# Step 1: 2020 Outcomes (from 19_23 table)
-t_bgs_step1 <- infoware_bgs_19_23 %>%
+# Step 1: 2020–2024 Outcomes (from 20_24 table)
+t_bgs_step1 <- infoware_bgs_20_24 %>%
   select(
     STQU_ID,
     RESPONDENT,
@@ -283,9 +301,9 @@ t_bgs_step1 <- infoware_bgs_19_23 %>%
     CPC
   )
 
-# Step 2: 2018 Outcomes (from 18_22 table, filtered for Year 2018)
-t_bgs_step2 <- infoware_bgs_18_22 %>%
-  filter(YEAR == 2018) %>%
+# Step 2: 2025 Outcomes (from 21_25 table, filtered for Year 2025)
+t_bgs_step2 <- infoware_bgs_21_25 %>%
+  filter(YEAR == 2025) %>%
   select(
     STQU_ID,
     RESPONDENT,
@@ -948,7 +966,11 @@ bgs_matching_flagged <- bgs_matching_flagged |>
         (YEAR == 2022 &
           PSI_AWARD_SCHOOL_YEAR %in% c("2019/2020", "2020/2021")) |
         (YEAR == 2023 &
-          PSI_AWARD_SCHOOL_YEAR %in% c("2020/2021", "2021/2022")) ~
+          PSI_AWARD_SCHOOL_YEAR %in% c("2020/2021", "2021/2022")) |
+        (YEAR == 2024 &
+          PSI_AWARD_SCHOOL_YEAR %in% c("2021/2022", "2022/2023")) |
+        (YEAR == 2025 &
+          PSI_AWARD_SCHOOL_YEAR %in% c("2022/2023", "2023/2024")) ~
         "Yes",
       TRUE ~ NA_character_
     )

--- a/R/02b-1-pssm-cohorts.R
+++ b/R/02b-1-pssm-cohorts.R
@@ -150,7 +150,7 @@ trd_data <- trd_data |>
   select(-WEIGHT) |>
   inner_join(
     t_weights |>
-      filter(MODEL == "2022-2023", SURVEY == "TRD") |>
+      filter(MODEL == "2024-2025", SURVEY == "TRD") |>
       select(SUBM_CD, WEIGHT = any_of(target_weight)),
     by = "SUBM_CD"
   ) |>
@@ -314,7 +314,7 @@ t_bgs_data_final <- t_bgs_data_final |>
   select(-WEIGHT, -AGE_GROUP, -AGE_GROUP_ROLLUP) |>
   inner_join(
     t_weights |>
-      filter(MODEL == "2022-2023", SURVEY == "BGS") |>
+      filter(MODEL == "2024-2025", SURVEY == "BGS") |>
       mutate(SURVEY_YEAR = as.double(SURVEY_YEAR)) |>
       select(SURVEY_YEAR, WEIGHT = any_of(target_weight)),
     by = "SURVEY_YEAR"
@@ -460,7 +460,7 @@ t_dacso_data_part_1 <- t_dacso_data_part_1 |>
   select(-WEIGHT) |>
   inner_join(
     t_weights |>
-      filter(MODEL == "2022-2023", SURVEY == "DACSO") |>
+      filter(MODEL == "2024-2025", SURVEY == "DACSO") |>
       select(SUBM_CD, WEIGHT = any_of(target_weight)),
     by = c("COCI_SUBM_CD" = "SUBM_CD")
   ) |>

--- a/R/load-cohort-appso.R
+++ b/R/load-cohort-appso.R
@@ -10,19 +10,61 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+# ---------------------------------------------------------------------------
+# LOAD COHORT - APPSO
+#
+# APPSO = Apprenticeship Student Outcomes.  Survey of former apprenticeship
+# students, conducted roughly two years after they completed (or exited)
+# their program.  These data describe what apprentices are doing after
+# leaving their training (employed / in the labour market / further study /
+# not in the labour force), by training institution, program area (CIP),
+# region, age and credential.
+#
+# This script loads the APPSO survey data from the LAN and writes the cleaned
+# tables to SQL Server (schema = write_schema, database = database/PSSM2025):
+#
+#   t_appso_data_final -> t_appso_data_final_r
+#       Survey responses, one row per respondent per survey cycle.
+#       Consumed by 02b-1-pssm-cohorts.R: joined to survey-cycle and age
+#       look-ups, standardized and stacked into T_Cohorts_Recoded, the master
+#       cohort table that feeds credential analysis (01c-), labour supply
+#       (02b-2) and projections (04-, 06-).
+#
+#   appso_graduates   -> appso_graduates_r
+#       Graduate counts by training program/credential/region, carried
+#       through the cohort modules and used in 04-graduate-projections.R
+#       for the 2-year average and historical forecast of apprentice
+#       graduates.
+#
+# Survey cycle is identified by SUBM_CD (C_Outc21 = 2021 cohort up to
+# C_Outc25 = 2025 cohort).  Weights derived from SUBM_CD scale the survey
+# respondents up to population counts for reporting.
+# Variable dictionary: see data_dictionary_so.csv on the LAN.
+# ---------------------------------------------------------------------------
+
 library(tidyverse)
 library(config)
 library(DBI)
 library(odbc)
+library(futile.logger)
 
-# qi_run <- F
-# regular_run <- T
-# ptib_run <- F
+## -------------------------- Logging Setup ------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== load-cohort-appso.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-my_schema <- config::get("myschema")
+write_schema <- config::get("shareschema")
 db_config <- config::get("decimal")
 
 con <- dbConnect(
@@ -35,22 +77,36 @@ con <- dbConnect(
 
 lan <- config::get("lan")
 
+log_info("Connected to SQL Server database (decimal)")
+
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
 
 # source(glue::glue("./sql/02b-pssm-cohorts/appso-data.sql"))
+# Read the APPSO survey responses from the LAN (source: query
+# APPSO_Data_01_Final in the LAN sql/ folder).  One row per respondent per
+# survey cycle; SUBM_CD gives the cycle (C_Outc21..C_Outc25).
 t_appso_data_final <- read_csv(glue::glue(
-  "{lan}/data/student-outcomes/csv/so-provision/APPSO_DATA_01_Final.csv"
+  "{lan}/data/student-outcomes/csv/APPSO_Data_01_Final.csv"
 ))
+log_info(glue::glue("Read APPSO_Data_01_Final.csv: {nrow(t_appso_data_final)} rows"))
+# Read the apprenticeship graduate counts (used in 04-graduate-projections
+# for the 2-year average / historical forecast of APPSO graduates).
 appso_graduates <- read_csv(glue::glue(
-  "{lan}/data/student-outcomes/csv/so-provision/APPSO_Graduates.csv"
+  "{lan}/data/student-outcomes/csv/APPSO_Graduates.csv"
 ))
+log_info(glue::glue("Read APPSO_Graduates.csv: {nrow(appso_graduates)} rows"))
 
 # Convert some variables that should be numeric
+# TTRAIN = total months of apprenticeship training; needed as numeric for
+# calculations in the labour supply modules.
 t_appso_data_final <- t_appso_data_final %>%
   mutate(TTRAIN = as.numeric(TTRAIN))
 
 # Make sure this is updated to only the last 6 years of data
+# Recode the survey's current-region fields (CURRENT_REGION1/CURRENT_REGION4)
+# into the standard PSSM region codes used across all modules
+# (see T_Current_Region_PSSM_Codes / roll-ups in 02b-2).
 t_appso_data_final <-
   t_appso_data_final %>%
   mutate(
@@ -63,6 +119,7 @@ t_appso_data_final <-
       TRUE ~ NA
     )
   ) %>%
+  # AGE_GROUP_LABEL: reporting labels for the standard PSSM age bands.
   mutate(
     AGE_GROUP_LABEL = case_when(
       APP_AGE_AT_SURVEY %in% 15:16 ~ "15 to 16",
@@ -77,6 +134,9 @@ t_appso_data_final <-
       TRUE ~ NA
     )
   ) %>%
+  # AGE_GROUP: numeric code for the same bands (2-8).  In 02b-1-pssm-cohorts.R
+  # this key is used to join TBL_AGE_GROUPS so every cohort gets a standard
+  # age grouping across survey types.
   mutate(
     AGE_GROUP = case_when(
       APP_AGE_AT_SURVEY %in% 17:19 ~ 2,
@@ -89,6 +149,9 @@ t_appso_data_final <-
       TRUE ~ NA
     )
   ) %>%
+  # NEW_LABOUR_SUPPLY: 1 if the respondent is employed or in the labour
+  # market, 0 otherwise.  Used in 02b-2-pssm-cohorts-new-labour-supply.R to
+  # estimate the share of new graduates entering the labour market.
   mutate(
     NEW_LABOUR_SUPPLY = case_when(
       APP_LABR_EMPLOYED == 1 ~ 1,
@@ -101,38 +164,52 @@ t_appso_data_final <-
 
 # When running, make sure to update weights for the regular run.
 # Replace the weights in the appropriate area in the code (~lines 71-77):
+# Weight values for C_Outc21..C_Outc25 still require analyst sign-off.
+# WEIGHT scales each survey cycle's respondents up to population counts for
+# reporting (larger cycle number = more recent cycle).  The same weighting
+# scheme applies to the other survey types via T_Weights.
 t_appso_data_final <-
   t_appso_data_final %>%
   mutate(
     WEIGHT = case_when(
-      SUBM_CD == 'C_Outc19' ~ 1,
-      SUBM_CD == 'C_Outc20' ~ 2,
-      SUBM_CD == 'C_Outc21' ~ 3,
-      SUBM_CD == 'C_Outc22' ~ 4,
-      SUBM_CD == 'C_Outc23' ~ 5,
+      SUBM_CD == 'C_Outc21' ~ 1,
+      SUBM_CD == 'C_Outc22' ~ 2,
+      SUBM_CD == 'C_Outc23' ~ 3,
+      SUBM_CD == 'C_Outc24' ~ 4,
+      SUBM_CD == 'C_Outc25' ~ 5,
       TRUE ~ 0
     )
   )
 
 # update the weights for the QI run.
-if (qi_run == TRUE) {
+# Quality Improvement run: re-weight excluding the most recent survey cycle
+# (C_Outc25 -> 0) so the QI run only uses the cycles shared with the
+# previous model run.
+if (exists("qi_run") && qi_run == TRUE) {
   # check that these years are correct
   # TODO: this moved out of query for derived weights  but means an extra step for QI - move back to query design?
   t_appso_data_final <-
     t_appso_data_final %>%
     mutate(
       WEIGHT = case_when(
-        SUBM_CD == 'C_Outc19' ~ 2,
-        SUBM_CD == 'C_Outc20' ~ 3,
-        SUBM_CD == 'C_Outc21' ~ 4,
-        SUBM_CD == 'C_Outc22' ~ 5,
-        SUBM_CD == 'C_Outc23' ~ 0,
+        SUBM_CD == 'C_Outc21' ~ 2,
+        SUBM_CD == 'C_Outc22' ~ 3,
+        SUBM_CD == 'C_Outc23' ~ 4,
+        SUBM_CD == 'C_Outc24' ~ 5,
+        SUBM_CD == 'C_Outc25' ~ 0,
         TRUE ~ 0
       )
     )
+  log_info("QI run: QI weights applied to APPSO data")
 }
 
+log_info(glue::glue(
+  "t_appso_data_final prepared: {nrow(t_appso_data_final)} rows, weights applied"
+))
+
 # prepare graduate dataset
+# Add the standard PSSM age-band labels to the graduate counts so they can be
+# reported consistently; used in 04-graduate-projections.R.
 appso_graduates %>%
   mutate(
     AGE_GROUP = case_when(
@@ -148,6 +225,7 @@ appso_graduates %>%
       TRUE ~ NA
     )
   ) -> appso_graduates
+log_info(glue::glue("appso_graduates prepared: {nrow(appso_graduates)} rows"))
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -162,16 +240,32 @@ tables_to_keep <- c(
   "t_appso_data_final"
 )
 
+# Write each kept table to SQL Server as <name>_r.  Downstream scripts
+# (02b-1-pssm-cohorts.R etc.) pick them up by object name from the loading
+# sequence in run-data-loading.R / run-data-preprocessing.R.
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
+  # Some source files contain invalid UTF-8 byte sequences (e.g. PROGRAM
+  # names), which make odbcDataType()/nchar() fail when writing.  Strip
+  # invalid bytes from all character columns before writing.
+  data <- base::get(table_name, envir = .GlobalEnv) %>%
+    mutate(across(
+      where(is.character),
+      ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+    ))
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    data,
     overwrite = TRUE
   )
 }
 
-walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+walk(tables_to_keep, write_table_to_db, schema = write_schema, con = con)
+log_info(glue::glue(
+  "Written to SQL Server ({write_schema}): {paste0(tables_to_keep, '_r', collapse = ', ')}"
+))
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server database")
+log_info("==== load-cohort-appso.R END ====")

--- a/R/load-cohort-bgs.R
+++ b/R/load-cohort-bgs.R
@@ -19,7 +19,7 @@
 # This script does two things:
 #
 # 1) Copies the INFOWARE (Oracle) BGS distribution/cohort tables into SQL
-#    Server (schema = write_schema, database = decimal/PSSM2025) as
+#    Server (schema = shareschema/dbo, database = decimal/PSSM2025) as
 #    INFOWARE_BGS_* tables.  These are the BGS survey records used by
 #    02a-bgs-program-matching.R to assign programs (CIP codes) to BGS
 #    graduates.
@@ -100,15 +100,15 @@ log_info("Connected to INFOWARE (Oracle)")
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-# ---- Load INFOWARE BGS tables to Decimal (dbo) ----
+# ---- Load INFOWARE BGS tables to SQL Server (dbo / shareschema) ----
 # Read BGS distribution/cohort tables from the INFOWARE (Oracle) database and write
 # them to SQL Server. Chunked writes because the full datasets are too large for
 # a single dbWriteTable call.
-# BGS_DIST_18_22 / 19_23 / 20_24 and BGS_21_25 = rolling six-year windows of
+# BGS_DIST_20_24 / 21_25 = rolling six-year windows of
 # BGS survey records; BGS_COHORT_INFO = BGS cohort information.  All are used
-# by 02a-bgs-program-matching.R to assign programs (CIP codes) to BGS
-# graduates.  Source names in INFOWARE = table name minus the INFOWARE_
-# prefix (e.g. INFOWARE_BGS_DIST_19_23 <- INFOWARE.BGS_DIST_19_23).
+# by 02a-bgs-program-matching.R (reads them from dbo) to assign programs
+# (CIP codes) to BGS graduates.  Source names in INFOWARE = table name minus
+# the INFOWARE_ prefix (e.g. INFOWARE_BGS_DIST_20_24 <- INFOWARE.BGS_DIST_20_24).
 
 # Load one INFOWARE table into SQL Server in chunks of chunk_size rows.
 # Skips (without overwriting) if the target table already exists.
@@ -162,10 +162,9 @@ load_infoware_table_by_chunk <- function(
 }
 
 # The INFOWARE BGS tables to copy over (first chunk writes the table,
-# subsequent chunks append).
+# subsequent chunks append).  Written to dbo (shareschema) because
+# 02a-bgs-program-matching.R reads them from there.
 bgs_infoware_tables <- c(
-  # "INFOWARE_BGS_DIST_18_22",
-  # "INFOWARE_BGS_DIST_19_23",
   "INFOWARE_BGS_DIST_20_24",
   "INFOWARE_BGS_DIST_21_25",
   "INFOWARE_BGS_COHORT_INFO"

--- a/R/load-cohort-bgs.R
+++ b/R/load-cohort-bgs.R
@@ -13,32 +13,63 @@
 # This script loads student outcomes data for students who students who recently graduated with a
 # Baccalaureate degree (Baccalaureate students are surveyed two years after graduation)
 #
-# The following data set is read from SQL server database:
-#   bgs_data_update: unique survey responses for each person/survey year (for years since last model run)
+# BGS = Baccalaureate Graduate Student Outcomes.  Survey of graduates with a
+# bachelor's degree, conducted roughly two years after graduation.
 #
-# The following data sets are read into SQL server from the LAN:
-#   T_BGS_Data: unique survey responses for each person/survey year (last model run)
-#   T_weights: carried forward from last models run and updated with new data.  Waiting for confirmation
-#   T_BGS_INST_Re-code: look-up used to re-code several institution codes
+# This script does two things:
 #
-# Notes: T_BGS_Data +  bgs_data_update contain the full set of survey responses used.
-# T_BGS_Data_Final_2017.csv used for 2019 model run, T_BGS_Data_Final.csv for 2023 model run (rollover)
-# Some changes to variable names were done for consistency and will be needed when using 2023 BGS_Data_Final
-# use query BGS_Q001_BGS_Data_2019_2023 for 2023 model run but note overlapping years (2019)
+# 1) Copies the INFOWARE (Oracle) BGS distribution/cohort tables into SQL
+#    Server (schema = write_schema, database = decimal/PSSM2025) as
+#    INFOWARE_BGS_* tables.  These are the BGS survey records used by
+#    02a-bgs-program-matching.R to assign programs (CIP codes) to BGS
+#    graduates.
+#
+# 2) Reads the BGS survey responses + look-ups from the LAN and writes the
+#    cleaned tables to SQL Server (dbo):
+#
+#    t_bgs_data_final -> t_bgs_data_final_r
+#        Unique survey responses for each person/survey year (2021-2025
+#        cycles for the 2027 model run).  Consumed by
+#        02b-1-pssm-cohorts.R: institution re-code, CIP updates from program
+#        matching, weights, labour supply, then stacked into
+#        T_Cohorts_Recoded (master cohort table feeding credential analysis
+#        01c-, labour supply 02b-2 and projections 04-/06-).
+#
+#    t_weights -> t_weights_r
+#        Weights by model run / survey type / survey cycle.  Carried forward
+#        from the last model run and updated with new data.  Applied to the
+#        TRD, DACSO and BGS cohorts in 02b-1-pssm-cohorts.R.
+#
+#    t_bgs_inst_recode -> t_bgs_inst_recode_r
+#        Look-up used to re-code several institution codes; joined to the
+#        BGS cohort in 02b-1-pssm-cohorts.R.
+#
+# Notes: use query BGS_Q001_BGS_Data_2021_2025 (see LAN sql/ folder) for the 2027 model run.
+# Some changes to variable names were done for consistency with the 2021-2025 file.
 
 library(tidyverse)
 library(config)
 library(DBI)
 library(odbc)
+library(futile.logger)
 
-# regular_run <- T
-# qi_run <- F
-# ptib_run <- F
+## -------------------------- Logging Setup ------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== load-cohort-bgs.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-my_schema <- config::get("myschema")
+write_schema <- config::get("shareschema")
 
 db_config <- config::get("decimal")
 con <- dbConnect(
@@ -51,17 +82,113 @@ con <- dbConnect(
 
 lan <- config::get("lan")
 
+log_info("Connected to SQL Server database (decimal)")
+
+#  ---- Connect to INFOWARE (Oracle) ----
+# Requires the "Oracle in instantclient_19c" ODBC driver to be installed.
+iw_config <- config::get("infoware")
+odbcListDrivers() # confirm available drivers / Oracle client is present
+iw_con <- dbConnect(
+  odbc::odbc(),
+  Driver = "Oracle in instantclient_19c",
+  DBQ = iw_config$dbq,
+  UID = iw_config$uid,
+  PWD = iw_config$pwd
+)
+log_info("Connected to INFOWARE (Oracle)")
+
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-# ---- Read T_BGS_Data_Final from SQL Server ----
-t_bgs_data_final_for_outcomesmatching <- dbReadTable(
+# ---- Load INFOWARE BGS tables to Decimal (dbo) ----
+# Read BGS distribution/cohort tables from the INFOWARE (Oracle) database and write
+# them to SQL Server. Chunked writes because the full datasets are too large for
+# a single dbWriteTable call.
+# BGS_DIST_18_22 / 19_23 / 20_24 and BGS_21_25 = rolling six-year windows of
+# BGS survey records; BGS_COHORT_INFO = BGS cohort information.  All are used
+# by 02a-bgs-program-matching.R to assign programs (CIP codes) to BGS
+# graduates.  Source names in INFOWARE = table name minus the INFOWARE_
+# prefix (e.g. INFOWARE_BGS_DIST_19_23 <- INFOWARE.BGS_DIST_19_23).
+
+# Load one INFOWARE table into SQL Server in chunks of chunk_size rows.
+# Skips (without overwriting) if the target table already exists.
+load_infoware_table_by_chunk <- function(
+  iw_con,
   con,
-  Id(schema = my_schema, table = "t_bgs_data_final_for_outcomesmatching")
+  table_name,
+  write_schema,
+  chunk_size = 80000
+) {
+  target <- DBI::Id(schema = write_schema, table = table_name)
+
+  if (dbExistsTable(con, target)) {
+    log_info(glue::glue(
+      "Table {write_schema}.{table_name} already exists; skipping"
+    ))
+    return(invisible(FALSE))
+  }
+
+  source_table <- sub("^INFOWARE_", "", table_name)
+  data <- dbReadTable(
+    iw_con,
+    DBI::Id(schema = "INFOWARE", table = source_table)
+  )
+
+  # Some values in the Oracle source contain invalid UTF-8 byte sequences
+  # (e.g. NOC_5_DIGIT_CODE_AND_NAME), which make odbcDataType()/nchar() fail
+  # when writing.  Strip invalid bytes from all character columns.
+  data <- data %>%
+    mutate(across(
+      where(is.character),
+      ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+    ))
+
+  n <- nrow(data)
+  starts <- seq(1, n, by = chunk_size)
+  for (i in seq_along(starts)) {
+    rows <- starts[i]:min(starts[i] + chunk_size - 1, n)
+    dbWriteTable(
+      con,
+      target,
+      data[rows, ],
+      append = i > 1
+    )
+  }
+
+  log_info(glue::glue(
+    "Loaded {n} rows from INFOWARE.{source_table} to {write_schema}.{table_name}"
+  ))
+  invisible(TRUE)
+}
+
+# The INFOWARE BGS tables to copy over (first chunk writes the table,
+# subsequent chunks append).
+bgs_infoware_tables <- c(
+  # "INFOWARE_BGS_DIST_18_22",
+  # "INFOWARE_BGS_DIST_19_23",
+  "INFOWARE_BGS_DIST_20_24",
+  "INFOWARE_BGS_DIST_21_25",
+  "INFOWARE_BGS_COHORT_INFO"
 )
+# We load six years of data for the analaysis/model run.
+walk(
+  bgs_infoware_tables,
+  load_infoware_table_by_chunk,
+  iw_con = iw_con,
+  con = con,
+  write_schema = write_schema
+)
+
+dbDisconnect(iw_con)
+log_info("Disconnected from INFOWARE (Oracle)")
 
 # ---- Read LAN Data ----
 # Lookups
+# Weights by model run / survey type / survey cycle (Weight = regular run,
+# WeightQI = QI run).  Carried forward from the last model run and applied to
+# the TRD, DACSO and BGS cohorts in 02b-1-pssm-cohorts.R (weights scale
+# survey respondents up to population counts for reporting).
+# the weights are updated with 24-25 survey data for the 2027 model run, but need to be verified.
 t_weights <-
   readr::read_csv(
     glue::glue("{lan}/development/csv/gh-source/lookups/02/T_Weights.csv"),
@@ -72,8 +199,12 @@ t_weights <-
       .default = col_character()
     )
   ) %>%
-  janitor::clean_names(case = "all_caps")
+  janitor::clean_names(case = "all_caps") |>
+  arrange(MODEL, SURVEY, SURVEY_YEAR)
 
+# Look-up used for region re-coding: maps each institution to its current
+# PSSM region (CURRENT_REGION_PSSM).  Used below as a fallback for BGS
+# records whose survey region is missing/unknown.
 tmp_bgs_inst_cds <-
   readr::read_csv(
     glue::glue(
@@ -83,6 +214,9 @@ tmp_bgs_inst_cds <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Look-up used to re-code several BGS institution codes to their current
+# code.  Joined in 02b-1-pssm-cohorts.R so older institution codes are
+# consolidated before weights are applied.
 t_bgs_inst_recode <-
   readr::read_csv(
     glue::glue(
@@ -94,52 +228,75 @@ t_bgs_inst_recode <-
 
 
 # ---- Read Outcomes Data ----
-if (regular_run == T | ptib_run == T) {
-  bgs_data_update <- read_csv(glue::glue(
-    "{lan}/data/student-outcomes/csv/so-provision/BGS_Q001_BGS_Data_2019_2023.csv"
-  ))
+# BGS survey responses, one row per person per survey year (2021-2025
+# cycles).  STQU_ID identifies the survey submission; SURVEY_YEAR dates the
+# cycle.
+bgs_data_update <- read_csv(glue::glue(
+  "{lan}/data/student-outcomes/csv/BGS_Q001_BGS_Data_2021_2025.csv"
+))
+log_info(glue::glue(
+  "Read BGS_Q001_BGS_Data_2021_2025.csv: {nrow(bgs_data_update)} rows"
+))
 
-  bgs_data_update <- bgs_data_update %>%
-    rename(
-      "FULL_TM_WRK" = FULL_TM,
-      "FULL_TM_SCHOOL" = D03_STUDYING_FT,
-      "IN_LBR_FRC" = LBR_FRC_LABOUR_MARKET,
-      "EMPLOYED" = LBR_FRC_CURRENTLY_EMPLOYED,
-      "UNEMPLOYED" = LBR_FRC_UNEMPLOYED,
-      "TRAINING_RELATED" = E10_IN_TRAINING_RELATED_JOB,
-      "TOOK_FURTH_ED" = D01_R1
-    ) %>% # this can be added to original query
-    mutate(AGE_17_34 = if_else(between(AGE, 17, 34), 1, 0)) %>%
-    mutate(OLD_LABOUR_SUPPLY = NA) %>% # I don't think we use this?
-    select(-c(D02_R1_CURRENTLY_STUDYING, SUBM_CD)) # nor these?
+# Rename to the variable names used by the rest of the model (the source
+# query used different names for the 2021-2025 file):
+#   FULL_TM_WRK = working full-time, IN_LBR_FRC = in the labour force,
+#   EMPLOYED / UNEMPLOYED = labour force status, TRAINING_RELATED = job
+#   related to the field of study, TOOK_FURTH_ED = took further education.
+# AGE_17_34 flags the young worker age band used for labour supply reporting;
+# OLD_LABOUR_SUPPLY is a legacy placeholder not used downstream.
+# PFST_CURRENTLY_STUDYING and SUBM_CD are dropped as not used downstream.
+bgs_data_update <- bgs_data_update %>%
+  rename(
+    "FULL_TM_WRK" = FULL_TM,
+    "IN_LBR_FRC" = LBR_FRC_LABOUR_MARKET,
+    "EMPLOYED" = LBR_FRC_CURRENTLY_EMPLOYED,
+    "UNEMPLOYED" = LBR_FRC_UNEMPLOYED,
+    "TRAINING_RELATED" = E10_IN_TRAINING_RELATED_JOB,
+    "TOOK_FURTH_ED" = D01_R1
+  ) %>% # this can be added to original query
+  mutate(AGE_17_34 = if_else(between(AGE, 17, 34), 1, 0)) %>%
+  mutate(OLD_LABOUR_SUPPLY = NA) %>% # I don't think we use this?
+  select(-c(PFST_CURRENTLY_STUDYING, SUBM_CD)) # nor these?
 
-  bgs_data_update <- bgs_data_update %>%
-    mutate(
-      CURRENT_REGION_PSSM_CODE = case_when(
-        REGION_CD %in% 1:8 ~ REGION_CD,
-        CURRENT_REGION %in% c(6, 9, 10) ~ 10,
-        CURRENT_REGION == 7 ~ 11,
-        CURRENT_REGION == 5 ~ 9,
-        CURRENT_REGION == 8 ~ -1,
-        TRUE ~ NA
-      )
+# Recode the survey's current-region fields into the standard PSSM region
+# codes (same scheme as APPSO/DACSO/TRD so regions are comparable across
+# cohorts; used for region-level outputs in 02b-1/02b-2).
+bgs_data_update <- bgs_data_update %>%
+  mutate(
+    CURRENT_REGION_PSSM_CODE = case_when(
+      REGION_CD %in% 1:8 ~ REGION_CD,
+      CURRENT_REGION %in% c(6, 9, 10) ~ 10,
+      CURRENT_REGION == 7 ~ 11,
+      CURRENT_REGION == 5 ~ 9,
+      CURRENT_REGION == 8 ~ -1,
+      TRUE ~ NA
     )
+  )
 
-  bgs_data_update <- bgs_data_update %>%
-    inner_join(tmp_bgs_inst_cds, by = join_by(INST)) %>%
-    mutate(
-      CURRENT_REGION_PSSM_CODE = if_else(
-        (CURRENT_REGION_PSSM_CODE == -1 | is.na(CURRENT_REGION_PSSM_CODE)) &
-          (SRV_Y_N == 0 | is.na(SRV_Y_N)),
-        as.numeric(CURRENT_REGION_PSSM),
-        CURRENT_REGION_PSSM_CODE
-      )
+# Fallback: where the survey region is missing/unknown (-1/NA) and the
+# graduate was NOT served by the institution (SRV_Y_N == 0), take the
+# institution's current PSSM region from the tmp_BGS_INST_REGION_CDS
+# look-up instead.
+bgs_data_update <- bgs_data_update %>%
+  inner_join(tmp_bgs_inst_cds, by = join_by(INST)) %>%
+  mutate(
+    CURRENT_REGION_PSSM_CODE = if_else(
+      (CURRENT_REGION_PSSM_CODE == -1 | is.na(CURRENT_REGION_PSSM_CODE)) &
+        (SRV_Y_N == 0 | is.na(SRV_Y_N)),
+      as.numeric(CURRENT_REGION_PSSM),
+      CURRENT_REGION_PSSM_CODE
     )
+  )
 
-  # ---- Make T_BGS_Data_Final ----
-  t_bgs_data_final <- bgs_data_update %>%
-    select(-c(CUR_RES, REGION_CD, CURRENT_REGION))
-}
+# ---- Make T_BGS_Data_Final ----
+# Drop the raw region variables now that CURRENT_REGION_PSSM_CODE is set.
+# t_bgs_data_final is the BGS cohort consumed by 02b-1-pssm-cohorts.R.
+t_bgs_data_final <- bgs_data_update %>%
+  select(-c(CUR_RES, REGION_CD, CURRENT_REGION))
+log_info(glue::glue(
+  "t_bgs_data_final prepared: {nrow(t_bgs_data_final)} rows"
+))
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -151,22 +308,38 @@ if (regular_run == T | ptib_run == T) {
 
 tables_to_keep <- c(
   "t_bgs_data_final",
-  "t_bgs_data_final_for_outcomesmatching",
   "t_weights",
   "t_bgs_inst_recode" #,
   #"tmp_bgs_inst_cds"
 )
 
+# Write each kept table to SQL Server as <name>_r.  Downstream scripts
+# (02b-1-pssm-cohorts.R etc.) pick them up by object name from the loading
+# sequence in run-data-loading.R / run-data-preprocessing.R.  tmp_bgs_inst_cds
+# is used only here (region fallback), so it is not written out.
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
+  # Some source files contain invalid UTF-8 byte sequences (e.g. PROGRAM
+  # names), which make odbcDataType()/nchar() fail when writing.  Strip
+  # invalid bytes from all character columns before writing.
+  data <- base::get(table_name, envir = .GlobalEnv) %>%
+    mutate(across(
+      where(is.character),
+      ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+    ))
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    data,
     overwrite = TRUE
   )
 }
 
-walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+walk(tables_to_keep, write_table_to_db, schema = write_schema, con = con)
+log_info(glue::glue(
+  "Written to SQL Server ({write_schema}): {paste0(tables_to_keep, '_r', collapse = ', ')}"
+))
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server database")
+log_info("==== load-cohort-bgs.R END ====")

--- a/R/load-cohort-dacso.R
+++ b/R/load-cohort-dacso.R
@@ -13,6 +13,18 @@
 # This script loads student outcomes data for students who students who recently graduated after
 # completing programs at public colleges, institutes, and teaching-intensive universities (~18 months prior)
 #
+# DACSO = Diploma / Associate Certificate Student Outcomes.  Survey of former
+# students of public colleges, institutes and teaching-intensive universities,
+# conducted roughly 18 months after graduation.
+#
+# This script reads survey responses + all the look-ups they need, prepares a
+# first-cut DACSO table and writes everything to SQL Server
+# (schema = write_schema, database = database/PSSM2025) as <name>_r tables.
+# Downstream, 02b-1-pssm-cohorts.R builds the full DACSO cohort from these
+# tables and refreshes the DACSO records in T_Cohorts_Recoded (the master
+# cohort table feeding credential analysis 01c-, labour supply 02b-2 and
+# projections 04-/06-).
+#
 # The following data-set is read from SQL server database:
 #   t_dacso_data_part_1_stepa: unique survey responses for each person/survey year (for years since last model run)
 #   infoware_c_outc_clean_short_resp:
@@ -38,16 +50,25 @@ library(tidyverse)
 library(config)
 library(DBI)
 library(odbc)
+library(futile.logger)
 
-# regular_run <- T
-# qi_run <- F
-# ptib_run <- F
+## -------------------------- Logging Setup ------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== load-cohort-dacso.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-my_schema <- config::get("myschema")
-
+write_schema <- config::get("shareschema")
 db_config <- config::get("decimal")
 con <- dbConnect(
   odbc::odbc(),
@@ -59,13 +80,28 @@ con <- dbConnect(
 
 lan <- config::get("lan")
 
+log_info("Connected to SQL Server database (decimal)")
+
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
 
+# Survey responses from INFOWARE (Oracle), one row per respondent per survey
+# cycle.  Carried through to 02b-1-pssm-cohorts.R where it supplies follow-up
+# flags (Q08 = had post-secondary training before this program;
+# PFST_HAD_PREVIOUS_CDTL, PFST_FURSTDY_INCL_STILL_ATTD) used to derive
+# HAD_PREVIOUS_CREDENTIAL / PFST_IN_POST_SEC_BEFORE for the DACSO cohort.
 infoware_c_outc_clean_short_resp <- read_csv(glue::glue(
-  "{lan}/data/student-outcomes/csv/so-provision/infoware_c_outc_clean_short_resp.csv"
+  "{lan}/data/student-outcomes/csv/infoware_c_outc_clean_short_resp.csv"
+))
+log_info(glue::glue(
+  "Read infoware_c_outc_clean_short_resp.csv: {nrow(infoware_c_outc_clean_short_resp)} rows"
 ))
 
+# Age look-ups: TBL_AGE assigns each age to an AGE_GROUP code and
+# TBL_AGE_GROUPS adds the group label + AGE_GROUP_ROLLUP.  Used in
+# 02b-1-pssm-cohorts.R for every survey type (DACSO, APPSO, BGS) so age is
+# grouped identically across cohorts.  TBL_AGE_GROUPS_ROLLUP is the
+# coarser rollup used for reporting.
 tbl_age_groups <-
   readr::read_csv(
     glue::glue("{lan}/development/csv/gh-source/lookups/02/tbl_Age_Groups.csv"),
@@ -89,6 +125,10 @@ tbl_age <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Static look-up that maps each institution's program credential
+# (PRGM_CREDENTIAL_AWARDED) to the standard PSSM credential.  Used in
+# 02b-1-pssm-cohorts.R to label credentials and to drop credentials excluded
+# from the model (DACSO_INCLUDE_IN_MODEL = NA).
 t_pssm_credential_grouping <-
   readr::read_csv(
     glue::glue(
@@ -98,15 +138,22 @@ t_pssm_credential_grouping <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Maps each survey cycle code (SUBM_CD) to the calendar year it surveyed
+# (SURVEY_YEAR), per survey type (SURVEY = DACSO/APPSO/BGS).  Used in
+# 02b-1-pssm-cohorts.R to date every cohort record before it enters
+# T_Cohorts_Recoded.
 t_year_survey_year <-
   readr::read_csv(
     glue::glue(
-      "{lan}/development/csv/gh-source/lookups/02/t_year_survey_year.csv"
+      "{lan}/development/csv/gh-source/lookups/02/T_Year_Survey_Year.csv"
     ),
     col_types = cols(.default = col_guess())
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# Empty column template (n_max = 1 row, then dropped) with the exact column
+# names/types of the master T_Cohorts_Recoded table.  Used by downstream
+# modules as the structure to rbind each cohort onto.
 t_cohorts_recoded <-
   readr::read_csv(
     glue::glue(
@@ -131,6 +178,10 @@ t_cohorts_recoded <-
   janitor::clean_names(case = "all_caps") |>
   filter(FALSE)
 
+# Region look-ups: re-code the survey's current-region fields to the standard
+# PSSM region codes (T_Current_Region_PSSM_Codes), then roll them up
+# (Rollup_Codes) and to the BC level (Rollup_Codes_BC).  Used throughout
+# 02b-1/02b-2 for region-level outputs.
 t_current_region_pssm_codes <-
   readr::read_csv(
     glue::glue(
@@ -158,6 +209,9 @@ t_current_region_pssm_rollup_codes_bc <-
   ) %>%
   janitor::clean_names(case = "all_caps")
 
+# NOC (National Occupational Classification) broad-category look-up.  Used in
+# 02b-2-pssm-cohorts-new-labour-supply.R to build the labour supply
+# distribution by broad occupation group.
 t_noc_broad_categories <-
   readr::read_csv(
     glue::glue(
@@ -168,35 +222,45 @@ t_noc_broad_categories <-
   janitor::clean_names(case = "all_caps")
 
 
-if (regular_run == T | ptib_run == T) {
-  t_dacso_data_part_1_stepa <- readr::read_csv(
-    glue::glue(
-      "{lan}/data/student-outcomes/csv/so-provision/DACSO_Q003_DACSO_DATA_Part_1_stepA.csv"
+# Main DACSO survey responses, one row per respondent per survey cycle.
+# Sub-cycle is COCI_SUBM_CD (C_Outc..); COCI_STQU_ID identifies the survey
+# submission.  In 02b-1-pssm-cohorts.R this is joined to the credential,
+# age and weight look-ups and becomes the DACSO block of T_Cohorts_Recoded.
+t_dacso_data_part_1_stepa <- readr::read_csv(
+  glue::glue(
+    "{lan}/data/student-outcomes/csv/DACSO_Q003_DACSO_DATA_Part_1_stepA.csv"
+  )
+)
+log_info(glue::glue(
+  "Read DACSO_Q003_DACSO_DATA_Part_1_stepA.csv: {nrow(t_dacso_data_part_1_stepa)} rows"
+))
+
+# Recode the survey's current-region fields into the standard PSSM region
+# codes (same scheme as APPSO/BGS so regions are comparable across cohorts).
+t_dacso_data_part_1_stepa <- t_dacso_data_part_1_stepa |>
+  mutate(
+    CURRENT_REGION_PSSM_CODE = case_when(
+      TPID_CURRENT_REGION1 %in%
+        c(1, 2, 3, 4, 5, 6, 7, 8) ~ TPID_CURRENT_REGION1,
+      TPID_CURRENT_REGION4 == 5 ~ 9,
+      TPID_CURRENT_REGION4 == 6 ~ 10,
+      TPID_CURRENT_REGION4 == 7 ~ 11,
+      TPID_CURRENT_REGION4 == 8 ~ -1,
+      TRUE ~ NA_integer_
     )
   )
-
-  t_dacso_data_part_1_stepa <- t_dacso_data_part_1_stepa |>
-    mutate(
-      CURRENT_REGION_PSSM_CODE = case_when(
-        TPID_CURRENT_REGION1 %in%
-          c(1, 2, 3, 4, 5, 6, 7, 8) ~ TPID_CURRENT_REGION1,
-        TPID_CURRENT_REGION4 == 5 ~ 9,
-        TPID_CURRENT_REGION4 == 6 ~ 10,
-        TPID_CURRENT_REGION4 == 7 ~ 11,
-        TPID_CURRENT_REGION4 == 8 ~ -1,
-        TRUE ~ NA_integer_
-      )
-    )
-  # commenting these out for now - see PR
-  #|>
-  #mutate(
-  #  TTRAIN = NA_integer_,
-  #  LABR_EMPLOYED = NA_integer_,
-  #  COSC_GRAD_STATUS_LGDS_CD = NA_integer_,
-  #  COSC_GRAD_STATUS_LGDS_CD_GROUP = NA_integer_,
-  #  RESPONDENT = NA_integer_,
-  #)
-}
+log_info(glue::glue(
+  "CURRENT_REGION_PSSM_CODE assigned: {nrow(t_dacso_data_part_1_stepa)} rows"
+))
+# commenting these out for now - see PR
+#|>
+#mutate(
+#  TTRAIN = NA_integer_,
+#  LABR_EMPLOYED = NA_integer_,
+#  COSC_GRAD_STATUS_LGDS_CD = NA_integer_,
+#  COSC_GRAD_STATUS_LGDS_CD_GROUP = NA_integer_,
+#  RESPONDENT = NA_integer_,
+#)
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -221,16 +285,32 @@ tables_to_keep <- c(
   "t_noc_broad_categories"
 )
 
+# Write each kept table to SQL Server as <name>_r.  Downstream scripts
+# (02b-1-pssm-cohorts.R etc.) pick them up by object name from the loading
+# sequence in run-data-loading.R / run-data-preprocessing.R.
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
+  # Some source files contain invalid UTF-8 byte sequences (e.g. PROGRAM
+  # names), which make odbcDataType()/nchar() fail when writing.  Strip
+  # invalid bytes from all character columns before writing.
+  data <- base::get(table_name, envir = .GlobalEnv) %>%
+    mutate(across(
+      where(is.character),
+      ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+    ))
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    data,
     overwrite = TRUE
   )
 }
 
-walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+walk(tables_to_keep, write_table_to_db, schema = write_schema, con = con)
+log_info(glue::glue(
+  "Written to SQL Server ({write_schema}): {paste0(tables_to_keep, '_r', collapse = ', ')}"
+))
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server database")
+log_info("==== load-cohort-dacso.R END ====")

--- a/R/load-cohort-trd.R
+++ b/R/load-cohort-trd.R
@@ -13,9 +13,25 @@
 # This script loads student outcomes data for students who students who were formerly enrolled in
 # a trades program (i.e. an apprenticeship, trades foundation program or trades-related vocational program)
 #
-# The following data sets are read into SQL server from the student outcomes survey database:
-#   q000_trd_data_01: unique survey responses for each person/survey year (a few duplicates)
-#   q000_trd_graduates: a count of graduates by credential type, age and survey year
+# TRD = Trades Student Outcomes.  Survey of former students of trades programs
+# (apprenticeships, trades foundation and trades-related vocational programs).
+#
+# This script reads the trades survey data from the LAN and writes the cleaned
+# tables to SQL Server (schema = write_schema, database = decimal/PSSM2025):
+#
+#   q000_trd_data_01 -> trd_data (trd_data_r)
+#       Survey responses, one row per respondent per survey cycle (a few
+#       duplicates exist).  Consumed by 02b-1-pssm-cohorts.R: weights are
+#       applied (T_Weights, SURVEY = TRD), age groups joined from TBL_AGE /
+#       TBL_AGE_GROUPS, NEW_LABOUR_SUPPLY derived, and the standardized
+#       records are stacked into T_Cohorts_Recoded (master cohort table
+#       feeding credential analysis 01c-, labour supply 02b-2 and
+#       projections 04-/06-).
+#
+#   q000_trd_graduates -> trd_graduates (trd_graduates_r)
+#       Count of graduates by credential type, age and survey year.  Carried
+#       through the cohort modules (02b-1/02b-2) and referenced by
+#       04-graduate-projections.R for graduate-count work.
 #
 # Notes: Age group labels are assigned.  Note there are two different groupings used to group students by age in the model.
 
@@ -23,15 +39,25 @@ library(tidyverse)
 library(config)
 library(DBI)
 library(odbc)
+library(futile.logger)
 
-# qi_run <- F
-# regular_run <- T
-# ptib_run <- F
+## -------------------------- Logging Setup ------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== load-cohort-trd.R START ====")
 
 ## -------------------------- Configure LAN Paths and DB Connection ------------------------------
 ## -----------------------------------------------------------------------------------------------
 
-my_schema <- config::get("myschema")
+write_schema <- config::get("shareschema")
 db_config <- config::get("decimal")
 
 con <- dbConnect(
@@ -44,18 +70,28 @@ con <- dbConnect(
 
 lan <- config::get("lan")
 
+log_info("Connected to SQL Server database (decimal)")
+
 ## --------------------------------------Required Tables------------------------------------------
 ## -----------------------------------------------------------------------------------------------
 
+# Trades survey responses, one row per respondent per survey cycle.  KEY
+# identifies the respondent within a cycle (used to build STQU_ID in
+# 02b-1-pssm-cohorts.R); SUBM_CD gives the survey cycle (C_Outc..).
 q000_trd_data_01 <- read_csv(glue::glue(
-  "{lan}/data/student-outcomes/csv/so-provision/Q000_TRD_DATA_01.csv"
+  "{lan}/data/student-outcomes/csv/Q000_TRD_DATA_01.csv"
 ))
+log_info(glue::glue("Read Q000_TRD_DATA_01.csv: {nrow(q000_trd_data_01)} rows"))
 
+# Trades graduate counts by credential type, age and survey year.
 q000_trd_graduates <- read_csv(glue::glue(
-  "{lan}/data/student-outcomes/csv/so-provision/Q000_TRD_Graduates.csv"
+  "{lan}/data/student-outcomes/csv/Q000_TRD_Graduates.csv"
 ))
+log_info(glue::glue("Read Q000_TRD_Graduates.csv: {nrow(q000_trd_graduates)} rows"))
 
 # Convert some variables that should be numeric
+# GRADSTAT = graduation status, KEY = respondent key, TTRAIN = total months
+# of trades training; all needed as numbers for joins and credential coding.
 q000_trd_data_01 <- q000_trd_data_01 %>%
   mutate(
     GRADSTAT = as.numeric(GRADSTAT),
@@ -64,6 +100,10 @@ q000_trd_data_01 <- q000_trd_data_01 %>%
   )
 
 # Gradstat group : couldn't find in outcomes data so defining here.
+# Build the standard credential key used across all cohorts: grad-status
+# group + 4-digit CIP + months of training + PSSM credential.  In
+# 02b-1-pssm-cohorts.R this becomes LCIP4_CRED / LCIP2_CRED, the codes by
+# which credential-level outputs are grouped.
 q000_trd_data_01 <- q000_trd_data_01 %>%
   mutate(
     LCIP4_CRED = paste0(
@@ -77,6 +117,9 @@ q000_trd_data_01 <- q000_trd_data_01 %>%
     )
   )
 
+# Recode the survey's current-region fields into the standard PSSM region
+# codes (same scheme as APPSO/DACSO/BGS so regions are comparable across
+# cohorts; used for region-level outputs in 02b-1/02b-2).
 trd_data <-
   q000_trd_data_01 %>%
   mutate(
@@ -89,8 +132,11 @@ trd_data <-
       TRUE ~ NA
     )
   )
+log_info(glue::glue("trd_data prepared: {nrow(trd_data)} rows"))
 
 # prepare graduate dataset
+# Add the standard PSSM age-band labels to the trades graduate counts for
+# consistent reporting.
 trd_graduates <- q000_trd_graduates %>%
   mutate(
     AGE_GROUP_LABEL = case_when(
@@ -106,6 +152,7 @@ trd_graduates <- q000_trd_graduates %>%
       TRUE ~ NA
     )
   )
+log_info(glue::glue("trd_graduates prepared: {nrow(trd_graduates)} rows"))
 
 ## ------------------------------------ Clean Up --------------------------------------------------
 # Current workflow:
@@ -120,16 +167,32 @@ tables_to_keep <- c(
   "trd_graduates"
 )
 
+# Write each kept table to SQL Server as <name>_r.  Downstream scripts
+# (02b-1-pssm-cohorts.R etc.) pick them up by object name from the loading
+# sequence in run-data-loading.R / run-data-preprocessing.R.
 write_table_to_db <- function(table_name, schema, con) {
   db_name <- paste0(table_name, "_r")
+  # Some source files contain invalid UTF-8 byte sequences (e.g. PROGRAM
+  # names), which make odbcDataType()/nchar() fail when writing.  Strip
+  # invalid bytes from all character columns before writing.
+  data <- base::get(table_name, envir = .GlobalEnv) %>%
+    mutate(across(
+      where(is.character),
+      ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+    ))
   dbWriteTable(
     con,
     SQL(glue::glue('"{schema}"."{db_name}"')),
-    base::get(table_name, envir = .GlobalEnv),
+    data,
     overwrite = TRUE
   )
 }
 
-walk(tables_to_keep, write_table_to_db, schema = my_schema, con = con)
+walk(tables_to_keep, write_table_to_db, schema = write_schema, con = con)
+log_info(glue::glue(
+  "Written to SQL Server ({write_schema}): {paste0(tables_to_keep, '_r', collapse = ', ')}"
+))
 
 dbDisconnect(con)
+log_info("Disconnected from SQL Server database")
+log_info("==== load-cohort-trd.R END ====")

--- a/R/load-infoware-lookups.R
+++ b/R/load-infoware-lookups.R
@@ -38,12 +38,14 @@ con <- dbConnect(
 # only run once to get tables ready
 iw_config <- config::get("infoware")
 
-odbcListDrivers()
 
+#  ---- Connect to INFOWARE (Oracle) ----
+# Requires the "Oracle in instantclient_19c" ODBC driver to be installed.
+odbcListDrivers() # confirm available drivers / Oracle client is present
 iw_con <- dbConnect(
   odbc::odbc(),
-  Driver = "Oracle in instantclient_19_30",
-  DBQ = "DEV01.world",
+  Driver = "Oracle in instantclient_19c",
+  DBQ = iw_config$dbq,
   UID = iw_config$uid,
   PWD = iw_config$pwd
 )

--- a/R/load-infoware-lookups.R
+++ b/R/load-infoware-lookups.R
@@ -50,101 +50,23 @@ iw_con <- dbConnect(
   PWD = iw_config$pwd
 )
 
-# ## ** NOTE **
-# ## Ideally match on all data but prioritizing the most recent 6 years - see documentation
-# ## Update which BGS_DIST tables to include.
+# # ## ** NOTE **
+# # ## Ideally match on all data but prioritizing the most recent 6 years - see documentation
+# # ## Update which BGS_DIST tables to include.
 
-# ## Run the following to get a list of all tables available
+# # ## Run the following to get a list of all tables available
 # # alltables_Infoware <- dbReadTable(iw_con,"ALL_TABLES")
+
+# # ---- BGS distribution/cohort tables ----
+# # The INFOWARE BGS distribution/cohort tables used to be loaded here
+# # (INFOWARE_BGS_DIST_19_23 / 18_22 / COHORT_INFO -> my_schema).  They are now
+# # copied by 'R/load-cohort-bgs.R' as BGS_DIST_20_24 / 21_25 / COHORT_INFO to
+# # dbo (shareschema), where 02a-bgs-program-matching.R reads them.  This script
+# # only handles the CIP taxonomy lookups and INFOWARE_PROGRAMS below.
 
 # ---- Write initial tables to Decimal ----
 ## Save static versions of the INFOWARE tables and last cycle XWALK to Decimal
 # !! UPDATE THE TABLES AND ROW NUMBERS !! - connection won't write the full datasets to decimal due to size
-
-if (
-  !dbExistsTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23")
-  )
-) {
-  INFOWARE_BGS_DIST_19_23 <- dbReadTable(
-    iw_con,
-    DBI::Id(schema = "INFOWARE", table = "BGS_DIST_19_23")
-  )
-
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23"),
-    INFOWARE_BGS_DIST_19_23[1:80000, ]
-  )
-
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_19_23"),
-    INFOWARE_BGS_DIST_19_23[80001:121074, ],
-    append = TRUE
-  )
-}
-
-if (
-  !dbExistsTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22")
-  )
-) {
-  INFOWARE_BGS_DIST_18_22 <- dbReadTable(
-    iw_con,
-    DBI::SQL("INFOWARE.BGS_DIST_18_22")
-  )
-
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22"),
-    INFOWARE_BGS_DIST_18_22[1:80000, ]
-  )
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_DIST_18_22"),
-    INFOWARE_BGS_DIST_18_22[80001:118632, ],
-    append = TRUE
-  )
-}
-
-
-if (
-  !dbExistsTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO")
-  )
-) {
-  INFOWARE_BGS_COHORT_INFO <- dbReadTable(
-    iw_con,
-    DBI::SQL("INFOWARE.BGS_COHORT_INFO")
-  )
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
-    INFOWARE_BGS_COHORT_INFO[1:80000, ]
-  )
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
-    INFOWARE_BGS_COHORT_INFO[80001:160000, ],
-    append = TRUE
-  )
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
-    INFOWARE_BGS_COHORT_INFO[160001:240000, ],
-    append = TRUE
-  )
-  dbWriteTable(
-    con,
-    DBI::Id(schema = my_schema, table = "INFOWARE_BGS_COHORT_INFO"),
-    INFOWARE_BGS_COHORT_INFO[240001:290758, ],
-    append = TRUE
-  )
-}
 
 if (
   !dbExistsTable(

--- a/R/load-outcomes-data.R
+++ b/R/load-outcomes-data.R
@@ -23,17 +23,40 @@
 #   Q000_TRD_Graduates: a count of graduates by credential type, age and survey year
 #   T_APPSO_DATA_Final: unique survey responses for each person/survey year  (a few duplicates)
 #   APPSO_Graduates: a count of graduates by credential type, age and survey year
-#   BGS_Data_Update: unique survey responses for each person/survey year (for years since last model run)
+#   BGS_Q001_BGS_Data_2021_2025: unique survey responses for each person/survey year (for years since last model run)
 #   t_dacso_data_part_1_stepa: unique survey responses for each person/survey year (for years since last model run)
 #   infoware_c_outc_clean_short_resp
-#   tmp_tbl_Age_AppendNewYears
-#   INFOWARE_L_CIP_4DIGITS_CIP2016
-#   INFOWARE_L_CIP_6DIGITS_CIP2016
+#   qry_make_tmp_table_Age_step1
+#   INFOWARE_L_CIP_4DIGITS_CIP2021
+#   INFOWARE_L_CIP_6DIGITS_CIP2021
+#
+# This script is the bulk raw loader: every CSV in the student-outcomes folder
+# is read into memory (one object per file, named after the file) and written
+# to SQL Server (schema = use_schema/shareschema, database = database/PSSM2025)
+# as <name>_raw.  These _raw tables are the unmodified archive copies of the
+# survey files for reference/audit.
+#
+# The cleaned versions of the survey data are built by the load-cohort-*
+# scripts (load-cohort-trd/appso/bgs/dacso.R), which re-read the same CSVs
+# from the LAN, add derived fields (region recodes, weights, age groups,
+# labour supply flags) and write the *_r tables that feed
+# 02b-1-pssm-cohorts.R -> T_Cohorts_Recoded -> 01c-/02b-2/04-/06-.
+#
+# File map:
+#   Q000_TRD_DATA_01 / Q000_TRD_Graduates  -> trades survey (load-cohort-trd.R)
+#   T_APPSO_DATA_Final / APPSO_Graduates   -> apprenticeship survey (load-cohort-appso.R)
+#   BGS_Q001_BGS_Data_2021_2025            -> baccalaureate survey (load-cohort-bgs.R)
+#   DACSO_Q003_DACSO_DATA_Part_1_stepA     -> college/diploma survey (load-cohort-dacso.R)
+#   infoware_c_outc_clean_short_resp       -> DACSO follow-up flags (load-cohort-dacso.R)
+#   qry_make_tmp_table_Age_step1           -> age-at-survey per submission (SQL query output)
+#   INFOWARE_L_CIP_4DIGITS_CIP2021 / INFOWARE_L_CIP_6DIGITS_CIP2021
+#                                          -> CIP2021 program classification look-ups,
+#                                             used for program matching in the 02a-* scripts
 #############################################################################################################################################
 
 #---------------------------------------------------------------------------------------------------------------------------
 # notes:
-#   (small n) minor differences in code description/name: INFOWARE_L_CIP_4DIGITS_CIP2016, INFOWARE_L_CIP_4DIGITS_CIP2016
+#   (small n) minor differences in code description/name: INFOWARE_L_CIP_4DIGITS_CIP2021, INFOWARE_L_CIP_6DIGITS_CIP2021
 #   (small n) differences in prgm_credential: T_DACSO_DATA_Part_1_stepA
 #   I've read that using assign() as below is fragile ... it works though, so..?
 #   TODO: investigate both tmp_table_Age and the BGS data a little more.
@@ -43,6 +66,21 @@ library(tidyverse)
 library(config)
 library(RODBC)
 library(DBI)
+library(odbc)
+library(futile.logger)
+
+## -------------------------- Logging Setup ------------------------------------------------------
+## -----------------------------------------------------------------------------------------------
+log_file <- "./R/execution_log.txt"
+flog.appender(appender.file(log_file), name = "file_logger")
+flog.threshold(INFO, name = "file_logger")
+
+log_info <- function(msg) {
+  flog.info(msg, name = "file_logger")
+  print(paste(Sys.time(), "|", msg))
+}
+
+log_info("==== load-outcomes-data.R START ====")
 
 # set up db connection and lan paths
 db_config <- config::get("decimal")
@@ -53,41 +91,52 @@ decimal_con <- dbConnect(
   Database = db_config$database,
   Trusted_Connection = "True"
 )
+log_info("Connected to SQL Server database (decimal)")
 # make sure vpn is on, and the lan is available. Or switch to safepath approach.
-use_schema <- config::get("myschema")
+use_schema <- config::get("shareschema")
 lan <- config::get("lan")
-so_lan_path <- glue::glue("{lan}/data/student-outcomes/csv/so-provision/")
+so_lan_path <- glue::glue("{lan}/data/student-outcomes/csv/")
 
 # read csv's into objects in memory.
+# List every CSV the student outcomes team dropped in the folder; each file is
+# loaded below as an object named after the file (extension removed).
 so_data_all_full_pathnames <- list.files(
   so_lan_path,
   pattern = ".csv",
   full.names = TRUE
 )
-tmp_table_age_full_pathnames <- list.files(
-  so_lan_path,
-  pattern = "qry_make_tmp_table_Age_step1_20[0-9][0-9].csv",
-  full.names = TRUE
+age_file_full_pathname <- glue::glue(
+  "{so_lan_path}qry_make_tmp_table_Age_step1.csv"
 )
+log_info(glue::glue(
+  "Found {length(so_data_all_full_pathnames)} CSV files in student-outcomes folder"
+))
 
-# read all files into current environment, processing tmp_table_Age_step1_20xx data sets separately.
+# read all files into current environment, processing the tmp_table_Age_step1 data set separately.
+# (The age file has a fixed column layout and must be read with explicit
+# col_types - COCI_STQU_ID/COCI_SUBM_CD/BTHDT/ENDDT/COCI_AGE_AT_SURVEY.)
 so_data_full_pathnames <- so_data_all_full_pathnames[
-  !so_data_all_full_pathnames %in% tmp_table_age_full_pathnames
+  tolower(basename(so_data_all_full_pathnames)) !=
+    "qry_make_tmp_table_age_step1.csv"
 ]
 so_data_full_pathnames %>%
   set_names(tools::file_path_sans_ext(basename(so_data_full_pathnames))) %>%
   map(read_csv, show_col_types = FALSE) %>%
   imap(~ assign(..2, ..1, envir = .GlobalEnv)) %>%
   invisible()
+log_info(glue::glue(
+  "Read {length(so_data_full_pathnames)} SO csv files into environment"
+))
 
-# tmp_table_Age_step1_20xx datasets
-qry_make_tmp_table_Age_step1 <- tmp_table_age_full_pathnames %>%
-  set_names(tools::file_path_sans_ext(basename(
-    tmp_table_age_full_pathnames
-  ))) %>%
-  map(read_csv, show_col_types = FALSE, col_types = "dcdcd") %>%
-  bind_rows() %>%
-  invisible()
+# tmp_table_Age_step1 data set
+qry_make_tmp_table_Age_step1 <- read_csv(
+  age_file_full_pathname,
+  show_col_types = FALSE,
+  col_types = "dcdcd"
+)
+log_info(glue::glue(
+  "Read qry_make_tmp_table_Age_step1.csv: {nrow(qry_make_tmp_table_Age_step1)} rows"
+))
 
 # sanity check: any datasets missing from current environment?
 so_data_expected <- c(
@@ -98,49 +147,103 @@ missing <- !so_data_expected %in% ls()
 
 if (any(missing)) {
   warning("One or more SO datasets were not loaded into current environment.")
+  log_info(glue::glue(
+    "WARNING: missing datasets: {paste0(so_data_expected[missing], collapse = ', ')}"
+  ))
+} else {
+  log_info("All expected SO datasets loaded into environment")
 }
 
 # recast datatypes
-APPSO_Data_01_Final$PEN <- as.character(APPSO_Data_01_Final$PEN)
-APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB <- as.numeric(
-  APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB
-)
+# PEN (person education number) must be character - it has leading zeros that
+# a numeric read would strip; survey value columns are recast for the
+# calculations in the cohort modules.
+# Each block is guarded with exists() so a missing CSV (noted in the sanity
+# check above) only logs a warning instead of stopping the script.
+if (exists("APPSO_Data_01_Final")) {
+  APPSO_Data_01_Final$PEN <- as.character(APPSO_Data_01_Final$PEN)
+  APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB <- as.numeric(
+    APPSO_Data_01_Final$APP_TIME_TO_FIND_EMPLOY_MJOB
+  )
+} else {
+  log_info("Skipping APPSO_Data_01_Final recasts: object not loaded")
+}
 
-BGS_Q001_BGS_Data_2019_2023$PEN <- as.character(BGS_Q001_BGS_Data_2019_2023$PEN)
+if (exists("BGS_Q001_BGS_Data_2021_2025")) {
+  BGS_Q001_BGS_Data_2021_2025$PEN <- as.character(
+    BGS_Q001_BGS_Data_2021_2025$PEN
+  )
+} else {
+  log_info("Skipping BGS_Q001_BGS_Data_2021_2025 recasts: object not loaded")
+}
 
-DACSO_Q003_DACSO_DATA_Part_1_stepA <- DACSO_Q003_DACSO_DATA_Part_1_stepA %>%
-  mutate(across(.cols = c(TPID_LGND_CD, COCI_PEN), .fns = as.character))
+if (exists("DACSO_Q003_DACSO_DATA_Part_1_stepA")) {
+  DACSO_Q003_DACSO_DATA_Part_1_stepA <- DACSO_Q003_DACSO_DATA_Part_1_stepA %>%
+    mutate(across(.cols = c(TPID_LGND_CD, COCI_PEN), .fns = as.character))
+} else {
+  log_info(
+    "Skipping DACSO_Q003_DACSO_DATA_Part_1_stepA recasts: object not loaded"
+  )
+}
 
-Q000_TRD_DATA_01 <- Q000_TRD_DATA_01 %>%
-  mutate(across(.cols = c(GRADSTAT_GROUP, PEN), .fns = as.character))
+if (exists("Q000_TRD_DATA_01")) {
+  Q000_TRD_DATA_01 <- Q000_TRD_DATA_01 %>%
+    mutate(across(.cols = c(GRADSTAT_GROUP, PEN), .fns = as.character))
+} else {
+  log_info("Skipping Q000_TRD_DATA_01 recasts: object not loaded")
+}
 
-INFOWARE_C_OutC_Clean_Short_Resp <- INFOWARE_C_OutC_Clean_Short_Resp %>%
-  mutate(across(
-    .cols = c(TTRAIN, Q08, FINAL_DISPOSITION, RESPONDENT, CREDENTIAL_DERIVED),
-    .fns = as.character
-  ))
+if (exists("INFOWARE_C_OutC_Clean_Short_Resp")) {
+  INFOWARE_C_OutC_Clean_Short_Resp <- INFOWARE_C_OutC_Clean_Short_Resp %>%
+    mutate(across(
+      .cols = c(TTRAIN, Q08, FINAL_DISPOSITION, RESPONDENT, CREDENTIAL_DERIVED),
+      .fns = as.character
+    ))
+} else {
+  log_info(
+    "Skipping INFOWARE_C_OutC_Clean_Short_Resp recasts: object not loaded"
+  )
+}
+log_info("Data types recast (PEN/keys as character, survey values as numeric)")
 
 # remove non-standard characters so ssms won't throw an err
-INFOWARE_L_CIP_4DIGITS_CIP2016$LCP4_DESCRIPTION <- iconv(
-  INFOWARE_L_CIP_4DIGITS_CIP2016$LCP4_DESCRIPTION,
-  "UTF-8",
-  "UTF-8",
-  sub = ''
-)
-INFOWARE_L_CIP_6DIGITS_CIP2016$LCIP_NAME <- iconv(
-  INFOWARE_L_CIP_6DIGITS_CIP2016$LCIP_NAME,
-  "UTF-8",
-  "UTF-8",
-  sub = ''
-)
-INFOWARE_L_CIP_6DIGITS_CIP2016$LCIP_DESCRIPTION <- iconv(
-  INFOWARE_L_CIP_6DIGITS_CIP2016$LCIP_DESCRIPTION,
-  "UTF-8",
-  "UTF-8",
-  sub = ''
-)
+# The CIP look-ups contain invalid UTF-8 byte sequences (e.g. accents encoded
+# in a legacy codepage); strip invalid bytes so dbWriteTable/odbcDataType do
+# not fail on them.
+if (exists("INFOWARE_L_CIP_4DIGITS_CIP2021")) {
+  INFOWARE_L_CIP_4DIGITS_CIP2021$LCP4_DIGITS_NAME <- iconv(
+    INFOWARE_L_CIP_4DIGITS_CIP2021$LCP4_DIGITS_NAME,
+    "UTF-8",
+    "UTF-8",
+    sub = ''
+  )
+} else {
+  log_info("Skipping INFOWARE_L_CIP_4DIGITS_CIP2021 iconv: object not loaded")
+}
+
+if (exists("INFOWARE_L_CIP_6DIGITS_CIP2021")) {
+  INFOWARE_L_CIP_6DIGITS_CIP2021$LCP6_DIGITS_NAME <- iconv(
+    INFOWARE_L_CIP_6DIGITS_CIP2021$LCP6_DIGITS_NAME,
+    "UTF-8",
+    "UTF-8",
+    sub = ''
+  )
+  INFOWARE_L_CIP_6DIGITS_CIP2021$LCIP_LCIPPC_NAME <- iconv(
+    INFOWARE_L_CIP_6DIGITS_CIP2021$LCIP_LCIPPC_NAME,
+    "UTF-8",
+    "UTF-8",
+    sub = ''
+  )
+} else {
+  log_info("Skipping INFOWARE_L_CIP_6DIGITS_CIP2021 iconv: object not loaded")
+}
+log_info("Invalid UTF-8 bytes stripped from CIP look-up columns")
 
 # load to ssms
+# Write each loaded object to SQL Server as <name>_raw - raw archive copy of
+# the survey file (unmodified except for the recasts/cleaning above).
+# Character columns are sanitized first: some source files contain invalid
+# UTF-8 byte sequences which make odbcDataType()/nchar() fail when writing.
 so_data_expected[!missing] %>%
   mget(envir = .GlobalEnv) %>%
   imap(
@@ -148,6 +251,18 @@ so_data_expected[!missing] %>%
       decimal_con,
       overwrite = TRUE,
       name = SQL(glue::glue('"{use_schema}"."{..2}_raw"')),
-      value = ..1
+      value = ..1 %>%
+        mutate(across(
+          where(is.character),
+          ~ iconv(.x, from = "UTF-8", to = "UTF-8", sub = "")
+        ))
     )
   )
+log_info(glue::glue(
+  "Written {length(so_data_expected[!missing])} raw tables to SQL Server ({use_schema}): ",
+  "{paste0(so_data_expected[!missing], '_raw', collapse = ', ')}"
+))
+
+dbDisconnect(decimal_con)
+log_info("Disconnected from SQL Server database")
+log_info("==== load-outcomes-data.R END ====")

--- a/R/run-data-loading.R
+++ b/R/run-data-loading.R
@@ -29,8 +29,15 @@
 #   load-stp-cred.R            -- STP credential raw data (TSV -> SQL)
 #   load-infoware-lookups.R    -- INFOWARE CIP taxonomy + outcomes reference tables
 #                                 (Oracle INFOWARE -> SQL, one-time per cycle)
-#   load-outcomes-data.R       -- BGS, DACSO, APPSO, TRD survey data
-#                                 (CSV from LAN -> SQL)
+#   load-outcomes-data.R       -- BGS, DACSO, APPSO, TRD survey data (CSV from LAN -> SQL)
+#   load-cohort-bgs.R          -- BGS cohort survey data (LAN CSV -> SQL, *_r tables)
+#   load-cohort-trd.R          -- TRD cohort survey data (LAN CSV -> SQL, *_r tables)
+#   load-cohort-appso.R        -- APPSO cohort survey data (LAN CSV -> SQL, *_r tables)
+#   load-cohort-dacso.R        -- DACSO cohort survey data (LAN CSV -> SQL, *_r tables)
+#
+# NOTE: the four load-cohort-*.R scripts are mode-agnostic (no regular_run / qi_run /
+# ptib_run flags); they load identical tables on every invocation. The prep-for-*.R
+# runners still invoke them at the start of each model run (overwrite is safe).
 #
 # NEXT STEP:
 #   After this script completes, run run-data-preprocessing.R to process the raw
@@ -84,7 +91,11 @@ data_loading_files <- c(
   "./R/load-stp-enrol.R",
   "./R/load-stp-cred.R",
   "./R/load-infoware-lookups.R",
-  "./R/load-outcomes-data.R"
+  "./R/load-outcomes-data.R",
+  "./R/load-cohort-bgs.R",
+  "./R/load-cohort-trd.R",
+  "./R/load-cohort-appso.R",
+  "./R/load-cohort-dacso.R"
 )
 
 log_info(glue::glue(

--- a/R/run-data-loading.R
+++ b/R/run-data-loading.R
@@ -29,8 +29,10 @@
 #   load-stp-cred.R            -- STP credential raw data (TSV -> SQL)
 #   load-infoware-lookups.R    -- INFOWARE CIP taxonomy + outcomes reference tables
 #                                 (Oracle INFOWARE -> SQL, one-time per cycle)
-#   load-outcomes-data.R       -- BGS, DACSO, APPSO, TRD survey data (CSV from LAN -> SQL)
+#   load-outcomes-data.R       -- BGS, DACSO, APPSO, TRD survey data (CSV from LAN -> SQL,
+#                                 <name>_raw archive tables, sanitized writes)
 #   load-cohort-bgs.R          -- BGS cohort survey data (LAN CSV -> SQL, *_r tables)
+#                                 + INFOWARE BGS dist/cohort tables (Oracle -> SQL, chunked)
 #   load-cohort-trd.R          -- TRD cohort survey data (LAN CSV -> SQL, *_r tables)
 #   load-cohort-appso.R        -- APPSO cohort survey data (LAN CSV -> SQL, *_r tables)
 #   load-cohort-dacso.R        -- DACSO cohort survey data (LAN CSV -> SQL, *_r tables)
@@ -38,6 +40,8 @@
 # NOTE: the four load-cohort-*.R scripts are mode-agnostic (no regular_run / qi_run /
 # ptib_run flags); they load identical tables on every invocation. The prep-for-*.R
 # runners still invoke them at the start of each model run (overwrite is safe).
+# All load scripts write to the schema configured as shareschema (dbo by default),
+# overwrite existing tables, and log to ./R/execution_log.txt.
 #
 # NEXT STEP:
 #   After this script completes, run run-data-preprocessing.R to process the raw
@@ -80,7 +84,7 @@ my_schema <- config::get("myschema")
 db_config <- config::get("decimal")
 
 log_info(glue::glue(
-  "Schema: {my_schema} | Database: {db_config$database}"
+  "My schema: {my_schema} | Database: {db_config$database} | Load scripts write to: {config::get('shareschema')}"
 ))
 
 # ---- Data loading scripts (in execution order) ----

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ df
 Scripts are labeled sequentially and generally run in that order with the exception of 01e-stp-distributions.R.  Most analysis scripts have a corresponding script that 
 handles loading of the data required for analysis. The run order is:
 
+Data loading (refresh once per data cycle, e.g. new survey year):
+
+- run-data-loading.R — pipeline entry point that runs all load scripts in order:
+
+  - load-stp-enrol.R / load-stp-cred.R — STP enrolment/credential raw data (TSV -> SQL)
+  - load-infoware-lookups.R — INFOWARE CIP taxonomy + outcomes reference tables (Oracle -> SQL)
+  - load-outcomes-data.R — bulk loads every student-outcomes CSV from the LAN into SQL Server as `<name>_raw` (raw archive copies)
+  - load-cohort-bgs.R / load-cohort-trd.R / load-cohort-appso.R / load-cohort-dacso.R — read survey responses + lookups from the LAN, build the cleaned cohort tables and write them as `<name>_r` (`t_bgs_data_final_r`, `trd_data_r`, `t_appso_data_final_r`, `t_dacso_data_part_1_stepa_r`, ...). load-cohort-bgs.R also copies the INFOWARE BGS distribution/cohort tables (BGS_DIST_20_24/21_25, BGS_COHORT_INFO) from Oracle to dbo/shareschema in 80k-row chunks (skip if already present) — consumed by 02a-bgs-program-matching.R.
+
+  All load scripts write to the schema configured as `shareschema` (dbo by
+  default) in config.yml, overwrite by default (safe to rerun — no
+  duplication between the `_raw` archives and the cleaned `_r` tables), and
+  log progress to ./R/execution_log.txt. They require VPN/LAN access and
+  the Oracle Instant Client (for INFOWARE tables).
+
 Initial data pre-processing and post-secondary analysis:
 
 - 01a-enrolment-preprocessing.R 
@@ -69,6 +84,10 @@ Create occupation and new labour supply weighted distributions:
 - 02b-1-pssm-cohorts.R 
 - 02b-2-pssm-cohorts-new-labour-supply.R 
 - 02b-3-pssm-cohorts-occupation-distributions.R 
+
+(The load-cohort-*.R scripts are mode-agnostic — no run flags — and are
+always invoked by run-data-loading.R at the start of each model run; see the
+data loading section above.)
 
 Calculate near completers ratio:
 

--- a/docs/project-summary-for-new-analyst.md
+++ b/docs/project-summary-for-new-analyst.md
@@ -128,13 +128,41 @@ Scripts are numbered `01a → 08` and are meant to run **in that order** (with t
 notable exception of `01e`, which is run later). Each "analysis" script has a
 companion `load-*.R` script that pulls its inputs.
 
+**Data loading — the first thing that runs.** Before any numbered module runs,
+the loading pipeline (`R/run-data-loading.R`) refreshes all raw inputs into
+SQL Server (schema = `shareschema`, i.e. `dbo` by default):
+
+- `load-outcomes-data.R` — bulk loader: reads every CSV in the
+  student-outcomes folder on the LAN and writes each to SQL Server as
+  `<name>_raw` (raw archive copies, overwrite). Recasts keys (`PEN`, etc.)
+  and strips invalid UTF-8 bytes so the write cannot fail.
+- `load-cohort-bgs/trd/appso/dacso.R` — build the cleaned cohort tables:
+  survey responses + look-ups from the LAN, with region recodes, age groups,
+  weights and labour-supply flags, written as `<name>_r`
+  (`t_bgs_data_final_r`, `trd_data_r`, `t_appso_data_final_r`,
+  `t_dacso_data_part_1_stepa_r`, …). `load-cohort-bgs.R` also copies the
+  INFOWARE BGS distribution/cohort tables
+  (`BGS_DIST_20_24 / 21_25`, `BGS_COHORT_INFO`) from the
+  Oracle INFOWARE database into dbo/shareschema in 80k-row chunks (skip if
+  already present) — consumed by `02a-bgs-program-matching.R`.
+- **Naming:** `<name>_raw` = unmodified archive; `<name>_r` = cleaned table
+  consumed by the numbered modules (02b-1 → `T_Cohorts_Recoded`). Every write
+  is `overwrite = TRUE`, so rerunning any load script never duplicates data.
+- **Logging:** all load scripts log to `R/execution_log.txt` via
+  `futile.logger` (row counts per read/write).
+- **Weights:** `T_Weights.csv` on the LAN carries one block per model run;
+  the 2027 run uses the `2024-2025` block (cycles `C_Outc21`–`C_Outc25`,
+  latest cycle = 5, QI run re-weights). `T_Year_Survey_Year.csv` was extended
+  to `C_Outc25` (2025).
+
 ---
 
 ## 4. End-to-end run order
 
 ```mermaid
 flowchart TD
-    Start([Start: set run flags]) --> S01a[01a enrolment preprocessing]
+    Start([Start: set run flags]) --> LD[run-data-loading.R<br/>STP + INFOWARE + survey data<br/>load-outcomes-data.R → *_raw<br/>load-cohort-* → *_r]
+    LD --> S01a[01a enrolment preprocessing]
     S01a --> S01b[01b credential preprocessing]
     S01b --> S01c[01c credential analysis]
     S01c --> S01d[01d enrolment analysis]
@@ -385,6 +413,7 @@ outputs in the first place.
 | **NEW_LABOUR_SUPPLY (NLS)** | Derived flag: did this graduate actually enter the workforce? `0/1/2/3` (see §11). The basis of Term 3. |
 | **Composite keys** | Concatenations like `PSSM_CRED` = "1 - DIPL", `LCIP4_CRED` = "1 - 0100 - BACH" — used to match grads to jobs across terms. |
 | **APPSO / TRD / BGS / DACSO** | The four Student Outcomes survey streams: Apprenticeship, Trades, Baccalaureate Graduates, Diploma/Assoc/Certificate. |
+| **`_r` vs `_raw` tables** | `_raw` = unmodified archive of a survey CSV (written by `load-outcomes-data.R`); `_r` = cleaned cohort table (`load-cohort-*.R`) consumed by the numbered modules. |
 | **PTIB** | Private Training Institutions Branch data (private, non-public colleges) — feeds Term 1/2. |
 | **PEOPLE** | BC Stats population projections used to drive enrolment forecasts in Term 1. |
 | **Delayed Award** | A secondary credential earned shortly after the primary one; exit date is reconciled forward by category-specific windows. |

--- a/docs/so-survey-schema-diff-2025.md
+++ b/docs/so-survey-schema-diff-2025.md
@@ -1,0 +1,74 @@
+# Student Outcome Survey Data — Schema Diff 2025 (2027 LAN refresh)
+
+Applies to the 2027 data refresh: the student-outcome survey CSVs moved from the 2022-2023 LAN folder (`{lan_2023}`) to the 2027 folder (`{lan}`), and the loading scripts were updated to match. This report documents every intentional column change, old CSV vs new CSV, cross-checked against the new LAN `sql/` query definitions and `data_dictionary_so.csv` as ground truth.
+
+Path shorthand: `{lan}` = new LAN root; `{lan_2023}` = old LAN root. All survey files live at `{lan}/data/student-outcomes/csv/` (the old `so-provision/` subfolder is gone).
+
+## Layout changes (all cohorts)
+
+| Change | Old | New |
+|---|---|---|
+| Survey CSV folder | `data/student-outcomes/csv/so-provision/` | `data/student-outcomes/csv/` (no subfolder) |
+| BGS survey file | `BGS_Q001_BGS_Data_2019_2023.csv` | `BGS_Q001_BGS_Data_2021_2025.csv` |
+| CIP lookup version | `INFOWARE_L_CIP_*_CIP2016.csv` | `INFOWARE_L_CIP_*_CIP2021.csv` |
+| Age table | per-year `qry_make_tmp_table_Age_step1_20xx.csv` | single `qry_make_tmp_table_Age_step1.csv` |
+| Survey year codes (`SUBM_CD`) | `C_Outc19` … `C_Outc23` | `C_Outc21` … `C_Outc25` |
+
+## BGS (Baccalaureate Graduate Survey)
+
+`BGS_Q001_BGS_Data_2021_2025.csv` vs `BGS_Q001_BGS_Data_2019_2023.csv`, per `sql/BGS_Q001_BGS_Data_2021_2025.sql`.
+
+| Column | Change | Action in R |
+|---|---|---|
+| `D03_STUDYING_FT` | **removed** from new file | drop `FULL_TM_SCHOOL` rename in `load-cohort-bgs.R` |
+| `D02_R1_CURRENTLY_STUDYING` | renamed → `PFST_CURRENTLY_STUDYING` | select out `PFST_CURRENTLY_STUDYING` instead |
+| `STUDID` | type change: numeric → character (16,090 `V`-prefixed UVIC rows) | none needed (readr infers character) |
+| `PEN` | still numeric-parsed; 4 leading-zero rows only | keep existing casts |
+| `NOC_CD` | character, `"XXXXX"` × 2,013 | none |
+| `AGE` | 210 blanks | none (existing `between(AGE, 17, 34)` handles NA) |
+| All other columns | unchanged names/order (32 → 31 cols) | — |
+
+BGS renames (`FULL_TM_WRK`, `IN_LBR_FRC`, `EMPLOYED`, `UNEMPLOYED`, `TRAINING_RELATED`, `TOOK_FURTH_ED`) are **not** pre-applied in the new SQL — the R rename block stays, minus `FULL_TM_SCHOOL`.
+
+Note: `data_dictionary_so.csv` currently has no rows for the 2021_2025 BGS file — dictionary update pending with the survey team.
+
+## TRD (Trades)
+
+`Q000_TRD_DATA_01.csv` + `Q000_TRD_Graduates.csv`, per the matching `sql/` files.
+
+| File | Change |
+|---|---|
+| `Q000_TRD_DATA_01.csv` | 23 cols, one rename: `LCIP_CD` → `LCP6_CD` (CIP2021). Types unchanged — `GRADSTAT`/`KEY`/`TTRAIN` numeric coercions in R still valid. `SUBM_CD` now `C_Outc21..25` (was 19..23). `PEN` now >1e9 (10-digit, exact as double). |
+| `Q000_TRD_Graduates.csv` | identical 6 columns. `SUBM_CD` range `C_Outc13..26` (was 13..24 — adds 25, 26). |
+
+## APPSO (Apprenticeship)
+
+`APPSO_Data_01_Final.csv` + `APPSO_Graduates.csv` (note: filename casing `APPSO_Data_01_Final` vs old `APPSO_DATA_01_Final`).
+
+| File | Change |
+|---|---|
+| `APPSO_Data_01_Final.csv` | one rename: `LCIP_CD` → `LCP6_CD`. Types unchanged. `SUBM_CD` `C_Outc21..25` (was 19..23); shared years row-identical, minus 19/20 plus 24/25 (+8,869 rows). `RESPONDENT` numeric 0/1 in both. `APP_TIME_TO_FIND_EMPLOY_MJOB` 100% empty (pre-existing). |
+| `APPSO_Graduates.csv` | identical columns; adds `C_Outc25`, `C_Outc26` (data file lags one year, as before). |
+
+**Weight mapping** — the hardcoded `SUBM_CD` weight case_whens in `load-cohort-appso.R` were remapped for the new codes: `C_Outc21→1 … C_Outc25→5` (regular) and QI variant shifted `C_Outc21→2 … C_Outc25→0`. Without the remap the new codes hit `TRUE ~ 0` and ~38% of rows would get zero weight. Exact weight values still pending analyst sign-off.
+
+## DACSO (Diploma/Associate/Certificate)
+
+`DACSO_Q003_DACSO_DATA_Part_1_stepA.csv` + `INFOWARE_C_OutC_Clean_Short_Resp.csv`.
+
+| File | Change |
+|---|---|
+| `DACSO_Q003_DACSO_DATA_Part_1_stepA.csv` | two renames: `LCIP_CD` → `LCP6_CD`, `LCP4_CIP_4DIGITS_NAME` → `LCP4_DIGITS_NAME` (CIP2016 → CIP2021 values). No type drift. Rows 136,675 → 147,020. `SUBM_CD` `C_Outc21..25`. Note: columns `LABR_EMPLOYED`, `COSC_GRAD_STATUS_LGDS_CD(_GROUP)`, `RESPONDENT` exist with real values — the commented-out NA-mutate block stays commented. |
+| `INFOWARE_C_OutC_Clean_Short_Resp.csv` | 16 columns, identical. Mixed quoting (75,855 quoted CIP names) — readr-safe. |
+
+## Age table
+
+`qry_make_tmp_table_Age_step1.csv` — single file replacing the per-year glob in `load-outcomes-data.R`. Header: `COCI_STQU_ID, COCI_SUBM_CD, BTHDT, ENDDT, COCI_AGE_AT_SURVEY`; 147,020 rows; `C_Outc21..25`. Column spec `"dcdcd"` remains valid (ENDDT read as character, lossless).
+
+## Lookups (root-swap only)
+
+All lookups referenced by the loading scripts exist at the same relative path on the new LAN (`development/csv/gh-source/lookups/02/`, `rollover/02/`). One case-only rename: `t_year_survey_year.csv` → `T_Year_Survey_Year.csv` (applied in `load-cohort-dacso.R`). Lookup content/schema verification deferred to a later branch.
+
+## Verdict
+
+No unexpected column-type breaks beyond `STUDID` (BGS) and the two CIP2021 renames. All R-side type coercions remain valid; two BGS references (removed column, renamed column) were fixed in `load-cohort-bgs.R`.

--- a/docs/so-survey-schema-diff-2025.md
+++ b/docs/so-survey-schema-diff-2025.md
@@ -69,6 +69,17 @@ Note: `data_dictionary_so.csv` currently has no rows for the 2021_2025 BGS file 
 
 All lookups referenced by the loading scripts exist at the same relative path on the new LAN (`development/csv/gh-source/lookups/02/`, `rollover/02/`). One case-only rename: `t_year_survey_year.csv` → `T_Year_Survey_Year.csv` (applied in `load-cohort-dacso.R`). Lookup content/schema verification deferred to a later branch.
 
+## Lookup content updates (2026-08)
+
+- `T_Year_Survey_Year.csv` extended with `C_Outc24`/`C_Outc25` rows for all four surveys: survey years 2024/2025, school years `2022/2023`/`2023/2024` (APPSO/TRD only), projection years `2023/2024`/`2024/2025`.
+- `T_Weights.csv` gained the `2024-2025` model block (groups 27-30): zeros for older cycles, then weighted cycles `C_Outc21→1,2 … C_Outc25→5,0` per survey (BGS keyed by survey year 2021-2025, same weights). Consistent with the hardcoded APPSO weights in `load-cohort-appso.R`.
+
+## Loader hardening (2026-08)
+
+- `write_table_to_db` (all four `load-cohort-*.R`) and the `_raw` write loop in `load-outcomes-data.R` now strip invalid UTF-8 byte sequences from character columns (`iconv` `sub=""`) before writing — previously `odbcDataType()`/`nchar()` failed on e.g. `PROGRAM` and `NOC_5_DIGIT_CODE_AND_NAME`.
+- `load-cohort-bgs.R` copies the INFOWARE BGS tables (`BGS_DIST_20_24`, `BGS_DIST_21_25`, `BGS_COHORT_INFO`) to dbo/shareschema via a chunked loader (`load_infoware_table_by_chunk`, 80k rows, skip-if-exists) — replaced the hardcoded row-count blocks. `02a-bgs-program-matching.R` was updated to read the new cycles from dbo (step 1: all years from 20_24; step 2: `YEAR == 2025` from 21_25, the year 20_24 lacks) and its survey-year→award-school-year flag now covers 2024/2025. The old 18_22/19_23 load blocks were removed from `load-infoware-lookups.R`.
+- All load scripts log to `./R/execution_log.txt` (`futile.logger`) with row counts per read/write.
+
 ## Verdict
 
 No unexpected column-type breaks beyond `STUDID` (BGS) and the two CIP2021 renames. All R-side type coercions remain valid; two BGS references (removed column, renamed column) were fixed in `load-cohort-bgs.R`.


### PR DESCRIPTION
Refresh all student-outcome (SO) survey loading for the 2027 model run (new LAN layout, PSSM2025, survey cycles C_Outc21..C_Outc25):
- New CSV sources — load-cohort-bgs/trd/appso/dacso.R + load-outcomes-data.R updated for the 2027 LAN files: BGS BGS_Q001_BGS_Data_2021_2025 (drops D03_STUDYING_FT, D02_R1_CURRENTLY_STUDYING → PFST_CURRENTLY_STUDYING), CIP2021 renames (LCIP_CD→LCP6_CD, LCP4_CIP_4DIGITS_NAME→LCP4_DIGITS_NAME) in TRD/APPSO/DACSO, single qry_make_tmp_table_Age_step1.csv age file.
- dbo writes — all SO tables land in shared schema dbo (shareschema): *_r cleaned cohort tables + *_raw archives from the bulk loader.
- Loader hardening — logging to ./R/execution_log.txt (futile.logger, row counts per read/write), invalid-UTF-8 sanitization on character columns (was failing on PROGRAM, NOC_5_DIGIT_CODE_AND_NAME), chunked 80k-row INFOWARE→SQL Server copy with skip-if-exists (replaces hardcoded row-count blocks).
- BGS cycle switch — INFOWARE BGS tables now BGS_DIST_20_24 / 21_25 / COHORT_INFO copied to dbo by load-cohort-bgs.R; 02a-bgs-program-matching.R reads them from dbo (step 1: all of 20_24, step 2: YEAR == 2025 from 21_25) and its survey-year→award-school-year flag extended to 2024/2025; old 18_22/19_23 load blocks removed from load-infoware-lookups.R.
- 2024-2025 weights — 02b-1-pssm-cohorts.R weight filters MODEL == "2022-2023" → "2024-2025"; LAN T_Weights.csv gained the 2024-2025 block (groups 27-30), T_Year_Survey_Year.csv extended to C_Outc25.
- Docs — new docs/so-survey-schema-diff-2025.md (per-file column diff old-vs-new vs sql/ vs data_dictionary_so.csv), README + analyst summary updated for the loading pipeline.

### Verification
Live read-only checks on PSSM2025: all *_raw/*_r tables in dbo with new-cycle row counts (DACSO 136,675 → 147,020; BGS/TRD/APPSO at 123,452 / 22,066 / 23,166), cycles C_Outc21..25 (BGS survey years 2021-2025), unique keys, 2024-2025 weight blocks present, INFOWARE BGS 20_24/21_25 in dbo and old cycles absent. All five SO-loading scripts parse-verified.

### Follow-ups
- 06-program-projections.R still filters STP weights on MODEL == "2023-2024" (t_weights_stp from load-program-projections.R) — separate STP weights CSV needs its own 2024-2025 block for the 2027 run.